### PR TITLE
Claude/customizable dashboard menu

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git add:*)",
+      "Bash(git commit:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,9 @@
   "permissions": {
     "allow": [
       "Bash(git add:*)",
-      "Bash(git commit:*)"
+      "Bash(git commit:*)",
+      "Bash(git push)",
+      "Bash(git push:*)"
     ],
     "deny": [],
     "ask": []

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
 		"fontawesome": "^5.6.3",
 		"holosphere": "^1.1.20",
 		"html5-qrcode": "^2.3.8",
+		"ical.js": "^2.2.1",
 		"lune": "^0.4.0",
 		"mapbox-gl": "^3.7.0",
 		"sass": "^1.77.6",

--- a/src/components/Calendar.svelte
+++ b/src/components/Calendar.svelte
@@ -49,10 +49,13 @@
 
     // Imported calendar state
     let showCalendarSettings = false;
-    let importedCalendars: Array<{ id: string; url: string; name: string; enabled: boolean }> = [];
+    let importedCalendars: Array<{ id: string; url: string; name: string; enabled: boolean; color?: string }> = [];
     let externalEvents: ExternalCalendarEvent[] = [];
     let syncInterval: NodeJS.Timeout | number | null = null;
     const SYNC_INTERVAL_MS = 10 * 60 * 1000; // Sync every 10 minutes
+
+    // Map to store calendar colors by calendar ID for quick lookup
+    let calendarColorsMap: Record<string, string> = {};
 
     // Orbital visualization variables
     interface RecurringTask {
@@ -396,7 +399,7 @@
                 location: event.location,
                 when: event.start.toISOString(),
                 ends: event.end.toISOString(),
-                color: '#10b981', // Green color for external events
+                color: calendarColorsMap[event.calendarUrl] || '#10b981', // Use calendar color or default green
                 isExternalEvent: true,
                 calendarName: event.calendarName
             }));
@@ -516,6 +519,15 @@
             const calendarData = await holosphere.get($ID, 'settings', 'imported_calendars');
             if (calendarData && Array.isArray(calendarData.calendars)) {
                 importedCalendars = calendarData.calendars;
+
+                // Build color map for quick lookup
+                calendarColorsMap = {};
+                importedCalendars.forEach(cal => {
+                    if (cal.color) {
+                        calendarColorsMap[cal.url] = cal.color;
+                    }
+                });
+
                 // Sync calendars after loading
                 await syncAllCalendars();
             }

--- a/src/components/Calendar.svelte
+++ b/src/components/Calendar.svelte
@@ -1502,10 +1502,11 @@
     }
 </script>
 
-<Timeline 
+<Timeline
     currentDate={currentDate}
     profiles={profiles}
     users={users}
+    tasks={tasks}
     on:dateSelect={handleTimelineDateSelect}
 />
 

