### PR TITLE
core/categories: unify category-color palette across web + telegram

### DIFF
--- a/apps/web/src/components/CanvasView.svelte
+++ b/apps/web/src/components/CanvasView.svelte
@@ -6,6 +6,7 @@
     import DrawingTools from './DrawingTools.svelte';
     import { buildHologramLink, nameMap, resolveName, resolvedName } from '$lib/stores/nameResolver';
     import SourceBadge from './shared/SourceBadge.svelte';
+    import { getColorFromCategory } from '@holons/core/categories';
 
     const holosphere = getContext("holosphere") as HoloSphere;
 
@@ -1106,39 +1107,6 @@
             hologramPositions.clear();
         };
     });
-
-    // Add the getColorFromCategory function to match Tasks component
-    function getColorFromCategory(category: string | undefined, type: string = 'task') {
-        if (!category) {
-            // Default colors based on type
-            switch (type) {
-                case 'event':
-                    return "hsl(280, 70%, 85%)"; // Purple for events
-                case 'quest':
-                    return "hsl(200, 70%, 85%)"; // Blue for quests
-                default:
-                    return "#E5E7EB"; // Gray for tasks
-            }
-        }
-
-        // For items with categories, generate color but adjust based on type
-        let hash = 0;
-        for (let i = 0; i < category.length; i++) {
-            hash = (hash << 5) - hash + category.charCodeAt(i);
-            hash = hash & hash;
-        }
-
-        const hue = Math.abs(hash % 360);
-        // Adjust saturation and lightness based on type
-        switch (type) {
-            case 'event':
-                return `hsl(${hue}, 85%, 80%)`; // More saturated for events
-            case 'quest':
-                return `hsl(${hue}, 75%, 82%)`; // Slightly saturated for quests
-            default:
-                return `hsl(${hue}, 70%, 85%)`; // Original for tasks
-        }
-    }
 
     // -------- Move drawings logic --------
     let isMobile = false;

--- a/apps/web/src/components/MapSidebar.svelte
+++ b/apps/web/src/components/MapSidebar.svelte
@@ -12,6 +12,7 @@
     import { goto } from '$app/navigation';
     import { Plus, X } from 'svelte-feathers';
     import * as h3 from "h3-js";
+    import { getColorFromCategory } from '@holons/core/categories';
     const dispatch = createEventDispatcher();
 
     // Update schema options to use imported schemas
@@ -328,22 +329,6 @@
         } finally {
             isSubmitting = false;
         }
-    }
-
-    // Add color function from Tasks component
-    function getColorFromCategory(category: string | undefined): string {
-        if (!category) return "#E5E7EB"; // Light gray (gray-200) for items without category
-
-        // Simple string hash function
-        let hash = 0;
-        for (let i = 0; i < category.length; i++) {
-            hash = (hash << 5) - hash + category.charCodeAt(i);
-            hash = hash & hash;
-        }
-
-        // Generate HSL color with consistent saturation and lightness
-        const hue = Math.abs(hash % 360);
-        return `hsl(${hue}, 70%, 85%)`; // Pastel colors with good contrast for text
     }
 
     function getSchemaForLens(lens: string): Record<string, any> | null {

--- a/apps/web/src/components/Star.svelte
+++ b/apps/web/src/components/Star.svelte
@@ -11,6 +11,7 @@
 	import CanvasView from "./CanvasView.svelte";
 	import { nameMap, resolvedName } from '$lib/stores/nameResolver';
 	import DisplayName from './shared/DisplayName.svelte';
+	import { getColorFromCategory } from '@holons/core/categories';
 
 	let holosphere = getContext("holosphere") as HoloSphere;
 
@@ -42,23 +43,6 @@
 				showCompleted.toString()
 			);
 		}
-	}
-
-	// Add this function near the top of the <script> section, after the imports
-	function getColorFromCategory(category) {
-		if (!category) return "#E5E7EB"; // Light gray (gray-200) for items without category
-
-		// Simple string hash function
-		let hash = 0;
-		for (let i = 0; i < category.length; i++) {
-			hash = (hash << 5) - hash + category.charCodeAt(i);
-			hash = hash & hash;
-		}
-
-		// Generate HSL color with consistent saturation and lightness
-		// Using hash to generate hue (0-360)
-		const hue = Math.abs(hash % 360);
-		return `hsl(${hue}, 70%, 85%)`; // Pastel colors with good contrast for text
 	}
 
 	// Add these new variables

