### PR TITLE
Claude/integrate google calendars 

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
 		"fontawesome": "^5.6.3",
 		"holosphere": "^1.1.20",
 		"html5-qrcode": "^2.3.8",
+		"ical.js": "^2.2.1",
 		"lune": "^0.4.0",
 		"mapbox-gl": "^3.7.0",
 		"sass": "^1.77.6",

--- a/src/components/CalendarSettings.svelte
+++ b/src/components/CalendarSettings.svelte
@@ -1,0 +1,350 @@
+<script lang="ts">
+    import { getContext, createEventDispatcher } from 'svelte';
+    import type HoloSphere from 'holosphere';
+    import { ID } from '../dashboard/store';
+    import { isValidICalUrl } from '$lib/services/icalParser';
+
+    const dispatch = createEventDispatcher();
+    const holosphere = getContext('holosphere') as HoloSphere;
+
+    export let show = false;
+
+    // State
+    let importedCalendars: Array<{ id: string; url: string; name: string; enabled: boolean }> = [];
+    let newCalendarUrl = '';
+    let newCalendarName = '';
+    let loading = false;
+    let error = '';
+    let successMessage = '';
+    let showExportSection = false;
+
+    // Get the export URL for this holon's calendar
+    $: exportUrl = typeof window !== 'undefined'
+        ? `${window.location.origin}/${$ID}/calendar/feed.ics`
+        : '';
+
+    // Load imported calendars from holon data
+    async function loadImportedCalendars() {
+        if (!$ID) return;
+
+        try {
+            const calendarData = await holosphere.get($ID, 'settings', 'imported_calendars');
+            if (calendarData && Array.isArray(calendarData.calendars)) {
+                importedCalendars = calendarData.calendars;
+            }
+        } catch (err) {
+            console.error('Error loading imported calendars:', err);
+        }
+    }
+
+    // Save imported calendars to holon data
+    async function saveImportedCalendars() {
+        if (!$ID) return;
+
+        try {
+            await holosphere.put($ID, 'settings', {
+                id: 'imported_calendars',
+                calendars: importedCalendars,
+                updated: new Date().toISOString()
+            });
+        } catch (err) {
+            console.error('Error saving imported calendars:', err);
+            throw err;
+        }
+    }
+
+    // Add a new calendar
+    async function addCalendar() {
+        error = '';
+        successMessage = '';
+
+        if (!newCalendarUrl.trim()) {
+            error = 'Please enter a calendar URL';
+            return;
+        }
+
+        if (!isValidICalUrl(newCalendarUrl)) {
+            error = 'Please enter a valid calendar URL (http://, https://, or webcal://)';
+            return;
+        }
+
+        loading = true;
+
+        try {
+            const calendarId = `cal_${Date.now()}`;
+            const newCalendar = {
+                id: calendarId,
+                url: newCalendarUrl.trim(),
+                name: newCalendarName.trim() || 'Imported Calendar',
+                enabled: true
+            };
+
+            importedCalendars = [...importedCalendars, newCalendar];
+            await saveImportedCalendars();
+
+            // Clear form
+            newCalendarUrl = '';
+            newCalendarName = '';
+            successMessage = 'Calendar added successfully!';
+
+            // Notify parent component to refresh
+            dispatch('calendarsUpdated');
+
+            setTimeout(() => {
+                successMessage = '';
+            }, 3000);
+        } catch (err) {
+            error = 'Failed to add calendar. Please try again.';
+            console.error(err);
+        } finally {
+            loading = false;
+        }
+    }
+
+    // Remove a calendar
+    async function removeCalendar(calendarId: string) {
+        if (!confirm('Are you sure you want to remove this calendar?')) {
+            return;
+        }
+
+        loading = true;
+        error = '';
+
+        try {
+            importedCalendars = importedCalendars.filter(cal => cal.id !== calendarId);
+            await saveImportedCalendars();
+            successMessage = 'Calendar removed successfully!';
+
+            // Notify parent component to refresh
+            dispatch('calendarsUpdated');
+
+            setTimeout(() => {
+                successMessage = '';
+            }, 3000);
+        } catch (err) {
+            error = 'Failed to remove calendar. Please try again.';
+            console.error(err);
+        } finally {
+            loading = false;
+        }
+    }
+
+    // Toggle calendar enabled state
+    async function toggleCalendar(calendarId: string) {
+        loading = true;
+        error = '';
+
+        try {
+            importedCalendars = importedCalendars.map(cal =>
+                cal.id === calendarId ? { ...cal, enabled: !cal.enabled } : cal
+            );
+            await saveImportedCalendars();
+
+            // Notify parent component to refresh
+            dispatch('calendarsUpdated');
+        } catch (err) {
+            error = 'Failed to update calendar. Please try again.';
+            console.error(err);
+        } finally {
+            loading = false;
+        }
+    }
+
+    // Copy export URL to clipboard
+    async function copyExportUrl() {
+        try {
+            await navigator.clipboard.writeText(exportUrl);
+            successMessage = 'Calendar link copied to clipboard!';
+            setTimeout(() => {
+                successMessage = '';
+            }, 3000);
+        } catch (err) {
+            error = 'Failed to copy to clipboard';
+        }
+    }
+
+    // Load calendars when modal opens
+    $: if (show) {
+        loadImportedCalendars();
+    }
+</script>
+
+{#if show}
+    <div class="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center p-4 z-50" style="backdrop-filter: blur(4px);">
+        <div class="bg-gray-800 rounded-xl border border-gray-700 max-w-3xl w-full max-h-[90vh] overflow-y-auto">
+            <!-- Header -->
+            <div class="flex justify-between items-center p-6 border-b border-gray-700 sticky top-0 bg-gray-800 z-10">
+                <h2 class="text-2xl font-bold text-white">Calendar Settings</h2>
+                <button
+                    class="p-2 rounded-lg bg-gray-700 text-white hover:bg-gray-600 transition-colors"
+                    on:click={() => show = false}
+                    aria-label="Close modal"
+                >
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                    </svg>
+                </button>
+            </div>
+
+            <div class="p-6 space-y-8">
+                <!-- Error/Success Messages -->
+                {#if error}
+                    <div class="bg-red-900/50 border border-red-700 text-red-200 px-4 py-3 rounded-lg">
+                        {error}
+                    </div>
+                {/if}
+
+                {#if successMessage}
+                    <div class="bg-green-900/50 border border-green-700 text-green-200 px-4 py-3 rounded-lg">
+                        {successMessage}
+                    </div>
+                {/if}
+
+                <!-- Export Section -->
+                <div class="space-y-4">
+                    <button
+                        class="flex items-center justify-between w-full text-left"
+                        on:click={() => showExportSection = !showExportSection}
+                    >
+                        <h3 class="text-xl font-semibold text-white">Subscribe to This Holon's Calendar</h3>
+                        <svg
+                            class="w-5 h-5 text-gray-400 transition-transform {showExportSection ? 'rotate-180' : ''}"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                        >
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+
+                    {#if showExportSection}
+                        <div class="bg-gray-900 rounded-lg p-4 space-y-3">
+                            <p class="text-gray-300 text-sm">
+                                Copy this link and add it to your calendar app (Google Calendar, Apple Calendar, Outlook, etc.) to subscribe to this holon's events:
+                            </p>
+                            <div class="flex gap-2">
+                                <input
+                                    type="text"
+                                    readonly
+                                    value={exportUrl}
+                                    class="flex-1 bg-gray-800 text-white px-3 py-2 rounded-lg border border-gray-700 text-sm font-mono"
+                                />
+                                <button
+                                    class="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-500 transition-colors whitespace-nowrap"
+                                    on:click={copyExportUrl}
+                                >
+                                    Copy Link
+                                </button>
+                            </div>
+                            <p class="text-gray-400 text-xs">
+                                📝 This calendar updates automatically. Any changes to scheduled events in this holon will appear in your subscribed calendar.
+                            </p>
+                        </div>
+                    {/if}
+                </div>
+
+                <!-- Import Section -->
+                <div class="space-y-4">
+                    <h3 class="text-xl font-semibold text-white">Import External Calendars</h3>
+                    <p class="text-gray-300 text-sm">
+                        Import events from external calendars (Google Calendar, Apple Calendar, etc.) to display them in this holon's calendar.
+                    </p>
+
+                    <!-- Add New Calendar Form -->
+                    <div class="bg-gray-900 rounded-lg p-4 space-y-4">
+                        <div>
+                            <label for="calendar-url" class="text-gray-300 text-sm font-medium block mb-2">
+                                Calendar URL (iCal/webcal link)
+                            </label>
+                            <input
+                                id="calendar-url"
+                                type="url"
+                                bind:value={newCalendarUrl}
+                                placeholder="https://calendar.google.com/calendar/ical/..."
+                                class="w-full bg-gray-800 text-white px-3 py-2 rounded-lg border border-gray-700 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none"
+                            />
+                            <p class="text-gray-400 text-xs mt-1">
+                                To get a Google Calendar link: Calendar Settings → Integrate Calendar → Secret address in iCal format
+                            </p>
+                        </div>
+
+                        <div>
+                            <label for="calendar-name" class="text-gray-300 text-sm font-medium block mb-2">
+                                Calendar Name (optional)
+                            </label>
+                            <input
+                                id="calendar-name"
+                                type="text"
+                                bind:value={newCalendarName}
+                                placeholder="My Google Calendar"
+                                class="w-full bg-gray-800 text-white px-3 py-2 rounded-lg border border-gray-700 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none"
+                            />
+                        </div>
+
+                        <button
+                            class="w-full px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                            on:click={addCalendar}
+                            disabled={loading}
+                        >
+                            {loading ? 'Adding...' : 'Add Calendar'}
+                        </button>
+                    </div>
+
+                    <!-- Imported Calendars List -->
+                    {#if importedCalendars.length > 0}
+                        <div class="space-y-2">
+                            <h4 class="text-sm font-medium text-gray-400">Imported Calendars</h4>
+                            {#each importedCalendars as calendar (calendar.id)}
+                                <div class="bg-gray-900 rounded-lg p-4 flex items-center justify-between">
+                                    <div class="flex items-center gap-3 flex-1 min-w-0">
+                                        <button
+                                            class="flex-shrink-0"
+                                            on:click={() => toggleCalendar(calendar.id)}
+                                            aria-label={calendar.enabled ? 'Disable calendar' : 'Enable calendar'}
+                                        >
+                                            <div class="w-5 h-5 rounded border-2 {calendar.enabled ? 'bg-indigo-600 border-indigo-600' : 'border-gray-600'} flex items-center justify-center">
+                                                {#if calendar.enabled}
+                                                    <svg class="w-3 h-3 text-white" fill="currentColor" viewBox="0 0 20 20">
+                                                        <path d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"/>
+                                                    </svg>
+                                                {/if}
+                                            </div>
+                                        </button>
+                                        <div class="flex-1 min-w-0">
+                                            <div class="text-white font-medium truncate">{calendar.name}</div>
+                                            <div class="text-gray-400 text-xs truncate">{calendar.url}</div>
+                                        </div>
+                                    </div>
+                                    <button
+                                        class="flex-shrink-0 ml-4 p-2 text-red-400 hover:text-red-300 hover:bg-red-900/20 rounded transition-colors"
+                                        on:click={() => removeCalendar(calendar.id)}
+                                        aria-label="Remove calendar"
+                                    >
+                                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                                        </svg>
+                                    </button>
+                                </div>
+                            {/each}
+                        </div>
+                    {:else}
+                        <div class="text-center py-8 text-gray-400">
+                            <svg class="w-12 h-12 mx-auto mb-3 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                            </svg>
+                            <p>No imported calendars yet</p>
+                            <p class="text-sm mt-1">Add your first calendar above</p>
+                        </div>
+                    {/if}
+                </div>
+            </div>
+        </div>
+    </div>
+{/if}
+
+<style>
+    /* Ensure smooth transitions */
+    button {
+        transition: all 0.2s ease;
+    }
+</style>

--- a/src/lib/services/icalGenerator.ts
+++ b/src/lib/services/icalGenerator.ts
@@ -1,0 +1,154 @@
+// iCal Feed Generator Service
+// Generates iCal feeds from holon events for export/subscription
+
+import ICAL from 'ical.js';
+
+export interface HolonEvent {
+    id: string;
+    title: string;
+    description?: string;
+    location?: string;
+    when: string; // ISO date string
+    ends?: string; // ISO date string
+    participants?: Array<{ id: string; username?: string; firstName?: string; lastName?: string }>;
+    status?: string;
+    category?: string;
+}
+
+/**
+ * Generates an iCal feed from holon events
+ * @param events - Array of holon events
+ * @param holonName - Name of the holon (for calendar name)
+ * @param holonId - ID of the holon
+ * @returns iCal formatted string
+ */
+export function generateICalFeed(
+    events: HolonEvent[],
+    holonName: string,
+    holonId: string
+): string {
+    // Create the calendar component
+    const cal = new ICAL.Component(['vcalendar', [], []]);
+
+    // Set calendar properties
+    cal.updatePropertyWithValue('prodid', '-//Harvest Holon Calendar//EN');
+    cal.updatePropertyWithValue('version', '2.0');
+    cal.updatePropertyWithValue('calscale', 'GREGORIAN');
+    cal.updatePropertyWithValue('method', 'PUBLISH');
+    cal.updatePropertyWithValue('x-wr-calname', `${holonName} Calendar`);
+    cal.updatePropertyWithValue('x-wr-caldesc', `Events from ${holonName} holon`);
+    cal.updatePropertyWithValue('x-wr-timezone', 'UTC');
+
+    // Add each event
+    events.forEach(event => {
+        try {
+            if (!event.when) return; // Skip events without dates
+
+            const vevent = new ICAL.Component('vevent');
+            const ievent = new ICAL.Event(vevent);
+
+            // Set UID - use event ID with holon ID for uniqueness
+            ievent.uid = `${event.id}@${holonId}.harvest.app`;
+
+            // Set summary (title)
+            ievent.summary = event.title || 'Untitled Event';
+
+            // Set description
+            if (event.description) {
+                ievent.description = event.description;
+            }
+
+            // Set location
+            if (event.location) {
+                ievent.location = event.location;
+            }
+
+            // Set start time
+            const startDate = new Date(event.when);
+            ievent.startDate = ICAL.Time.fromJSDate(startDate, true);
+
+            // Set end time
+            const endDate = event.ends ? new Date(event.ends) : new Date(startDate.getTime() + 60 * 60 * 1000); // Default 1 hour
+            ievent.endDate = ICAL.Time.fromJSDate(endDate, true);
+
+            // Add status
+            if (event.status) {
+                vevent.updatePropertyWithValue('status', mapStatusToICalStatus(event.status));
+            }
+
+            // Add categories
+            if (event.category) {
+                vevent.updatePropertyWithValue('categories', event.category);
+            }
+
+            // Add participants as attendees
+            if (event.participants && event.participants.length > 0) {
+                event.participants.forEach(participant => {
+                    const attendeeName = participant.firstName || participant.username || participant.id;
+                    const attendee = vevent.addPropertyWithValue(
+                        'attendee',
+                        `mailto:${participant.id}@harvest.app`
+                    );
+                    attendee.setParameter('cn', attendeeName);
+                    attendee.setParameter('role', 'REQ-PARTICIPANT');
+                    attendee.setParameter('partstat', 'ACCEPTED');
+                });
+            }
+
+            // Set created and last modified timestamps
+            const now = ICAL.Time.now();
+            vevent.updatePropertyWithValue('dtstamp', now);
+            vevent.updatePropertyWithValue('created', now);
+            vevent.updatePropertyWithValue('last-modified', now);
+
+            // Add the event to the calendar
+            cal.addSubcomponent(vevent);
+        } catch (error) {
+            console.error('Error generating iCal event:', error);
+            // Skip malformed events
+        }
+    });
+
+    return cal.toString();
+}
+
+/**
+ * Maps holon event status to iCal status
+ */
+function mapStatusToICalStatus(status: string): string {
+    const statusMap: Record<string, string> = {
+        'completed': 'CONFIRMED',
+        'ongoing': 'CONFIRMED',
+        'scheduled': 'CONFIRMED',
+        'cancelled': 'CANCELLED',
+        'tentative': 'TENTATIVE'
+    };
+
+    return statusMap[status.toLowerCase()] || 'CONFIRMED';
+}
+
+/**
+ * Generates a download URL for the iCal feed
+ * @param icalContent - iCal content string
+ * @returns Blob URL for download
+ */
+export function createICalDownloadUrl(icalContent: string): string {
+    const blob = new Blob([icalContent], { type: 'text/calendar;charset=utf-8' });
+    return URL.createObjectURL(blob);
+}
+
+/**
+ * Downloads an iCal file
+ * @param icalContent - iCal content string
+ * @param fileName - Name for the downloaded file
+ */
+export function downloadICalFile(icalContent: string, fileName: string = 'calendar.ics'): void {
+    const url = createICalDownloadUrl(icalContent);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = fileName;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+}

--- a/src/lib/services/icalParser.ts
+++ b/src/lib/services/icalParser.ts
@@ -1,0 +1,169 @@
+// iCal Feed Parser Service
+// Fetches and parses external iCal/webcal feeds for calendar integration
+
+import ICAL from 'ical.js';
+
+export interface ExternalCalendarEvent {
+    id: string;
+    title: string;
+    description?: string;
+    location?: string;
+    start: Date;
+    end: Date;
+    allDay: boolean;
+    recurrence?: string;
+    calendarUrl: string;
+    calendarName?: string;
+}
+
+export interface ParsedCalendar {
+    name: string;
+    events: ExternalCalendarEvent[];
+    lastSync: Date;
+}
+
+/**
+ * Fetches and parses an iCal feed from a URL
+ * @param url - The iCal/webcal feed URL
+ * @param calendarName - Optional name for the calendar
+ * @returns Parsed calendar with events
+ */
+export async function fetchAndParseICalFeed(
+    url: string,
+    calendarName?: string
+): Promise<ParsedCalendar> {
+    try {
+        // Convert webcal:// to https://
+        const fetchUrl = url.replace(/^webcal:\/\//i, 'https://');
+
+        // Fetch the iCal feed
+        const response = await fetch(fetchUrl, {
+            headers: {
+                'Accept': 'text/calendar, text/plain, */*'
+            }
+        });
+
+        if (!response.ok) {
+            throw new Error(`Failed to fetch calendar: ${response.statusText}`);
+        }
+
+        const icalText = await response.text();
+
+        // Parse the iCal data
+        return parseICalText(icalText, url, calendarName);
+    } catch (error) {
+        console.error('Error fetching iCal feed:', error);
+        throw error;
+    }
+}
+
+/**
+ * Parses iCal text data into structured calendar events
+ * @param icalText - Raw iCal text data
+ * @param calendarUrl - The source URL for reference
+ * @param calendarName - Optional calendar name
+ * @returns Parsed calendar with events
+ */
+export function parseICalText(
+    icalText: string,
+    calendarUrl: string,
+    calendarName?: string
+): ParsedCalendar {
+    try {
+        const jcalData = ICAL.parse(icalText);
+        const comp = new ICAL.Component(jcalData);
+
+        // Get calendar name from X-WR-CALNAME or use provided name
+        const calNameProp = comp.getFirstPropertyValue('x-wr-calname');
+        const calName = calendarName ||
+            (typeof calNameProp === 'string' ? calNameProp : null) ||
+            'Imported Calendar';
+
+        const events: ExternalCalendarEvent[] = [];
+        const vevents = comp.getAllSubcomponents('vevent');
+
+        vevents.forEach((vevent) => {
+            try {
+                const event = new ICAL.Event(vevent);
+
+                // Get event properties
+                const uid = event.uid;
+                const summary = event.summary || 'Untitled Event';
+                const description = event.description || '';
+                const location = event.location || '';
+
+                // Get start and end times
+                const startDate = event.startDate.toJSDate();
+                const endDate = event.endDate.toJSDate();
+
+                // Check if it's an all-day event
+                const allDay = !event.startDate.isDate ? false : true;
+
+                // Get recurrence rule if exists
+                const rrule = vevent.getFirstPropertyValue('rrule');
+                const recurrence = rrule ? rrule.toString() : undefined;
+
+                events.push({
+                    id: uid,
+                    title: summary,
+                    description,
+                    location,
+                    start: startDate,
+                    end: endDate,
+                    allDay,
+                    recurrence,
+                    calendarUrl,
+                    calendarName: calName
+                });
+            } catch (error) {
+                console.error('Error parsing event:', error);
+                // Skip malformed events
+            }
+        });
+
+        return {
+            name: calName,
+            events,
+            lastSync: new Date()
+        };
+    } catch (error) {
+        console.error('Error parsing iCal text:', error);
+        throw error;
+    }
+}
+
+/**
+ * Filters events within a date range
+ * @param events - Array of calendar events
+ * @param startDate - Range start date
+ * @param endDate - Range end date
+ * @returns Filtered events
+ */
+export function filterEventsByDateRange(
+    events: ExternalCalendarEvent[],
+    startDate: Date,
+    endDate: Date
+): ExternalCalendarEvent[] {
+    return events.filter(event => {
+        const eventStart = new Date(event.start);
+        const eventEnd = new Date(event.end);
+
+        // Include event if it overlaps with the date range
+        return eventStart <= endDate && eventEnd >= startDate;
+    });
+}
+
+/**
+ * Validates an iCal URL
+ * @param url - URL to validate
+ * @returns true if valid
+ */
+export function isValidICalUrl(url: string): boolean {
+    try {
+        const urlObj = new URL(url);
+        const protocol = urlObj.protocol.toLowerCase();
+        return protocol === 'http:' || protocol === 'https:' || protocol === 'webcal:';
+    } catch {
+        return false;
+    }
+}

--- a/src/routes/[id]/calendar/feed.ics/+server.ts
+++ b/src/routes/[id]/calendar/feed.ics/+server.ts
@@ -1,0 +1,48 @@
+// iCal Feed Server Endpoint
+// Serves the holon's calendar as an iCal feed for external subscription
+
+import { error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { generateICalFeed } from '$lib/services/icalGenerator';
+import HoloSphere from 'holosphere';
+
+// Initialize HoloSphere instance for server-side data access
+// Default to production environment for iCal feed endpoint
+const holosphere = new HoloSphere('Holons');
+
+export const GET: RequestHandler = async ({ params }) => {
+    const holonId = params.id;
+
+    if (!holonId) {
+        throw error(400, 'Holon ID is required');
+    }
+
+    try {
+        // Fetch holon data to get the name
+        const holonData = await holosphere.get(holonId, 'profile', holonId);
+        const holonName = holonData?.name || holonData?.title || 'Holon Calendar';
+
+        // Fetch all quests/events from the holon
+        const quests = await holosphere.getAll(holonId, 'quests');
+
+        // Filter events that have a 'when' field (are scheduled)
+        const scheduledEvents = (quests || []).filter((quest: any) => quest.when);
+
+        // Generate the iCal feed
+        const icalContent = generateICalFeed(scheduledEvents, holonName, holonId);
+
+        // Return the iCal feed with proper headers
+        return new Response(icalContent, {
+            headers: {
+                'Content-Type': 'text/calendar; charset=utf-8',
+                'Content-Disposition': `attachment; filename="${holonName.replace(/[^a-z0-9]/gi, '_')}.ics"`,
+                'Cache-Control': 'no-cache, no-store, must-revalidate',
+                'Pragma': 'no-cache',
+                'Expires': '0'
+            }
+        });
+    } catch (err) {
+        console.error('Error generating iCal feed:', err);
+        throw error(500, 'Failed to generate calendar feed');
+    }
+};


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds calendar settings UI to import external iCal feeds and exposes a holon iCal feed, with periodic sync and merged display of external events.
> 
> - **Calendar UI**
>   - Adds `CalendarSettings.svelte` modal to import external calendars (add/remove/enable/disable) and copy export link.
>   - Integrates settings button into `src/components/Calendar.svelte` and binds updates via `on:calendarsUpdated`.
>   - Merges external iCal events into day/week/month views, visually distinguishing with `color` and flags (`isExternalEvent`, `isHolonEvent`).
>   - Periodic sync of enabled imported calendars every 10 minutes.
> - **Services**
>   - New `src/lib/services/icalParser.ts` to fetch/parse iCal/webcal feeds (`fetchAndParseICalFeed`, `parseICalText`, `filterEventsByDateRange`, `isValidICalUrl`).
>   - New `src/lib/services/icalGenerator.ts` to generate iCal content from holon events (`generateICalFeed`, download helpers).
> - **Backend**
>   - Adds server endpoint `src/routes/[id]/calendar/feed.ics/+server.ts` serving holon events as an iCal feed using HoloSphere data.
> - **Dependencies**
>   - Adds `ical.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83cc1e4db6dc07c67800fe28f2359c934473d567. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->