### PR TITLE
Fix/dashboard widget counts and ics singleton

### DIFF
--- a/src/components/Dashboard.svelte
+++ b/src/components/Dashboard.svelte
@@ -283,6 +283,21 @@
             completedTaskCount = actualTasks.filter((task: any) => task.status === "completed").length;
             openTaskCount = actualTasks.filter((task: any) => task.status !== "completed").length;
 
+            // Debug logging
+            console.log('Dashboard data fetched:', {
+                holonID,
+                totalQuests: questValues.length,
+                actualTasks: actualTasks.length,
+                completedTaskCount,
+                openTaskCount,
+                roleCount,
+                userCount,
+                offerCount,
+                proposalCount,
+                shoppingItemCount,
+                checklistCount
+            });
+
         } catch (error: any) {
             console.error('Error fetching dashboard data:', error);
             
@@ -298,8 +313,8 @@
         }
     }
 
-    // Define all available dashboard cards
-    const allCards: Record<string, DashboardCard> = {
+    // Define all available dashboard cards (reactive to count changes)
+    $: allCards = {
         users: {
             id: 'users',
             title: 'Users',


### PR DESCRIPTION
Title:
  Fix dashboard widget counts display and optimize ICS server

  Description:
  ## Summary
  This PR addresses two issues found in the dashboard and calendar feed
  server.

  ## Changes

  ### 1. Dashboard Widget Counts Not Displaying
  **Problem:** Task counts displayed "0/0" even though data was correctly
  fetched (console showed 12 tasks).

  **Solution:** Changed `allCards` from `const` to a reactive statement (`$:
   allCards = {...}`).

  **Result:** Dashboard widgets now correctly display task counts (e.g.,
  "0/12" instead of "0/0")

  ### 2. ICS Calendar Server Optimization
  **Problem:** A new HoloSphere instance was created for every calendar feed
   request.

  **Solution:** Implemented singleton pattern that creates and reuses a
  single HoloSphere instance.

  **Benefits:** Better performance, reduced memory usage, maintains
  persistent GunDB connection

  ## Testing
  - [x] Verified dashboard widgets display correct task counts
  - [x] Verified data fetching works correctly
  - [x] Tested drag-and-drop functionality still works
  - [x] ICS calendar feed endpoints work correctly

  🤖 Generated with [Claude Code](https://claude.com/claude-code)