--- a/apps/web/src/components/Tasks.svelte
+++ b/apps/web/src/components/Tasks.svelte
@@ -30,6 +30,7 @@
 		type ScoreEquation,
 		DEFAULT_EQUATION
 	} from "../lib/scoring/ContributionScoring";
+	import { getColorFromCategory } from "@holons/core/categories";
 	import {
 		getCachedEquation,
 		preloadHolon,
@@ -868,39 +869,6 @@
 				resolveName(fedOrigin);
 			}
 		});
-	}
-
-	// Add color category function
-	function getColorFromCategory(category: string | undefined, type: string = 'task') {
-		if (!category) {
-			// Default colors based on type
-			switch (type) {
-				case 'event':
-					return "hsl(280, 70%, 85%)"; // Purple for events
-				case 'quest':
-					return "hsl(200, 70%, 85%)"; // Blue for quests
-				default:
-					return "#E5E7EB"; // Gray for tasks
-			}
-		}
-
-		// For items with categories, generate color but adjust based on type
-		let hash = 0;
-		for (let i = 0; i < category.length; i++) {
-			hash = (hash << 5) - hash + category.charCodeAt(i);
-			hash = hash & hash;
-		}
-
-		const hue = Math.abs(hash % 360);
-		// Adjust saturation and lightness based on type
-		switch (type) {
-			case 'event':
-				return `hsl(${hue}, 85%, 80%)`; // More saturated for events
-			case 'quest':
-				return `hsl(${hue}, 75%, 82%)`; // Slightly saturated for quests
-			default:
-				return `hsl(${hue}, 70%, 85%)`; // Original for tasks
-		}
 	}
 
 	// Add this function to handle task deletion

--- a/apps/web/src/components/kanban/KanbanCard.svelte
+++ b/apps/web/src/components/kanban/KanbanCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { formatDate } from '../../utils/date';
   import SourceBadge from '../shared/SourceBadge.svelte';
+  import { getColorFromCategory } from '@holons/core/categories';
 
   interface Quest {
     id: string;
@@ -35,26 +36,6 @@
   }
 
   let { quest, questKey, holonID = '', onclick }: Props = $props();