--- a/src/components/CalendarSettings.svelte
+++ b/src/components/CalendarSettings.svelte
@@ -1,0 +1,350 @@
+<script lang="ts">
+    import { getContext, createEventDispatcher } from 'svelte';
+    import type HoloSphere from 'holosphere';
+    import { ID } from '../dashboard/store';
+    import { isValidICalUrl } from '$lib/services/icalParser';
+
+    const dispatch = createEventDispatcher();
+    const holosphere = getContext('holosphere') as HoloSphere;
+
+    export let show = false;
+
+    // State
+    let importedCalendars: Array<{ id: string; url: string; name: string; enabled: boolean }> = [];
+    let newCalendarUrl = '';
+    let newCalendarName = '';
+    let loading = false;
+    let error = '';
+    let successMessage = '';
+    let showExportSection = false;
+
+    // Get the export URL for this holon's calendar
+    $: exportUrl = typeof window !== 'undefined'
+        ? `${window.location.origin}/${$ID}/calendar/feed.ics`
+        : '';
+
+    // Load imported calendars from holon data
+    async function loadImportedCalendars() {
+        if (!$ID) return;
+
+        try {
+            const calendarData = await holosphere.get($ID, 'settings', 'imported_calendars');
+            if (calendarData && Array.isArray(calendarData.calendars)) {
+                importedCalendars = calendarData.calendars;
+            }
+        } catch (err) {
+            console.error('Error loading imported calendars:', err);
+        }
+    }
+
+    // Save imported calendars to holon data
+    async function saveImportedCalendars() {
+        if (!$ID) return;
+
+        try {
+            await holosphere.put($ID, 'settings', {
+                id: 'imported_calendars',
+                calendars: importedCalendars,
+                updated: new Date().toISOString()
+            });
+        } catch (err) {
+            console.error('Error saving imported calendars:', err);
+            throw err;
+        }
+    }
+
+    // Add a new calendar
+    async function addCalendar() {
+        error = '';
+        successMessage = '';
+
+        if (!newCalendarUrl.trim()) {
+            error = 'Please enter a calendar URL';
+            return;
+        }
+
+        if (!isValidICalUrl(newCalendarUrl)) {
+            error = 'Please enter a valid calendar URL (http://, https://, or webcal://)';
+            return;
+        }
+
+        loading = true;
+
+        try {
+            const calendarId = `cal_${Date.now()}`;
+            const newCalendar = {
+                id: calendarId,
+                url: newCalendarUrl.trim(),
+                name: newCalendarName.trim() || 'Imported Calendar',
+                enabled: true
+            };
+
+            importedCalendars = [...importedCalendars, newCalendar];
+            await saveImportedCalendars();
+
+            // Clear form
+            newCalendarUrl = '';
+            newCalendarName = '';
+            successMessage = 'Calendar added successfully!';
+
+            // Notify parent component to refresh
+            dispatch('calendarsUpdated');
+
+            setTimeout(() => {
+                successMessage = '';
+            }, 3000);
+        } catch (err) {
+            error = 'Failed to add calendar. Please try again.';
+            console.error(err);
+        } finally {
+            loading = false;
+        }
+    }
+
+    // Remove a calendar
+    async function removeCalendar(calendarId: string) {
+        if (!confirm('Are you sure you want to remove this calendar?')) {
+            return;
+        }
+
+        loading = true;
+        error = '';
+
+        try {
+            importedCalendars = importedCalendars.filter(cal => cal.id !== calendarId);
+            await saveImportedCalendars();
+            successMessage = 'Calendar removed successfully!';
+
+            // Notify parent component to refresh
+            dispatch('calendarsUpdated');
+
+            setTimeout(() => {
+                successMessage = '';
+            }, 3000);
+        } catch (err) {
+            error = 'Failed to remove calendar. Please try again.';
+            console.error(err);
+        } finally {
+            loading = false;
+        }
+    }
+
+    // Toggle calendar enabled state
+    async function toggleCalendar(calendarId: string) {
+        loading = true;
+        error = '';
+
+        try {
+            importedCalendars = importedCalendars.map(cal =>
+                cal.id === calendarId ? { ...cal, enabled: !cal.enabled } : cal
+            );
+            await saveImportedCalendars();
+
+            // Notify parent component to refresh
+            dispatch('calendarsUpdated');
+        } catch (err) {
+            error = 'Failed to update calendar. Please try again.';
+            console.error(err);
+        } finally {
+            loading = false;
+        }
+    }
+
+    // Copy export URL to clipboard
+    async function copyExportUrl() {
+        try {
+            await navigator.clipboard.writeText(exportUrl);
+            successMessage = 'Calendar link copied to clipboard!';
+            setTimeout(() => {
+                successMessage = '';
+            }, 3000);
+        } catch (err) {
+            error = 'Failed to copy to clipboard';
+        }
+    }
+
+    // Load calendars when modal opens
+    $: if (show) {
+        loadImportedCalendars();
+    }
+</script>
+
+{#if show}
+    <div class="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center p-4 z-50" style="backdrop-filter: blur(4px);">
+        <div class="bg-gray-800 rounded-xl border border-gray-700 max-w-3xl w-full max-h-[90vh] overflow-y-auto">
+            <!-- Header -->
+            <div class="flex justify-between items-center p-6 border-b border-gray-700 sticky top-0 bg-gray-800 z-10">
+                <h2 class="text-2xl font-bold text-white">Calendar Settings</h2>
+                <button
+                    class="p-2 rounded-lg bg-gray-700 text-white hover:bg-gray-600 transition-colors"
+                    on:click={() => show = false}
+                    aria-label="Close modal"
+                >
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                    </svg>
+                </button>
+            </div>
+
+            <div class="p-6 space-y-8">
+                <!-- Error/Success Messages -->
+                {#if error}
+                    <div class="bg-red-900/50 border border-red-700 text-red-200 px-4 py-3 rounded-lg">
+                        {error}
+                    </div>
+                {/if}
+
+                {#if successMessage}
+                    <div class="bg-green-900/50 border border-green-700 text-green-200 px-4 py-3 rounded-lg">
+                        {successMessage}
+                    </div>
+                {/if}
+
+                <!-- Export Section -->
+                <div class="space-y-4">
+                    <button
+                        class="flex items-center justify-between w-full text-left"
+                        on:click={() => showExportSection = !showExportSection}
+                    >
+                        <h3 class="text-xl font-semibold text-white">Subscribe to This Holon's Calendar</h3>
+                        <svg
+                            class="w-5 h-5 text-gray-400 transition-transform {showExportSection ? 'rotate-180' : ''}"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                        >
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+
+                    {#if showExportSection}
+                        <div class="bg-gray-900 rounded-lg p-4 space-y-3">
+                            <p class="text-gray-300 text-sm">
+                                Copy this link and add it to your calendar app (Google Calendar, Apple Calendar, Outlook, etc.) to subscribe to this holon's events:
+                            </p>
+                            <div class="flex gap-2">
+                                <input
+                                    type="text"
+                                    readonly
+                                    value={exportUrl}
+                                    class="flex-1 bg-gray-800 text-white px-3 py-2 rounded-lg border border-gray-700 text-sm font-mono"
+                                />
+                                <button
+                                    class="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-500 transition-colors whitespace-nowrap"
+                                    on:click={copyExportUrl}
+                                >
+                                    Copy Link
+                                </button>
+                            </div>
+                            <p class="text-gray-400 text-xs">
+                                📝 This calendar updates automatically. Any changes to scheduled events in this holon will appear in your subscribed calendar.
+                            </p>
+                        </div>
+                    {/if}
+                </div>
+
+                <!-- Import Section -->
+                <div class="space-y-4">
+                    <h3 class="text-xl font-semibold text-white">Import External Calendars</h3>
+                    <p class="text-gray-300 text-sm">
+                        Import events from external calendars (Google Calendar, Apple Calendar, etc.) to display them in this holon's calendar.
+                    </p>
+
+                    <!-- Add New Calendar Form -->
+                    <div class="bg-gray-900 rounded-lg p-4 space-y-4">
+                        <div>
+                            <label for="calendar-url" class="text-gray-300 text-sm font-medium block mb-2">
+                                Calendar URL (iCal/webcal link)
+                            </label>
+                            <input
+                                id="calendar-url"
+                                type="url"
+                                bind:value={newCalendarUrl}
+                                placeholder="https://calendar.google.com/calendar/ical/..."
+                                class="w-full bg-gray-800 text-white px-3 py-2 rounded-lg border border-gray-700 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none"
+                            />
+                            <p class="text-gray-400 text-xs mt-1">
+                                To get a Google Calendar link: Calendar Settings → Integrate Calendar → Secret address in iCal format
+                            </p>
+                        </div>
+
+                        <div>
+                            <label for="calendar-name" class="text-gray-300 text-sm font-medium block mb-2">
+                                Calendar Name (optional)
+                            </label>
+                            <input
+                                id="calendar-name"
+                                type="text"
+                                bind:value={newCalendarName}
+                                placeholder="My Google Calendar"
+                                class="w-full bg-gray-800 text-white px-3 py-2 rounded-lg border border-gray-700 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 outline-none"
+                            />
+                        </div>
+
+                        <button
+                            class="w-full px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                            on:click={addCalendar}
+                            disabled={loading}
+                        >
+                            {loading ? 'Adding...' : 'Add Calendar'}
+                        </button>
+                    </div>
+
+                    <!-- Imported Calendars List -->
+                    {#if importedCalendars.length > 0}
+                        <div class="space-y-2">
+                            <h4 class="text-sm font-medium text-gray-400">Imported Calendars</h4>
+                            {#each importedCalendars as calendar (calendar.id)}
+                                <div class="bg-gray-900 rounded-lg p-4 flex items-center justify-between">
+                                    <div class="flex items-center gap-3 flex-1 min-w-0">
+                                        <button
+                                            class="flex-shrink-0"
+                                            on:click={() => toggleCalendar(calendar.id)}
+                                            aria-label={calendar.enabled ? 'Disable calendar' : 'Enable calendar'}
+                                        >
+                                            <div class="w-5 h-5 rounded border-2 {calendar.enabled ? 'bg-indigo-600 border-indigo-600' : 'border-gray-600'} flex items-center justify-center">
+                                                {#if calendar.enabled}
+                                                    <svg class="w-3 h-3 text-white" fill="currentColor" viewBox="0 0 20 20">
+                                                        <path d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"/>
+                                                    </svg>
+                                                {/if}
+                                            </div>
+                                        </button>
+                                        <div class="flex-1 min-w-0">
+                                            <div class="text-white font-medium truncate">{calendar.name}</div>
+                                            <div class="text-gray-400 text-xs truncate">{calendar.url}</div>
+                                        </div>
+                                    </div>
+                                    <button
+                                        class="flex-shrink-0 ml-4 p-2 text-red-400 hover:text-red-300 hover:bg-red-900/20 rounded transition-colors"
+                                        on:click={() => removeCalendar(calendar.id)}
+                                        aria-label="Remove calendar"
+                                    >
+                                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                                        </svg>
+                                    </button>
+                                </div>
+                            {/each}
+                        </div>
+                    {:else}
+                        <div class="text-center py-8 text-gray-400">
+                            <svg class="w-12 h-12 mx-auto mb-3 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                            </svg>
+                            <p>No imported calendars yet</p>
+                            <p class="text-sm mt-1">Add your first calendar above</p>
+                        </div>
+                    {/if}
+                </div>
+            </div>
+        </div>
+    </div>
+{/if}
+
+<style>
+    /* Ensure smooth transitions */
+    button {
+        transition: all 0.2s ease;
+    }
+</style>

--- a/src/components/Dashboard.svelte
+++ b/src/components/Dashboard.svelte
@@ -7,6 +7,103 @@
     import HoloSphere from 'holosphere';
     import { fetchHolonName } from "../utils/holonNames";
 
+    // Dashboard card interface
+    interface DashboardCard {
+        id: string;
+        title: string;
+        href: string;
+        icon: string;
+        colorClasses: {
+            bg: string;
+            bgOpacity: string;
+            text: string;
+            textHover: string;
+            progress: string;
+        };
+        gradient: string;
+        description?: string;
+        count?: () => number | string;
+        subtext?: () => string;
+        showProgress?: boolean;
+        progressPercent?: () => number;
+    }
+
+    // Helper to get color classes
+    function getColorClasses(baseColor: string) {
+        const colorMap: Record<string, any> = {
+            'green': {
+                bg: 'bg-green-500',
+                bgOpacity: 'bg-green-500 bg-opacity-20',
+                text: 'text-green-400',
+                textHover: 'group-hover:text-green-400',
+                progress: 'bg-green-500'
+            },
+            'blue': {
+                bg: 'bg-blue-500',
+                bgOpacity: 'bg-blue-500 bg-opacity-20',
+                text: 'text-blue-400',
+                textHover: 'group-hover:text-blue-400',
+                progress: 'bg-blue-500'
+            },
+            'cyan': {
+                bg: 'bg-cyan-500',
+                bgOpacity: 'bg-cyan-500 bg-opacity-20',
+                text: 'text-cyan-400',
+                textHover: 'group-hover:text-cyan-400',
+                progress: 'bg-cyan-500'
+            },
+            'emerald': {
+                bg: 'bg-emerald-500',
+                bgOpacity: 'bg-emerald-500 bg-opacity-20',
+                text: 'text-emerald-400',
+                textHover: 'group-hover:text-emerald-400',
+                progress: 'bg-emerald-500'
+            },
+            'red': {
+                bg: 'bg-red-500',
+                bgOpacity: 'bg-red-500 bg-opacity-20',
+                text: 'text-red-400',
+                textHover: 'group-hover:text-red-400',
+                progress: 'bg-red-500'
+            },
+            'amber': {
+                bg: 'bg-amber-500',
+                bgOpacity: 'bg-amber-500 bg-opacity-20',
+                text: 'text-amber-400',
+                textHover: 'group-hover:text-amber-400',
+                progress: 'bg-amber-500'
+            },
+            'yellow': {
+                bg: 'bg-yellow-500',
+                bgOpacity: 'bg-yellow-500 bg-opacity-20',
+                text: 'text-yellow-400',
+                textHover: 'group-hover:text-yellow-400',
+                progress: 'bg-yellow-500'
+            },
+            'indigo': {
+                bg: 'bg-indigo-500',
+                bgOpacity: 'bg-indigo-500 bg-opacity-20',
+                text: 'text-indigo-400',
+                textHover: 'group-hover:text-indigo-400',
+                progress: 'bg-indigo-500'
+            },
+            'teal': {
+                bg: 'bg-teal-500',
+                bgOpacity: 'bg-teal-500 bg-opacity-20',
+                text: 'text-teal-400',
+                textHover: 'group-hover:text-teal-400',
+                progress: 'bg-teal-500'
+            },
+            'orange': {
+                bg: 'bg-orange-500',
+                bgOpacity: 'bg-orange-500 bg-opacity-20',
+                text: 'text-orange-400',
+                textHover: 'group-hover:text-orange-400',
+                progress: 'bg-orange-500'
+            }
+        };
+        return colorMap[baseColor] || colorMap['green'];
+    }
 
     // Initialize holosphere
     const holosphere = getContext("holosphere") as HoloSphere;
@@ -20,13 +117,16 @@
     let completedTaskCount = 0;
     let openTaskCount = 0;
     let proposalCount = 0;
-    let recentEventCount = 0;
     let shoppingItemCount = 0;
     let offerCount = 0;
     let checklistCount = 0;
     let completedChecklistCount = 0;
     let roleCount = 0;
     let unassignedRoleCount = 0;
+
+    // Drag and drop state
+    let draggedCard: string | null = null;
+    let draggedFromRow: 'primary' | 'secondary' | null = null;
 
     onMount(() => {
         // Initialize with URL parameter first
@@ -114,7 +214,6 @@
         completedTaskCount = 0;
         openTaskCount = 0;
         proposalCount = 0;
-        recentEventCount = 0;
         shoppingItemCount = 0;
         offerCount = 0;
         checklistCount = 0;
@@ -174,22 +273,15 @@
                 (role: any) => !role.participants || role.participants.length === 0
             ).length;
 
-            // Process quests to separate tasks, proposals, and events
+            // Process quests to separate tasks and proposals
             proposalCount = questValues.filter((item: any) => item.type === "proposal").length;
-            const questEvents = questValues.filter((item: any) => item.type === "event");
-            
+
             const actualTasks = questValues.filter((item: any) => {
                 const type = item.type || 'task';
                 return type === 'task' || type === 'recurring';
             });
             completedTaskCount = actualTasks.filter((task: any) => task.status === "completed").length;
             openTaskCount = actualTasks.filter((task: any) => task.status !== "completed").length;
-            
-            const oneWeekAgo = new Date();
-            oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
-            recentEventCount = questEvents.filter(
-                (event: any) => event.when && new Date(event.when) >= oneWeekAgo
-            ).length;
 
         } catch (error: any) {
             console.error('Error fetching dashboard data:', error);
@@ -205,6 +297,220 @@
             isLoading = false;
         }
     }
+
+    // Define all available dashboard cards
+    const allCards: Record<string, DashboardCard> = {
+        users: {
+            id: 'users',
+            title: 'Users',
+            href: `/${holonID}/status`,
+            icon: 'fas fa-users',
+            colorClasses: getColorClasses('green'),
+            gradient: 'from-green-500/10 to-green-600/5',
+            description: 'View rankings & stats',
+            count: () => userCount,
+            subtext: () => 'Active Users'
+        },
+        tasks: {
+            id: 'tasks',
+            title: 'Tasks',
+            href: `/${holonID}/tasks`,
+            icon: 'fas fa-tasks',
+            colorClasses: getColorClasses('blue'),
+            gradient: 'from-blue-500/10 to-blue-600/5',
+            count: () => `${completedTaskCount}/${openTaskCount + completedTaskCount}`,
+            subtext: () => 'Completed',
+            showProgress: true,
+            progressPercent: () => Math.round((completedTaskCount / (openTaskCount + completedTaskCount || 1)) * 100)
+        },
+        roles: {
+            id: 'roles',
+            title: 'Roles',
+            href: `/${holonID}/roles`,
+            icon: 'fas fa-user-tag',
+            colorClasses: getColorClasses('cyan'),
+            gradient: 'from-cyan-500/10 to-cyan-600/5',
+            description: 'Active roles',
+            count: () => roleCount,
+            subtext: () => `${unassignedRoleCount} Unassigned`
+        },
+        settings: {
+            id: 'settings',
+            title: 'Settings',
+            href: `/${holonID}/settings`,
+            icon: 'fas fa-cog',
+            colorClasses: getColorClasses('emerald'),
+            gradient: 'from-emerald-500/10 to-emerald-600/5',
+            description: 'Configure holon'
+        },
+        shopping: {
+            id: 'shopping',
+            title: 'Shopping',
+            href: `/${holonID}/shopping`,
+            icon: 'fas fa-shopping-cart',
+            colorClasses: getColorClasses('red'),
+            gradient: 'from-red-500/10 to-red-600/5',
+            count: () => shoppingItemCount
+        },
+        expenses: {
+            id: 'expenses',
+            title: 'Expenses',
+            href: `/${holonID}/expenses`,
+            icon: 'fas fa-coins',
+            colorClasses: getColorClasses('amber'),
+            gradient: 'from-amber-500/10 to-amber-600/5',
+            description: 'Track spending'
+        },
+        proposals: {
+            id: 'proposals',
+            title: 'Proposals',
+            href: `/${holonID}/proposals`,
+            icon: 'fas fa-lightbulb',
+            colorClasses: getColorClasses('yellow'),
+            gradient: 'from-yellow-500/10 to-yellow-600/5',
+            count: () => proposalCount
+        },
+        offers: {
+            id: 'offers',
+            title: 'Offers & Requests',
+            href: `/${holonID}/offers`,
+            icon: 'fas fa-gift',
+            colorClasses: getColorClasses('indigo'),
+            gradient: 'from-indigo-500/10 to-indigo-600/5',
+            count: () => offerCount
+        },
+        checklists: {
+            id: 'checklists',
+            title: 'Checklists',
+            href: `/${holonID}/checklists`,
+            icon: 'fas fa-clipboard-check',
+            colorClasses: getColorClasses('teal'),
+            gradient: 'from-teal-500/10 to-teal-600/5',
+            count: () => `${completedChecklistCount}/${checklistCount}`,
+            showProgress: true,
+            progressPercent: () => (completedChecklistCount / (checklistCount || 1)) * 100
+        },
+        federation: {
+            id: 'federation',
+            title: 'Federation',
+            href: `/${holonID}/federation`,
+            icon: 'fas fa-network-wired',
+            colorClasses: getColorClasses('orange'),
+            gradient: 'from-orange-500/10 to-orange-600/5',
+            description: 'Configure data sharing'
+        }
+    };
+
+    // Default layout
+    const defaultPrimaryCards = ['users', 'tasks', 'roles', 'settings'];
+    const defaultSecondaryCards = ['shopping', 'expenses', 'proposals', 'offers', 'checklists', 'federation'];
+
+    // Load layout from localStorage or use defaults
+    let primaryCards: string[] = [];
+    let secondaryCards: string[] = [];
+
+    function loadLayout() {
+        if (typeof window === 'undefined') return;
+
+        const storageKey = `dashboard-layout-${holonID}`;
+        const saved = localStorage.getItem(storageKey);
+
+        if (saved) {
+            try {
+                const layout = JSON.parse(saved);
+                // Validate that saved cards exist in allCards
+                const validPrimary = (layout.primary || []).filter((id: string) => allCards[id]);
+                const validSecondary = (layout.secondary || []).filter((id: string) => allCards[id]);
+
+                // Use validated cards or defaults if empty
+                primaryCards = validPrimary.length > 0 ? validPrimary : [...defaultPrimaryCards];
+                secondaryCards = validSecondary.length > 0 ? validSecondary : [...defaultSecondaryCards];
+            } catch (e) {
+                primaryCards = [...defaultPrimaryCards];
+                secondaryCards = [...defaultSecondaryCards];
+            }
+        } else {
+            primaryCards = [...defaultPrimaryCards];
+            secondaryCards = [...defaultSecondaryCards];
+        }
+    }
+
+    function saveLayout() {
+        if (typeof window === 'undefined') return;
+
+        const storageKey = `dashboard-layout-${holonID}`;
+        const layout = {
+            primary: primaryCards,
+            secondary: secondaryCards
+        };
+        localStorage.setItem(storageKey, JSON.stringify(layout));
+    }
+
+    // Drag and drop handlers
+    function handleDragStart(e: DragEvent, cardId: string, row: 'primary' | 'secondary') {
+        draggedCard = cardId;
+        draggedFromRow = row;
+        if (e.dataTransfer) {
+            e.dataTransfer.effectAllowed = 'move';
+        }
+    }
+
+    function handleDragOver(e: DragEvent) {
+        e.preventDefault();
+        if (e.dataTransfer) {
+            e.dataTransfer.dropEffect = 'move';
+        }
+    }
+
+    function handleDrop(e: DragEvent, targetCardId: string, targetRow: 'primary' | 'secondary') {
+        e.preventDefault();
+
+        if (!draggedCard || !draggedFromRow) return;
+
+        // Remove card from source row
+        if (draggedFromRow === 'primary') {
+            primaryCards = primaryCards.filter(id => id !== draggedCard);
+        } else {
+            secondaryCards = secondaryCards.filter(id => id !== draggedCard);
+        }
+
+        // Add card to target row at the position of targetCardId
+        if (targetRow === 'primary') {
+            const targetIndex = primaryCards.indexOf(targetCardId);
+            primaryCards = [
+                ...primaryCards.slice(0, targetIndex),
+                draggedCard,
+                ...primaryCards.slice(targetIndex)
+            ];
+        } else {
+            const targetIndex = secondaryCards.indexOf(targetCardId);
+            secondaryCards = [
+                ...secondaryCards.slice(0, targetIndex),
+                draggedCard,
+                ...secondaryCards.slice(targetIndex)
+            ];
+        }
+
+        saveLayout();
+        draggedCard = null;
+        draggedFromRow = null;
+    }
+
+    function handleDragEnd() {
+        draggedCard = null;
+        draggedFromRow = null;
+    }
+
+    function resetLayout() {
+        primaryCards = [...defaultPrimaryCards];
+        secondaryCards = [...defaultSecondaryCards];
+        saveLayout();
+    }
+
+    // Load layout when holon changes
+    $: if (holonID) {
+        loadLayout();
+    }
 </script>
 
 {#if isLoading && !connectionReady}
@@ -216,224 +522,106 @@
 </div>
 {:else}
 <div class="space-y-8">
-    <!-- Stats Grid -->
+    <!-- Reset Button -->
+    <div class="flex justify-end">
+        <button
+            on:click={resetLayout}
+            class="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors text-sm flex items-center gap-2"
+        >
+            <i class="fas fa-undo"></i>
+            Reset Layout
+        </button>
+    </div>
+
+    <!-- Primary Stats Grid -->
     <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6">
-        <!-- Users Card -->
-        <a
-            href={`/${holonID}/status`}
-            class="group bg-gray-800 hover:bg-gray-750 transition-all duration-300 p-8 rounded-2xl shadow-xl hover:shadow-2xl transform hover:scale-105 relative overflow-hidden"
-        >
-            <div class="absolute inset-0 bg-gradient-to-br from-green-500/10 to-green-600/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-            <div class="relative z-10">
-                <div class="flex items-center justify-between mb-4">
-                    <div class="p-3 bg-green-500 bg-opacity-20 rounded-xl">
-                        <i class="fas fa-users text-2xl text-green-400"></i>
+        {#each primaryCards as cardId (cardId)}
+            {@const card = allCards[cardId]}
+            <a
+                href={card.href}
+                draggable="true"
+                on:dragstart={(e) => handleDragStart(e, cardId, 'primary')}
+                on:dragover={handleDragOver}
+                on:drop={(e) => handleDrop(e, cardId, 'primary')}
+                on:dragend={handleDragEnd}
+                class="group bg-gray-800 hover:bg-gray-750 transition-all duration-300 p-8 rounded-2xl shadow-xl hover:shadow-2xl transform hover:scale-105 relative overflow-hidden cursor-move"
+                class:opacity-50={draggedCard === cardId}
+            >
+                <div class="absolute inset-0 bg-gradient-to-br {card.gradient} opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+                <div class="relative z-10">
+                    <div class="flex items-center justify-between mb-4">
+                        <div class="p-3 {card.colorClasses.bgOpacity} rounded-xl">
+                            <i class="{card.icon} text-2xl {card.colorClasses.text}"></i>
+                        </div>
+                        {#if card.count}
+                            <div class="text-right">
+                                <p class="text-3xl font-bold text-white">{card.count()}</p>
+                                {#if card.subtext}
+                                    <p class="text-sm text-gray-400">{card.subtext()}</p>
+                                {/if}
+                            </div>
+                        {/if}
                     </div>
-                    <div class="text-right">
-                        <p class="text-3xl font-bold text-white">{userCount}</p>
-                        <p class="text-sm text-gray-400">Active Users</p>
-                    </div>
+                    <h3 class="text-xl font-semibold text-white {card.colorClasses.textHover} transition-colors">{card.title}</h3>
+                    {#if card.description}
+                        <p class="text-gray-400 text-sm mt-1">{card.description}</p>
+                    {/if}
+                    {#if card.showProgress}
+                        <div class="mt-2">
+                            <div class="flex justify-between text-sm text-gray-400 mb-1">
+                                <span>Progress</span>
+                                <span>{card.progressPercent()}%</span>
+                            </div>
+                            <div class="w-full bg-gray-700 rounded-full h-2">
+                                <div class="{card.colorClasses.progress} h-2 rounded-full transition-all duration-500" style="width: {card.progressPercent()}%"></div>
+                            </div>
+                        </div>
+                    {/if}
                 </div>
-                <h3 class="text-xl font-semibold text-white group-hover:text-green-400 transition-colors">Users</h3>
-                <p class="text-gray-400 text-sm mt-1">View rankings & stats</p>
-            </div>
-        </a>
-
-        <!-- Tasks Card -->
-        <a
-            href={`/${holonID}/tasks`}
-            class="group bg-gray-800 hover:bg-gray-750 transition-all duration-300 p-8 rounded-2xl shadow-xl hover:shadow-2xl transform hover:scale-105 relative overflow-hidden"
-        >
-            <div class="absolute inset-0 bg-gradient-to-br from-blue-500/10 to-blue-600/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-            <div class="relative z-10">
-                <div class="flex items-center justify-between mb-4">
-                    <div class="p-3 bg-blue-500 bg-opacity-20 rounded-xl">
-                        <i class="fas fa-tasks text-2xl text-blue-400"></i>
-                    </div>
-                    <div class="text-right">
-                        <p class="text-2xl font-bold text-white">{completedTaskCount}<span class="text-lg text-gray-400">/{openTaskCount + completedTaskCount}</span></p>
-                        <p class="text-sm text-gray-400">Completed</p>
-                    </div>
-                </div>
-                <h3 class="text-xl font-semibold text-white group-hover:text-blue-400 transition-colors">Tasks</h3>
-                <div class="mt-2">
-                    <div class="flex justify-between text-sm text-gray-400 mb-1">
-                        <span>Progress</span>
-                        <span>{Math.round((completedTaskCount / (openTaskCount + completedTaskCount || 1)) * 100)}%</span>
-                    </div>
-                    <div class="w-full bg-gray-700 rounded-full h-2">
-                        <div class="bg-blue-500 h-2 rounded-full transition-all duration-500" style="width: {(completedTaskCount / (openTaskCount + completedTaskCount || 1)) * 100}%"></div>
-                    </div>
-                </div>
-            </div>
-        </a>
-
-        <!-- Events Card -->
-        <a
-            href={`/${holonID}/schedule`}
-            class="group bg-gray-800 hover:bg-gray-750 transition-all duration-300 p-8 rounded-2xl shadow-xl hover:shadow-2xl transform hover:scale-105 relative overflow-hidden"
-        >
-            <div class="absolute inset-0 bg-gradient-to-br from-purple-500/10 to-purple-600/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-            <div class="relative z-10">
-                <div class="flex items-center justify-between mb-4">
-                    <div class="p-3 bg-purple-500 bg-opacity-20 rounded-xl">
-                        <i class="fas fa-calendar-alt text-2xl text-purple-400"></i>
-                    </div>
-                    <div class="text-right">
-                        <p class="text-3xl font-bold text-white">{recentEventCount}</p>
-                        <p class="text-sm text-gray-400">This Week</p>
-                    </div>
-                </div>
-                <h3 class="text-xl font-semibold text-white group-hover:text-purple-400 transition-colors">Events</h3>
-                <p class="text-gray-400 text-sm mt-1">Recent activities</p>
-            </div>
-        </a>
-
-        <!-- Shopping Card -->
-        <a
-            href={`/${holonID}/shopping`}
-            class="group bg-gray-800 hover:bg-gray-750 transition-all duration-300 p-8 rounded-2xl shadow-xl hover:shadow-2xl transform hover:scale-105 relative overflow-hidden"
-        >
-            <div class="absolute inset-0 bg-gradient-to-br from-red-500/10 to-red-600/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-            <div class="relative z-10">
-                <div class="flex items-center justify-between mb-4">
-                    <div class="p-3 bg-red-500 bg-opacity-20 rounded-xl">
-                        <i class="fas fa-shopping-cart text-2xl text-red-400"></i>
-                    </div>
-                    <div class="text-right">
-                        <p class="text-3xl font-bold text-white">{shoppingItemCount}</p>
-                        <p class="text-sm text-gray-400">Items</p>
-                    </div>
-                </div>
-                <h3 class="text-xl font-semibold text-white group-hover:text-red-400 transition-colors">Shopping</h3>
-                <p class="text-gray-400 text-sm mt-1">Active items</p>
-            </div>
-        </a>
+            </a>
+        {/each}
     </div>
 
     <!-- Secondary Stats Grid -->
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-6">
-        <!-- Proposals Card -->
-        <a
-            href={`/${holonID}/proposals`}
-            class="group bg-gray-800 hover:bg-gray-750 transition-all duration-300 p-6 rounded-2xl shadow-xl hover:shadow-2xl transform hover:scale-105 relative overflow-hidden"
-        >
-            <div class="absolute inset-0 bg-gradient-to-br from-yellow-500/10 to-yellow-600/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-            <div class="relative z-10">
-                <div class="flex items-center space-x-4">
-                    <div class="p-3 bg-yellow-500 bg-opacity-20 rounded-xl">
-                        <i class="fas fa-lightbulb text-xl text-yellow-400"></i>
-                    </div>
-                    <div class="flex-1">
-                        <h3 class="text-lg font-semibold text-white group-hover:text-yellow-400 transition-colors">Proposals</h3>
-                        <p class="text-2xl font-bold text-white">{proposalCount}</p>
-                    </div>
-                </div>
-            </div>
-        </a>
-
-        <!-- Offers Card -->
-        <a
-            href={`/${holonID}/offers`}
-            class="group bg-gray-800 hover:bg-gray-750 transition-all duration-300 p-6 rounded-2xl shadow-xl hover:shadow-2xl transform hover:scale-105 relative overflow-hidden"
-        >
-            <div class="absolute inset-0 bg-gradient-to-br from-indigo-500/10 to-indigo-600/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-            <div class="relative z-10">
-                <div class="flex items-center space-x-4">
-                    <div class="p-3 bg-indigo-500 bg-opacity-20 rounded-xl">
-                        <i class="fas fa-gift text-xl text-indigo-400"></i>
-                    </div>
-                    <div class="flex-1">
-                        <h3 class="text-lg font-semibold text-white group-hover:text-indigo-400 transition-colors">Offers & Requests</h3>
-                        <p class="text-2xl font-bold text-white">{offerCount}</p>
-                    </div>
-                </div>
-            </div>
-        </a>
-
-        <!-- Checklists Card -->
-        <a
-            href={`/${holonID}/checklists`}
-            class="group bg-gray-800 hover:bg-gray-750 transition-all duration-300 p-6 rounded-2xl shadow-xl hover:shadow-2xl transform hover:scale-105 relative overflow-hidden"
-        >
-            <div class="absolute inset-0 bg-gradient-to-br from-teal-500/10 to-teal-600/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-            <div class="relative z-10">
-                <div class="flex items-center space-x-4">
-                    <div class="p-3 bg-teal-500 bg-opacity-20 rounded-xl">
-                        <i class="fas fa-clipboard-check text-xl text-teal-400"></i>
-                    </div>
-                    <div class="flex-1">
-                        <h3 class="text-lg font-semibold text-white group-hover:text-teal-400 transition-colors">Checklists</h3>
-                        <p class="text-2xl font-bold text-white">{completedChecklistCount}<span class="text-lg text-gray-400">/{checklistCount}</span></p>
-                        <div class="mt-1">
-                            <div class="w-full bg-gray-700 rounded-full h-1.5">
-                                <div class="bg-teal-500 h-1.5 rounded-full transition-all duration-500" style="width: {(completedChecklistCount / (checklistCount || 1)) * 100}%"></div>
-                            </div>
+        {#each secondaryCards as cardId (cardId)}
+            {@const card = allCards[cardId]}
+            <a
+                href={card.href}
+                draggable="true"
+                on:dragstart={(e) => handleDragStart(e, cardId, 'secondary')}
+                on:dragover={handleDragOver}
+                on:drop={(e) => handleDrop(e, cardId, 'secondary')}
+                on:dragend={handleDragEnd}
+                class="group bg-gray-800 hover:bg-gray-750 transition-all duration-300 p-6 rounded-2xl shadow-xl hover:shadow-2xl transform hover:scale-105 relative overflow-hidden cursor-move"
+                class:opacity-50={draggedCard === cardId}
+            >
+                <div class="absolute inset-0 bg-gradient-to-br {card.gradient} opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+                <div class="relative z-10">
+                    <div class="flex items-center space-x-4">
+                        <div class="p-3 {card.colorClasses.bgOpacity} rounded-xl">
+                            <i class="{card.icon} text-xl {card.colorClasses.text}"></i>
+                        </div>
+                        <div class="flex-1">
+                            <h3 class="text-lg font-semibold text-white {card.colorClasses.textHover} transition-colors">{card.title}</h3>
+                            {#if card.count}
+                                <p class="text-2xl font-bold text-white">{card.count()}</p>
+                            {/if}
+                            {#if card.description}
+                                <p class="text-sm text-gray-400">{card.description}</p>
+                            {/if}
+                            {#if card.showProgress}
+                                <div class="mt-1">
+                                    <div class="w-full bg-gray-700 rounded-full h-1.5">
+                                        <div class="{card.colorClasses.progress} h-1.5 rounded-full transition-all duration-500" style="width: {card.progressPercent()}%"></div>
+                                    </div>
+                                </div>
+                            {/if}
                         </div>
                     </div>
                 </div>
-            </div>
-        </a>
-
-        <!-- Roles Card -->
-        <a
-            href={`/${holonID}/roles`}
-            class="group bg-gray-800 hover:bg-gray-750 transition-all duration-300 p-6 rounded-2xl shadow-xl hover:shadow-2xl transform hover:scale-105 relative overflow-hidden"
-        >
-            <div class="absolute inset-0 bg-gradient-to-br from-cyan-500/10 to-cyan-600/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-            <div class="relative z-10">
-                <div class="flex items-center space-x-4">
-                    <div class="p-3 bg-cyan-500 bg-opacity-20 rounded-xl">
-                        <i class="fas fa-user-tag text-xl text-cyan-400"></i>
-                    </div>
-                    <div class="flex-1">
-                        <h3 class="text-lg font-semibold text-white group-hover:text-cyan-400 transition-colors">Roles</h3>
-                        <p class="text-2xl font-bold text-white">{roleCount}</p>
-                        <p class="text-sm text-gray-400">{unassignedRoleCount} Unassigned</p>
-                    </div>
-                </div>
-            </div>
-        </a>
-
-
-
-        <!-- Federation Card -->
-        <a
-            href={`/${holonID}/federation`}
-            class="group bg-gray-800 hover:bg-gray-750 transition-all duration-300 p-6 rounded-2xl shadow-xl hover:shadow-2xl transform hover:scale-105 relative overflow-hidden"
-        >
-            <div class="absolute inset-0 bg-gradient-to-br from-orange-500/10 to-orange-600/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-            <div class="relative z-10">
-                <div class="flex items-center space-x-4">
-                    <div class="p-3 bg-orange-500 bg-opacity-20 rounded-xl">
-                        <i class="fas fa-network-wired text-xl text-orange-400"></i>
-                    </div>
-                    <div class="flex-1">
-                        <h3 class="text-lg font-semibold text-white group-hover:text-orange-400 transition-colors">Federation</h3>
-                        <p class="text-sm text-gray-400">Configure data sharing</p>
-                    </div>
-                </div>
-            </div>
-        </a>
-
-        <!-- Settings Card -->
-        <a
-            href={`/${holonID}/settings`}
-            class="group bg-gray-800 hover:bg-gray-750 transition-all duration-300 p-6 rounded-2xl shadow-xl hover:shadow-2xl transform hover:scale-105 relative overflow-hidden"
-        >
-            <div class="absolute inset-0 bg-gradient-to-br from-emerald-500/10 to-emerald-600/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-            <div class="relative z-10">
-                <div class="flex items-center space-x-4">
-                    <div class="p-3 bg-emerald-500 bg-opacity-20 rounded-xl">
-                        <i class="fas fa-cog text-xl text-emerald-400"></i>
-                    </div>
-                    <div class="flex-1">
-                        <h3 class="text-lg font-semibold text-white group-hover:text-emerald-400 transition-colors">Settings</h3>
-                        <p class="text-sm text-gray-400">Configure holon</p>
-                    </div>
-                </div>
-            </div>
-        </a>
+            </a>
+        {/each}
     </div>
 
     <!-- Announcements Section -->

--- a/src/lib/services/icalGenerator.ts
+++ b/src/lib/services/icalGenerator.ts
@@ -1,0 +1,154 @@
+// iCal Feed Generator Service
+// Generates iCal feeds from holon events for export/subscription
+
+import ICAL from 'ical.js';
+
+export interface HolonEvent {
+    id: string;
+    title: string;
+    description?: string;
+    location?: string;
+    when: string; // ISO date string
+    ends?: string; // ISO date string
+    participants?: Array<{ id: string; username?: string; firstName?: string; lastName?: string }>;
+    status?: string;
+    category?: string;
+}
+
+/**
+ * Generates an iCal feed from holon events
+ * @param events - Array of holon events
+ * @param holonName - Name of the holon (for calendar name)
+ * @param holonId - ID of the holon
+ * @returns iCal formatted string
+ */
+export function generateICalFeed(
+    events: HolonEvent[],
+    holonName: string,
+    holonId: string
+): string {
+    // Create the calendar component
+    const cal = new ICAL.Component(['vcalendar', [], []]);
+
+    // Set calendar properties
+    cal.updatePropertyWithValue('prodid', '-//Harvest Holon Calendar//EN');
+    cal.updatePropertyWithValue('version', '2.0');
+    cal.updatePropertyWithValue('calscale', 'GREGORIAN');
+    cal.updatePropertyWithValue('method', 'PUBLISH');
+    cal.updatePropertyWithValue('x-wr-calname', `${holonName} Calendar`);
+    cal.updatePropertyWithValue('x-wr-caldesc', `Events from ${holonName} holon`);
+    cal.updatePropertyWithValue('x-wr-timezone', 'UTC');
+
+    // Add each event
+    events.forEach(event => {
+        try {
+            if (!event.when) return; // Skip events without dates
+
+            const vevent = new ICAL.Component('vevent');
+            const ievent = new ICAL.Event(vevent);
+
+            // Set UID - use event ID with holon ID for uniqueness
+            ievent.uid = `${event.id}@${holonId}.harvest.app`;
+
+            // Set summary (title)
+            ievent.summary = event.title || 'Untitled Event';
+
+            // Set description
+            if (event.description) {
+                ievent.description = event.description;
+            }
+
+            // Set location
+            if (event.location) {
+                ievent.location = event.location;
+            }
+
+            // Set start time
+            const startDate = new Date(event.when);
+            ievent.startDate = ICAL.Time.fromJSDate(startDate, true);
+
+            // Set end time
+            const endDate = event.ends ? new Date(event.ends) : new Date(startDate.getTime() + 60 * 60 * 1000); // Default 1 hour
+            ievent.endDate = ICAL.Time.fromJSDate(endDate, true);
+
+            // Add status
+            if (event.status) {
+                vevent.updatePropertyWithValue('status', mapStatusToICalStatus(event.status));
+            }
+
+            // Add categories
+            if (event.category) {
+                vevent.updatePropertyWithValue('categories', event.category);
+            }
+
+            // Add participants as attendees
+            if (event.participants && event.participants.length > 0) {
+                event.participants.forEach(participant => {
+                    const attendeeName = participant.firstName || participant.username || participant.id;
+                    const attendee = vevent.addPropertyWithValue(
+                        'attendee',
+                        `mailto:${participant.id}@harvest.app`
+                    );
+                    attendee.setParameter('cn', attendeeName);
+                    attendee.setParameter('role', 'REQ-PARTICIPANT');
+                    attendee.setParameter('partstat', 'ACCEPTED');
+                });
+            }
+
+            // Set created and last modified timestamps
+            const now = ICAL.Time.now();
+            vevent.updatePropertyWithValue('dtstamp', now);
+            vevent.updatePropertyWithValue('created', now);
+            vevent.updatePropertyWithValue('last-modified', now);
+
+            // Add the event to the calendar
+            cal.addSubcomponent(vevent);
+        } catch (error) {
+            console.error('Error generating iCal event:', error);
+            // Skip malformed events
+        }
+    });
+
+    return cal.toString();
+}
+
+/**
+ * Maps holon event status to iCal status
+ */
+function mapStatusToICalStatus(status: string): string {
+    const statusMap: Record<string, string> = {
+        'completed': 'CONFIRMED',
+        'ongoing': 'CONFIRMED',
+        'scheduled': 'CONFIRMED',
+        'cancelled': 'CANCELLED',
+        'tentative': 'TENTATIVE'
+    };
+
+    return statusMap[status.toLowerCase()] || 'CONFIRMED';
+}
+
+/**
+ * Generates a download URL for the iCal feed
+ * @param icalContent - iCal content string
+ * @returns Blob URL for download
+ */
+export function createICalDownloadUrl(icalContent: string): string {
+    const blob = new Blob([icalContent], { type: 'text/calendar;charset=utf-8' });
+    return URL.createObjectURL(blob);
+}
+
+/**
+ * Downloads an iCal file
+ * @param icalContent - iCal content string
+ * @param fileName - Name for the downloaded file
+ */
+export function downloadICalFile(icalContent: string, fileName: string = 'calendar.ics'): void {
+    const url = createICalDownloadUrl(icalContent);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = fileName;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+}

--- a/src/lib/services/icalParser.ts
+++ b/src/lib/services/icalParser.ts
@@ -96,9 +96,7 @@ export function parseICalText(
         const events: ExternalCalendarEvent[] = [];
         const vevents = comp.getAllSubcomponents('vevent');
 
-        console.log(`Found ${vevents.length} events in calendar`);
-
-        vevents.forEach((vevent, index) => {
+        vevents.forEach((vevent) => {
             try {
                 const event = new ICAL.Event(vevent);
 
@@ -118,21 +116,6 @@ export function parseICalText(
                 // Get recurrence rule if exists
                 const rrule = vevent.getFirstPropertyValue('rrule');
                 const recurrence = rrule ? rrule.toString() : undefined;
-
-                // Check event status and transparency (for debugging)
-                const status = vevent.getFirstPropertyValue('status');
-                const transp = vevent.getFirstPropertyValue('transp');
-
-                // Log event details for debugging
-                if (index < 3) { // Log first 3 events as sample
-                    console.log(`Event ${index + 1}:`, {
-                        title: summary,
-                        start: startDate,
-                        status,
-                        transp,
-                        uid: uid.substring(0, 20) + '...'
-                    });
-                }
 
                 events.push({
                     id: uid,

--- a/src/lib/services/icalParser.ts
+++ b/src/lib/services/icalParser.ts
@@ -96,7 +96,9 @@ export function parseICalText(
         const events: ExternalCalendarEvent[] = [];
         const vevents = comp.getAllSubcomponents('vevent');
 
-        vevents.forEach((vevent) => {
+        console.log(`Found ${vevents.length} events in calendar`);
+
+        vevents.forEach((vevent, index) => {
             try {
                 const event = new ICAL.Event(vevent);
 
@@ -116,6 +118,21 @@ export function parseICalText(
                 // Get recurrence rule if exists
                 const rrule = vevent.getFirstPropertyValue('rrule');
                 const recurrence = rrule ? rrule.toString() : undefined;
+
+                // Check event status and transparency (for debugging)
+                const status = vevent.getFirstPropertyValue('status');
+                const transp = vevent.getFirstPropertyValue('transp');
+
+                // Log event details for debugging
+                if (index < 3) { // Log first 3 events as sample
+                    console.log(`Event ${index + 1}:`, {
+                        title: summary,
+                        start: startDate,
+                        status,
+                        transp,
+                        uid: uid.substring(0, 20) + '...'
+                    });
+                }
 
                 events.push({
                     id: uid,

--- a/src/lib/services/icalParser.ts
+++ b/src/lib/services/icalParser.ts
@@ -1,0 +1,169 @@
+// iCal Feed Parser Service
+// Fetches and parses external iCal/webcal feeds for calendar integration
+
+import ICAL from 'ical.js';
+
+export interface ExternalCalendarEvent {
+    id: string;
+    title: string;
+    description?: string;
+    location?: string;
+    start: Date;
+    end: Date;
+    allDay: boolean;
+    recurrence?: string;
+    calendarUrl: string;
+    calendarName?: string;
+}
+
+export interface ParsedCalendar {
+    name: string;
+    events: ExternalCalendarEvent[];
+    lastSync: Date;
+}
+
+/**
+ * Fetches and parses an iCal feed from a URL
+ * @param url - The iCal/webcal feed URL
+ * @param calendarName - Optional name for the calendar
+ * @returns Parsed calendar with events
+ */
+export async function fetchAndParseICalFeed(
+    url: string,
+    calendarName?: string
+): Promise<ParsedCalendar> {
+    try {
+        // Convert webcal:// to https://
+        const fetchUrl = url.replace(/^webcal:\/\//i, 'https://');
+
+        // Fetch the iCal feed
+        const response = await fetch(fetchUrl, {
+            headers: {
+                'Accept': 'text/calendar, text/plain, */*'
+            }
+        });
+
+        if (!response.ok) {
+            throw new Error(`Failed to fetch calendar: ${response.statusText}`);
+        }
+
+        const icalText = await response.text();
+
+        // Parse the iCal data
+        return parseICalText(icalText, url, calendarName);
+    } catch (error) {
+        console.error('Error fetching iCal feed:', error);
+        throw error;
+    }
+}
+
+/**
+ * Parses iCal text data into structured calendar events
+ * @param icalText - Raw iCal text data
+ * @param calendarUrl - The source URL for reference
+ * @param calendarName - Optional calendar name
+ * @returns Parsed calendar with events
+ */
+export function parseICalText(
+    icalText: string,
+    calendarUrl: string,
+    calendarName?: string
+): ParsedCalendar {
+    try {
+        const jcalData = ICAL.parse(icalText);
+        const comp = new ICAL.Component(jcalData);
+
+        // Get calendar name from X-WR-CALNAME or use provided name
+        const calNameProp = comp.getFirstPropertyValue('x-wr-calname');
+        const calName = calendarName ||
+            (typeof calNameProp === 'string' ? calNameProp : null) ||
+            'Imported Calendar';
+
+        const events: ExternalCalendarEvent[] = [];
+        const vevents = comp.getAllSubcomponents('vevent');
+
+        vevents.forEach((vevent) => {
+            try {
+                const event = new ICAL.Event(vevent);
+
+                // Get event properties
+                const uid = event.uid;
+                const summary = event.summary || 'Untitled Event';
+                const description = event.description || '';
+                const location = event.location || '';
+
+                // Get start and end times
+                const startDate = event.startDate.toJSDate();
+                const endDate = event.endDate.toJSDate();
+
+                // Check if it's an all-day event
+                const allDay = !event.startDate.isDate ? false : true;
+
+                // Get recurrence rule if exists
+                const rrule = vevent.getFirstPropertyValue('rrule');
+                const recurrence = rrule ? rrule.toString() : undefined;
+
+                events.push({
+                    id: uid,
+                    title: summary,
+                    description,
+                    location,
+                    start: startDate,
+                    end: endDate,
+                    allDay,
+                    recurrence,
+                    calendarUrl,
+                    calendarName: calName
+                });
+            } catch (error) {
+                console.error('Error parsing event:', error);
+                // Skip malformed events
+            }
+        });
+
+        return {
+            name: calName,
+            events,
+            lastSync: new Date()
+        };
+    } catch (error) {
+        console.error('Error parsing iCal text:', error);
+        throw error;
+    }
+}
+
+/**
+ * Filters events within a date range
+ * @param events - Array of calendar events
+ * @param startDate - Range start date
+ * @param endDate - Range end date
+ * @returns Filtered events
+ */
+export function filterEventsByDateRange(
+    events: ExternalCalendarEvent[],
+    startDate: Date,
+    endDate: Date
+): ExternalCalendarEvent[] {
+    return events.filter(event => {
+        const eventStart = new Date(event.start);
+        const eventEnd = new Date(event.end);
+
+        // Include event if it overlaps with the date range
+        return eventStart <= endDate && eventEnd >= startDate;
+    });
+}
+
+/**
+ * Validates an iCal URL
+ * @param url - URL to validate
+ * @returns true if valid
+ */
+export function isValidICalUrl(url: string): boolean {
+    try {
+        const urlObj = new URL(url);
+        const protocol = urlObj.protocol.toLowerCase();
+        return protocol === 'http:' || protocol === 'https:' || protocol === 'webcal:';
+    } catch {
+        return false;
+    }
+}

--- a/src/routes/[id]/calendar/feed.ics/+server.ts
+++ b/src/routes/[id]/calendar/feed.ics/+server.ts
@@ -1,0 +1,48 @@
+// iCal Feed Server Endpoint
+// Serves the holon's calendar as an iCal feed for external subscription
+
+import { error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { generateICalFeed } from '$lib/services/icalGenerator';
+import HoloSphere from 'holosphere';
+
+// Initialize HoloSphere instance for server-side data access
+// Default to production environment for iCal feed endpoint
+const holosphere = new HoloSphere('Holons');
+
+export const GET: RequestHandler = async ({ params }) => {
+    const holonId = params.id;
+
+    if (!holonId) {
+        throw error(400, 'Holon ID is required');
+    }
+
+    try {
+        // Fetch holon data to get the name
+        const holonData = await holosphere.get(holonId, 'profile', holonId);
+        const holonName = holonData?.name || holonData?.title || 'Holon Calendar';
+
+        // Fetch all quests/events from the holon
+        const quests = await holosphere.getAll(holonId, 'quests');
+
+        // Filter events that have a 'when' field (are scheduled)
+        const scheduledEvents = (quests || []).filter((quest: any) => quest.when);
+
+        // Generate the iCal feed
+        const icalContent = generateICalFeed(scheduledEvents, holonName, holonId);
+
+        // Return the iCal feed with proper headers
+        return new Response(icalContent, {
+            headers: {
+                'Content-Type': 'text/calendar; charset=utf-8',
+                'Content-Disposition': `attachment; filename="${holonName.replace(/[^a-z0-9]/gi, '_')}.ics"`,
+                'Cache-Control': 'no-cache, no-store, must-revalidate',
+                'Pragma': 'no-cache',
+                'Expires': '0'
+            }
+        });
+    } catch (err) {
+        console.error('Error generating iCal feed:', err);
+        throw error(500, 'Failed to generate calendar feed');
+    }
+};


### PR DESCRIPTION
Summary

  Implemented a drag-and-drop customizable dashboard that allows users to
  personalize their holon dashboard layout. Each user can arrange dashboard
  cards to their preference, with layouts saved locally per-user and
  per-holon.

  Key Features

  - Drag & Drop Interface: Intuitive card reordering between primary and
  secondary rows
  - User-Specific Customization: Layouts stored in browser localStorage
  (per-user, per-holon)
  - Reset Functionality: One-click button to restore default layout
  - Robust Validation: Handles removed/renamed cards gracefully with
  fallback to defaults
  - Visual Feedback: Cards show opacity change while being dragged

  Default Layout

  Primary Row: Users, Tasks, Roles, SettingsSecondary Row: Shopping,
  Expenses, Proposals, Offers & Requests, Checklists, Federation

  Technical Implementation

  - Uses HTML5 drag-and-drop API
  - Predefined Tailwind color classes (prevents purging issues)
  - localStorage key: dashboard-layout-${holonID}
  - Backwards compatible with graceful fallbacks

  Limitations

  - Desktop-only (HTML5 drag-and-drop doesn't work on mobile/touch devices)
  - Users on tablets/phones will see the default layout

  Testing

  - Drag cards between primary and secondary rows
  - Reorder cards within each row
  - Reset layout button restores defaults
  - Layout persists across page reloads
  - Different holons have separate layouts
  - Invalid saved layouts fall back to defaults