### PR TITLE
Handle past dates in date formatting

### DIFF
--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,25 +1,34 @@
-	// Format time for display
-	/**
-	 * @param {string | number | Date} dateTime
-	 */
-        export function formatTime(dateTime ) {
-            return new Date(dateTime).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-        }
-	/**
-	 * @param {string | number | Date} dateTime
-	 */
-	export function formatDate(dateTime) {
-		const date = new Date(dateTime);
-		const today = new Date();
-		const tomorrow = new Date(today);
-		tomorrow.setDate(tomorrow.getDate() + 1);
+// Format time for display
+/**
+ * @param {string | number | Date} dateTime
+ */
+export function formatTime(dateTime) {
+  return new Date(dateTime).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
 
-		if (date.toDateString() === today.toDateString()) {
-			return 'today';
-		} else if (date.toDateString() === tomorrow.toDateString()) {
-			return 'tomorrow';
-		} else {
-			const diff = Math.ceil((date.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
-			return `in ${diff} days`;
-		}
-	}
+/**
+ * @param {string | number | Date} dateTime
+ */
+export function formatDate(dateTime) {
+  const date = new Date(dateTime);
+  const today = new Date();
+  const tomorrow = new Date(today);
+  const yesterday = new Date(today);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  yesterday.setDate(yesterday.getDate() - 1);
+
+  if (date.toDateString() === today.toDateString()) {
+    return "today";
+  } else if (date.toDateString() === tomorrow.toDateString()) {
+    return "tomorrow";
+  } else if (date.toDateString() === yesterday.toDateString()) {
+    return "yesterday";
+  } else {
+    const diffMs = date.getTime() - today.getTime();
+    const diffDays = Math.ceil(Math.abs(diffMs) / (1000 * 60 * 60 * 24));
+    return diffMs > 0 ? `in ${diffDays} days` : `${diffDays} days ago`;
+  }
+}

--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { formatDate } from "./date";
+
+describe("formatDate", () => {
+  it("labels yesterday correctly", () => {
+    const date = new Date();
+    date.setDate(date.getDate() - 1);
+    expect(formatDate(date)).toBe("yesterday");
+  });
+
+  it("handles past dates", () => {
+    const date = new Date();
+    date.setDate(date.getDate() - 3);
+    expect(formatDate(date)).toBe("3 days ago");
+  });
+
+  it("handles future dates", () => {
+    const date = new Date();
+    date.setDate(date.getDate() + 3);
+    expect(formatDate(date)).toBe("in 3 days");
+  });
+});


### PR DESCRIPTION
## Summary
- fix `formatDate` utility to properly report yesterday and past dates
- add tests for date formatting

## Testing
- `npm run test:unit`
- `npx prettier src/utils/date.js src/utils/date.test.ts --check`


------
https://chatgpt.com/codex/tasks/task_e_68ac997254b88323b18b4ef9c3af6696