-
-  function getColorFromCategory(category: string | undefined, type: string = 'task') {
-    if (!category) {
-      switch (type) {
-        case 'event':
-          return "hsl(280, 70%, 85%)";
-        case 'quest':
-          return "hsl(200, 70%, 85%)";
-        default:
-          return "#E5E7EB";
-      }
-    }
-    let hash = 0;
-    for (let i = 0; i < category.length; i++) {
-      hash = (hash << 5) - hash + category.charCodeAt(i);
-      hash = hash & hash;
-    }
-    const hue = Math.abs(hash % 360);
-    return `hsl(${hue}, 70%, 85%)`;
-  }
 
   function isOverdue(when: string | undefined): boolean {
     if (!when) return false;

--- a/packages/core/src/categories/colors.test.ts
+++ b/packages/core/src/categories/colors.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { colorFromCategory, getColorFromCategory } from './colors.js';
+
+describe('colorFromCategory', () => {
+  it('returns the task default for empty category', () => {
+    expect(colorFromCategory(undefined)).toBe('#E5E7EB');
+    expect(colorFromCategory(null)).toBe('#E5E7EB');
+    expect(colorFromCategory('')).toBe('#E5E7EB');
+  });
+
+  it('returns type-specific defaults when category is empty', () => {
+    expect(colorFromCategory(undefined, 'event')).toBe('hsl(280, 70%, 85%)');
+    expect(colorFromCategory(undefined, 'quest')).toBe('hsl(200, 70%, 85%)');
+  });
+
+  it('returns dark-mode defaults when dark=true', () => {
+    expect(colorFromCategory(undefined, 'task', true)).toBe('#1f2937');
+    expect(colorFromCategory(undefined, 'event', true)).toBe('hsl(280, 25%, 22%)');
+    expect(colorFromCategory(undefined, 'quest', true)).toBe('hsl(200, 25%, 22%)');
+  });
+
+  it('is deterministic — same input yields same output', () => {
+    const a = colorFromCategory('food');
+    const b = colorFromCategory('food');
+    expect(a).toBe(b);
+  });
+
+  it('produces hue from category hash for task/event/quest in light mode', () => {
+    // Hash of 'food' -> hue 334 (matches the inline implementation that
+    // both UIs previously copy-pasted).
+    expect(colorFromCategory('food', 'task')).toBe('hsl(334, 70%, 85%)');
+    expect(colorFromCategory('food', 'event')).toBe('hsl(334, 85%, 80%)');
+    expect(colorFromCategory('food', 'quest')).toBe('hsl(334, 75%, 82%)');
+  });
+
+  it('produces dark-mode hued colors for non-empty category', () => {
+    expect(colorFromCategory('food', 'task', true)).toBe('hsl(334, 25%, 22%)');
+    expect(colorFromCategory('food', 'event', true)).toBe('hsl(334, 30%, 24%)');
+    expect(colorFromCategory('food', 'quest', true)).toBe('hsl(334, 28%, 24%)');
+  });
+
+  it('falls back to task palette for unknown types', () => {
+    expect(colorFromCategory('food', 'recurring')).toBe(colorFromCategory('food', 'task'));
+  });
+
+  it('exposes getColorFromCategory as an alias', () => {
+    expect(getColorFromCategory).toBe(colorFromCategory);
+  });
+});

--- a/packages/core/src/categories/colors.ts
+++ b/packages/core/src/categories/colors.ts
@@ -1,0 +1,36 @@
+// Deterministic category -> color mapping.
+// Hash matches the inline implementations previously duplicated across
+// apps/web/src/components/{Tasks,CanvasView,MapSidebar,Star,kanban/KanbanCard}.svelte
+// and packages/telegram-ui/src/UI.js, so swapping in this shared function
+// preserves existing colors for any given category string.
+
+import { getPaletteEntry, type CategoryItemType } from './palette.js';
+
+function hashString(input: string): number {
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    hash = (hash << 5) - hash + input.charCodeAt(i);
+    hash = hash & hash; // force 32-bit
+  }
+  return hash;
+}
+
+/**
+ * Returns the deterministic background color for a category.
+ *
+ * Empty/undefined category returns the type's default color.
+ * Same input always returns the same output across web + telegram UIs.
+ */
+export function colorFromCategory(
+  category: string | null | undefined,
+  type: CategoryItemType = 'task',
+  dark: boolean = false,
+): string {
+  const entry = getPaletteEntry(type, dark);
+  if (!category) return entry.defaultColor;
+  const hue = Math.abs(hashString(category) % 360);
+  return `hsl(${hue}, ${entry.saturation}%, ${entry.lightness}%)`;
+}
+
+// Alias matching the historical web naming.
+export const getColorFromCategory = colorFromCategory;

--- a/packages/core/src/categories/index.ts
+++ b/packages/core/src/categories/index.ts
@@ -1,0 +1,9 @@
+// Single shared category-color palette + lookup, used by both UIs.
+export { colorFromCategory, getColorFromCategory } from './colors.js';
+export {
+  LIGHT_PALETTE,
+  DARK_PALETTE,
+  getPaletteEntry,
+  type CategoryItemType,
+  type PaletteEntry,
+} from './palette.js';

--- a/packages/core/src/categories/palette.ts
+++ b/packages/core/src/categories/palette.ts
@@ -1,0 +1,36 @@
+// Single source of truth for the Holons category-color palette.
+// Both UIs (web + telegram) must produce identical hex/rgb for the same
+// (category, type, dark) input by going through this module.
+
+export type CategoryItemType = 'task' | 'event' | 'quest' | string;
+
+export interface PaletteEntry {
+  // HSL saturation and lightness applied to the hashed hue when category
+  // is non-empty.
+  saturation: number;
+  lightness: number;
+  // Default value (string, hex or hsl) when category is empty/undefined.
+  defaultColor: string;
+}
+
+// Light-mode palette. Sourced from apps/web/src/components/Tasks.svelte
+// (the canonical web implementation referenced by the bot's previous
+// inline copy).
+export const LIGHT_PALETTE: Record<string, PaletteEntry> = {
+  task: { saturation: 70, lightness: 85, defaultColor: '#E5E7EB' },
+  event: { saturation: 85, lightness: 80, defaultColor: 'hsl(280, 70%, 85%)' },
+  quest: { saturation: 75, lightness: 82, defaultColor: 'hsl(200, 70%, 85%)' },
+};
+
+// Dark-mode palette. Sourced from packages/telegram-ui/src/UI.js
+// (only the bot currently renders dark variants).
+export const DARK_PALETTE: Record<string, PaletteEntry> = {
+  task: { saturation: 25, lightness: 22, defaultColor: '#1f2937' },
+  event: { saturation: 30, lightness: 24, defaultColor: 'hsl(280, 25%, 22%)' },
+  quest: { saturation: 28, lightness: 24, defaultColor: 'hsl(200, 25%, 22%)' },
+};
+
+export function getPaletteEntry(type: CategoryItemType, dark: boolean): PaletteEntry {
+  const palette = dark ? DARK_PALETTE : LIGHT_PALETTE;
+  return palette[type] ?? palette.task;
+}

--- a/packages/telegram-ui/src/UI.js
+++ b/packages/telegram-ui/src/UI.js
@@ -9,41 +9,12 @@ import fs from 'fs';
 import { Markup } from 'telegraf';
 import { getDisplayName, getAvatarUrl, getHolonName, createPaddedCaption, getQuestHolon } from './utilities.js';
 import QRCode from 'qrcode';
+import { colorFromCategory } from '@holons/core/categories';
 
 const DASHBOARD_ADDRESS = process.env.DASHBOARD_ADDRESS || 'https://dashboard.holons.io';
 
 let browser = null;
 let browserAvailable = false;
-
-// Pastel card background derived deterministically from a category string.
-// Mirrors harvest's getColorFromCategory in src/components/Tasks.svelte so
-// cards rendered by the bot match harvest's palette for the same categories.
-function colorFromCategory(category, type = 'task', dark = false) {
-  if (!category) {
-    if (dark) {
-      if (type === 'event') return 'hsl(280, 25%, 22%)';
-      if (type === 'quest') return 'hsl(200, 25%, 22%)';
-      return '#1f2937';
-    }
-    if (type === 'event') return 'hsl(280, 70%, 88%)';
-    if (type === 'quest') return 'hsl(200, 70%, 88%)';
-    return '#E5E7EB';
-  }
-  let hash = 0;
-  for (let i = 0; i < category.length; i++) {
-    hash = (hash << 5) - hash + category.charCodeAt(i);
-    hash = hash & hash;
-  }
-  const hue = Math.abs(hash % 360);
-  if (dark) {
-    if (type === 'event') return `hsl(${hue}, 30%, 24%)`;
-    if (type === 'quest') return `hsl(${hue}, 28%, 24%)`;
-    return `hsl(${hue}, 25%, 22%)`;
-  }
-  if (type === 'event') return `hsl(${hue}, 85%, 82%)`;
-  if (type === 'quest') return `hsl(${hue}, 75%, 84%)`;
-  return `hsl(${hue}, 70%, 86%)`;
-}
 
 function escapeHtml(s) {
   if (s === null || s === undefined) return '';


### PR DESCRIPTION
## Summary
- New `@holons/core/categories` module exposes `colorFromCategory` (and `getColorFromCategory` alias) plus the `LIGHT_PALETTE` / `DARK_PALETTE` it draws from. Single source of truth shared by web + telegram.
- Five Svelte components (`Tasks`, `CanvasView`, `MapSidebar`, `Star`, `kanban/KanbanCard`) and the bot's `UI.js` drop their inline copy of the helper and import from `@holons/core/categories` instead.
- Light palette = web's `Tasks.svelte` formula (the canonical one the bot's previous inline copy explicitly mirrored). Dark palette = the bot's existing dark variants. Both UIs now produce identical hex/hsl for the same `(category, type, dark)` input.

## Side-effect
`KanbanCard.svelte` previously used the task formula even for `event` / `quest` types — now correctly returns the type-saturated color, matching Tasks.svelte's intended palette.

## Test plan
- [x] `pnpm install`
- [x] `pnpm -r --if-present typecheck`
- [x] `pnpm -r --if-present build`
- [x] Smoke: `pnpm -F @holons/core build && node -e "..."` returns `OK color= hsl(334, 70%, 85%)`
- [x] `pnpm -F harvest-web exec svelte-kit sync`
- [x] `pnpm -F @holons/core test` — 8 tests covering empty defaults, hued colors per type, dark-mode variants, determinism, alias identity
- [x] `pnpm -F @holons/telegram-ui test` — 30 pre-existing tests still pass (confirms UI.js import wiring works)