### PR TITLE
core/shopping: extract ShoppingItem + CRUD into @holons/core

### DIFF
--- a/apps/web/src/types/shoppingItem.ts
+++ b/apps/web/src/types/shoppingItem.ts
@@ -1,8 +1,3 @@
-export interface ShoppingItem {
-    id: string;
-    name: string;
-    quantity: number;
-    done: boolean;
-    addedBy: string;
-    addedOn: string;
-}
+// Re-export from @holons/core/shopping. The canonical ShoppingItem + ShoppingChecklist
+// types live in packages/core/src/shopping/ so web and telegram UIs share one shape.
+export type { ShoppingItem, ShoppingChecklist } from '@holons/core/shopping';

--- a/packages/core/src/shopping/index.ts
+++ b/packages/core/src/shopping/index.ts
@@ -1,0 +1,5 @@
+// @holons/core/shopping — shared shopping-list domain.
+// Used by apps/web (ShoppingList.svelte) and packages/telegram-ui (Shopping.js).
+
+export * from './types.js';
+export * from './operations.js';

--- a/packages/core/src/shopping/operations.test.ts
+++ b/packages/core/src/shopping/operations.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import {
+  addItem,
+  addItems,
+  clearChecked,
+  createEmptyChecklist,
+  createShoppingItem,
+  isShoppingDoc,
+  normalizeChecklist,
+  removeChecked,
+  removeItem,
+  toggleItem,
+} from './operations.js';
+
+describe('shopping operations', () => {
+  it('createShoppingItem builds a defaulted item', () => {
+    const item = createShoppingItem('  Milk  ', { createdBy: 42 });
+    expect(item.text).toBe('Milk');
+    expect(item.checked).toBe(false);
+    expect(item.createdBy).toBe(42);
+    expect(item.id).toBeTruthy();
+  });
+
+  it('addItem appends without mutating the input', () => {
+    const empty = createEmptyChecklist(1000);
+    const next = addItem(empty, 'Bread');
+    expect(empty.items).toHaveLength(0);
+    expect(next.items).toHaveLength(1);
+    expect(next.items[0].text).toBe('Bread');
+  });
+
+  it('addItem creates a new checklist when given null', () => {
+    const next = addItem(null, 'Eggs', { createdBy: 7 });
+    expect(next.id).toBe('shopping');
+    expect(next.items[0].createdBy).toBe(7);
+  });
+
+  it('addItems trims and skips blanks', () => {
+    const next = addItems(null, ['  ', 'a', '', 'b']);
+    expect(next.items.map((i) => i.text)).toEqual(['a', 'b']);
+  });
+
+  it('toggleItem flips checked, removeItem drops by id, removeChecked drops checked', () => {
+    let list = addItems(null, ['a', 'b', 'c']);
+    const ids = list.items.map((i) => i.id);
+    list = toggleItem(list, ids[0])!;
+    list = toggleItem(list, ids[2])!;
+    expect(list.items.filter((i) => i.checked).map((i) => i.text)).toEqual(['a', 'c']);
+
+    const cleared = clearChecked(list)!;
+    expect(cleared.items.every((i) => !i.checked)).toBe(true);
+
+    const pruned = removeChecked(list)!;
+    expect(pruned.items.map((i) => i.text)).toEqual(['b']);
+
+    const minusOne = removeItem(list, ids[1])!;
+    expect(minusOne.items.map((i) => i.text)).toEqual(['a', 'c']);
+  });
+
+  it('normalizeChecklist filters deleted/invalid items and rejects deleted docs', () => {
+    expect(normalizeChecklist(null)).toBeNull();
+    expect(normalizeChecklist({ _deleted: true })).toBeNull();
+    const norm = normalizeChecklist({
+      title: 'X',
+      createdAt: 5,
+      items: [{ id: 1, text: 'ok', checked: false }, null, { id: 2, text: 'gone', _deleted: true }],
+    });
+    expect(norm?.items.map((i) => i.text)).toEqual(['ok']);
+  });
+
+  it('isShoppingDoc recognises the container by key, id, or type', () => {
+    expect(isShoppingDoc({ type: 'shopping' })).toBe(true);
+    expect(isShoppingDoc({ id: 'shopping' })).toBe(true);
+    expect(isShoppingDoc({}, 'shopping')).toBe(true);
+    expect(isShoppingDoc({ type: 'tasks' })).toBe(false);
+    expect(isShoppingDoc(null)).toBe(false);
+  });
+});

--- a/packages/core/src/shopping/operations.ts
+++ b/packages/core/src/shopping/operations.ts
@@ -1,0 +1,126 @@
+/**
+ * Pure CRUD for shopping checklists. UI-agnostic: takes data in, returns data out.
+ * Storage I/O is the caller's responsibility (telegram uses `db.put`, web uses `holosphere.put`).
+ */
+
+import {
+  SHOPPING_KEY,
+  type ShoppingChecklist,
+  type ShoppingItem,
+} from './types.js';
+
+/** Default container shape, used when no document exists yet for a holon. */
+export function createEmptyChecklist(now: number = Date.now()): ShoppingChecklist {
+  return {
+    id: SHOPPING_KEY,
+    type: 'shopping',
+    title: 'Shopping List',
+    items: [],
+    createdAt: now,
+  };
+}
+
+/** Coerce a raw document (possibly partial / from gun) into a sane checklist, or null if deleted/absent. */
+export function normalizeChecklist(data: unknown): ShoppingChecklist | null {
+  if (!data || typeof data !== 'object') return null;
+  const d = data as Record<string, unknown>;
+  if (d._deleted) return null;
+  return {
+    id: SHOPPING_KEY,
+    type: 'shopping',
+    title: typeof d.title === 'string' ? d.title : 'Shopping List',
+    items: Array.isArray(d.items)
+      ? (d.items as ShoppingItem[]).filter((i) => i && i.id != null && !i._deleted)
+      : [],
+    createdAt: typeof d.createdAt === 'number' ? d.createdAt : Date.now(),
+    _hologram: d._hologram as ShoppingChecklist['_hologram'],
+    _federation: d._federation as ShoppingChecklist['_federation'],
+  };
+}
+
+/** Build one item with sensible defaults. id-collision-free even within the same millisecond. */
+export function createShoppingItem(
+  text: string,
+  opts: { id?: string | number; createdBy?: number | string; checked?: boolean } = {}
+): ShoppingItem {
+  return {
+    id: opts.id ?? `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    text: String(text).trim(),
+    checked: opts.checked ?? false,
+    ...(opts.createdBy !== undefined ? { createdBy: opts.createdBy } : {}),
+  };
+}
+
+/** Append multiple items, dropping blanks. Returns a new checklist (does not mutate input). */
+export function addItems(
+  checklist: ShoppingChecklist | null,
+  texts: string[],
+  opts: { createdBy?: number | string } = {}
+): ShoppingChecklist {
+  const base = checklist ?? createEmptyChecklist();
+  const fresh = texts
+    .map((t) => String(t).trim())
+    .filter((t) => t.length > 0)
+    .map((t) => createShoppingItem(t, opts));
+  return { ...base, items: [...base.items, ...fresh] };
+}
+
+/** Single-item convenience wrapper around {@link addItems}. */
+export function addItem(
+  checklist: ShoppingChecklist | null,
+  text: string,
+  opts: { createdBy?: number | string } = {}
+): ShoppingChecklist {
+  return addItems(checklist, [text], opts);
+}
+
+/** Toggle one item's `checked` flag. Returns a new checklist. */
+export function toggleItem(
+  checklist: ShoppingChecklist | null,
+  itemId: string | number
+): ShoppingChecklist | null {
+  if (!checklist) return null;
+  const target = String(itemId);
+  return {
+    ...checklist,
+    items: checklist.items.map((i) =>
+      String(i.id) === target ? { ...i, checked: !i.checked } : i
+    ),
+  };
+}
+
+/** Remove one item by id. Returns a new checklist. */
+export function removeItem(
+  checklist: ShoppingChecklist | null,
+  itemId: string | number
+): ShoppingChecklist | null {
+  if (!checklist) return null;
+  const target = String(itemId);
+  return {
+    ...checklist,
+    items: checklist.items.filter((i) => String(i.id) !== target),
+  };
+}
+
+/** Drop every checked item. Used by telegram "Done" / web "Remove checked" buttons. */
+export function removeChecked(checklist: ShoppingChecklist | null): ShoppingChecklist | null {
+  if (!checklist) return null;
+  return { ...checklist, items: checklist.items.filter((i) => !i.checked) };
+}
+
+/** Uncheck every item without removing them. Used by web "Refresh" button. */
+export function clearChecked(checklist: ShoppingChecklist | null): ShoppingChecklist | null {
+  if (!checklist) return null;
+  return {
+    ...checklist,
+    items: checklist.items.map((i) => (i.checked ? { ...i, checked: false } : i)),
+  };
+}
+
+/** Convenience: is the document the shopping container? */
+export function isShoppingDoc(doc: unknown, key?: string): boolean {
+  if (!doc) return false;
+  if (key === SHOPPING_KEY) return true;
+  const d = doc as Record<string, unknown>;
+  return d.id === SHOPPING_KEY || d.type === 'shopping';
+}

--- a/packages/core/src/shopping/types.ts
+++ b/packages/core/src/shopping/types.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared shopping-list types for Holons UIs (web, telegram, text, ai).
+ *
+ * Storage layout (canonical, see HolonsBot commit 63aa1d4 + ShoppingList.svelte):
+ * a single container document under the `checklists` collection with id `shopping`,
+ * holding all items in `items[]`.
+ */
+
+/**
+ * One row in a shopping checklist. Identical between web and telegram UIs.
+ * `id` may be a string (web: `Date.now().toString()`) or number (telegram: `Date.now() + Math.random()`)
+ * for legacy compatibility — both UIs compare with `String(item.id)`.
+ */
+export interface ShoppingItem {
+  id: string | number;
+  text: string;
+  checked: boolean;
+  createdBy?: number | string;
+  // Optional federation/hologram metadata stamped by holosphere on read.
+  _hologram?: { isHologram?: boolean; sourceHolon?: string; soul?: string };
+  _federation?: { origin?: string; sourceLens?: string };
+  _deleted?: boolean;
+  // Allow forward-compatible fields (category, priority, quantity, notes — see schemas/shopping.json).
+  [key: string]: unknown;
+}
+
+/**
+ * Container document persisted at (`<holonId>`, `checklists`, `shopping`).
+ */
+export interface ShoppingChecklist {
+  id: 'shopping';
+  type: 'shopping';
+  title: string;
+  items: ShoppingItem[];
+  createdAt: number;
+  _hologram?: { isHologram?: boolean; sourceHolon?: string; soul?: string };
+  _federation?: { origin?: string; sourceLens?: string };
+  [key: string]: unknown;
+}
+
+/** Storage-layer constants shared by both UIs. */
+export const SHOPPING_KEY = 'shopping' as const;
+export const CHECKLISTS_COLLECTION = 'checklists' as const;

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts", "src/**/*.spec.ts"]
 }

--- a/packages/telegram-ui/src/Shopping.js
+++ b/packages/telegram-ui/src/Shopping.js
@@ -1,8 +1,20 @@
 /**
  * @fileoverview Shopping list management for HolonsBot.
  * @module src/Shopping
+ *
+ * Storage layer (add / toggle / remove / clear-checked) is delegated to
+ * `@holons/core/shopping` so the bot and the web UI read/write identical
+ * shopping records. Telegraf scenes + inline keyboards remain here.
  */
 import { Markup } from 'telegraf';
+import {
+    CHECKLISTS_COLLECTION,
+    SHOPPING_KEY,
+    addItems,
+    normalizeChecklist,
+    removeChecked,
+    toggleItem,
+} from '@holons/core/shopping';
 import * as utils from './utilities.js';
 
 /**
@@ -39,244 +51,177 @@ class Shopping {
         this.bot.action('add_shopping_item', (ctx) => this.addItem(ctx));
     }
 
+    /**
+     * Read the shopping container, normalized through core.
+     * @private
+     * @param {string|number} holonId
+     * @returns {Promise<import('@holons/core/shopping').ShoppingChecklist|null>}
+     */
+    async _loadList(holonId) {
+        const raw = await this.db.get(String(holonId), CHECKLISTS_COLLECTION, SHOPPING_KEY);
+        return normalizeChecklist(raw);
+    }
+
+    /**
+     * Persist the shopping container.
+     * @private
+     * @param {string|number} holonId
+     * @param {import('@holons/core/shopping').ShoppingChecklist} list
+     */
+    async _saveList(holonId, list) {
+        await this.db.put(String(holonId), CHECKLISTS_COLLECTION, list);
+    }
+
+    /**
+     * Append items to the holon's shopping list and persist. Shared by /buy and the
+     * "Add Item" inline button.
+     * @private
+     * @param {string|number} holonId
+     * @param {string[]} items
+     * @param {number|string} [createdBy]
+     * @returns {Promise<import('@holons/core/shopping').ShoppingChecklist>}
+     */
+    async _appendItems(holonId, items, createdBy) {
+        const current = await this._loadList(holonId);
+        const updated = addItems(current, items, createdBy !== undefined ? { createdBy } : {});
+        await this._saveList(holonId, updated);
+        return updated;
+    }
+
     async buy(ctx) {
-        let holonId = ctx.chat.id;
-        const language = await this.settings.getLanguage(holonId)
-        const type = ctx.message.text.split(' ')[0].replace('/', '');
-        let items = utils.parseList(ctx.message.text)
+        const holonId = ctx.chat.id;
+        const language = await this.settings.getLanguage(holonId);
+        let items = utils.parseList(ctx.message.text);
 
         console.log('[Shopping buy] Parsed items:', items);
-        console.log('[Shopping buy] Items length:', items ? items.length : 0);
 
         if (!items || items.length === 0) {
-            console.log('[Shopping buy] No items, entering InputScene');
-            // No items provided, use InputScene to collect them
+            // No items provided, use InputScene to collect them.
             return ctx.scene.enter('input_scene', {
                 promptText: utils.i18next.t('shoppingprompt', { lng: language }),
                 inputType: 'array',  // Auto-splits by comma/newline
                 allowEmpty: false,
-                onComplete: async (ctx, items) => {
-                    // Get holonId fresh from the callback context
-                    const callbackholonId = ctx.chat.id;
-                    const callbackLanguage = await this.settings.getLanguage(callbackholonId);
+                onComplete: async (sceneCtx, sceneItems) => {
+                    const callbackHolonId = sceneCtx.chat.id;
+                    const callbackLanguage = await this.settings.getLanguage(callbackHolonId);
 
-                    console.log('[Shopping InputScene] Adding items:', items);
-                    console.log('[Shopping InputScene] Holon ID:', callbackholonId);
+                    console.log('[Shopping InputScene] Adding items:', sceneItems);
+                    await this._appendItems(callbackHolonId, sceneItems, sceneCtx.from?.id);
 
-                    // Get or create the shopping checklist
-                    let shoppingList = await this.db.get(callbackholonId.toString(), 'checklists', 'shopping');
-
-                    if (!shoppingList) {
-                        console.log('[Shopping InputScene] Creating new shopping checklist');
-                        shoppingList = {
-                            id: 'shopping',
-                            type: 'shopping',
-                            title: 'Shopping List',
-                            items: [],
-                            createdAt: Date.now()
-                        };
-                    }
-
-                    // Add items to checklist
-                    const newItems = items.map(item => ({
-                        id: Date.now() + Math.random(),
-                        text: item,
-                        checked: false,
-                        createdBy: ctx.from.id
+                    await sceneCtx.reply(utils.i18next.t('shoppingadded', {
+                        items: sceneItems.join(", "),
+                        lng: callbackLanguage,
                     }));
-
-                    shoppingList.items.push(...newItems);
-                    console.log('[Shopping InputScene] Updated shopping list:', shoppingList);
-
-                    // Save to checklists
-                    await this.db.put(callbackholonId.toString(), 'checklists', shoppingList);
-                    console.log('[Shopping InputScene] Saved to database');
-
-                    await ctx.reply(utils.i18next.t('shoppingadded', {
-                        items: items.join(", "),
-                        lng: callbackLanguage
-                    }));
-                }
+                },
             });
         }
 
-        // Items provided in command, process directly
-        console.log('[Shopping buy] Items provided directly, adding to DB');
-
-        // Get or create the shopping checklist
-        let shoppingList = await this.db.get(holonId.toString(), 'checklists', 'shopping');
-
-        if (!shoppingList) {
-            console.log('[Shopping buy direct] Creating new shopping checklist');
-            shoppingList = {
-                id: 'shopping',
-                type: 'shopping',
-                title: 'Shopping List',
-                items: [],
-                createdAt: Date.now()
-            };
-        }
-
-        // Add items to checklist
-        const newItems = items.map(item => ({
-            id: Date.now() + Math.random(),
-            text: item,
-            checked: false,
-            createdBy: ctx.from.id
-        }));
-
-        shoppingList.items.push(...newItems);
-        console.log('[Shopping buy direct] Updated shopping list:', shoppingList);
-
-        // Save to checklists
-        await this.db.put(holonId.toString(), 'checklists', shoppingList);
-        console.log('[Shopping buy direct] Saved to database');
-
+        await this._appendItems(holonId, items, ctx.from?.id);
         ctx.reply(utils.i18next.t('shoppingadded', { items: items.join(", "), lng: language }));
     }
 
     async shopping(ctx) {
-        console.log('[Shopping shopping] Command called');
-        let holonId = ctx.chat.id;
+        const holonId = ctx.chat.id;
         const language = await this.settings.getLanguage(holonId);
 
-        // Get the shopping checklist
-        let shoppingList = await this.db.get(holonId.toString(), 'checklists', 'shopping');
+        const shoppingList = await this._loadList(holonId);
 
-        if (!shoppingList || !shoppingList.items || shoppingList.items.length === 0) {
-            console.log('[Shopping shopping] List is empty');
+        if (!shoppingList || shoppingList.items.length === 0) {
             ctx.reply(utils.i18next.t("shoppingempty", { lng: language }));
             return;
         }
 
-        console.log('[Shopping shopping] Showing list with', shoppingList.items.length, 'items');
-        ctx.reply(utils.i18next.t("shoppinglist", { lng: language }), this.getShoppingListKeyboard(shoppingList.items, language))
-            .catch((error) => {console.log(error)});
+        ctx.reply(
+            utils.i18next.t("shoppinglist", { lng: language }),
+            this.getShoppingListKeyboard(shoppingList.items, language),
+        ).catch((error) => { console.log(error); });
     }
 
     async toggle(ctx) {
-        let holonId = ctx.chat.id;
+        const holonId = ctx.chat.id;
         const language = await this.settings.getLanguage(holonId);
         const itemId = ctx.match[1];
 
-        // Get the shopping checklist
-        let shoppingList = await this.db.get(holonId.toString(), 'checklists', 'shopping');
-
-        if (!shoppingList || !shoppingList.items) {
+        const current = await this._loadList(holonId);
+        if (!current) {
             console.log('[Shopping toggle] Shopping list not found');
             return;
         }
 
-        // Find and toggle the item
-        const item = shoppingList.items.find(i => i.id == itemId);
-        if (item) {
-            item.checked = !item.checked;
-            await this.db.put(holonId.toString(), 'checklists', shoppingList);
+        const exists = current.items.some(i => String(i.id) === String(itemId));
+        if (!exists) return;
 
-            ctx.editMessageText(
-                utils.i18next.t("shoppinglist", { lng: language }),
-                this.getShoppingListKeyboard(shoppingList.items, language)
-            ).catch((error) => {console.log(error)});
-        }
+        const updated = toggleItem(current, itemId);
+        await this._saveList(holonId, updated);
+
+        ctx.editMessageText(
+            utils.i18next.t("shoppinglist", { lng: language }),
+            this.getShoppingListKeyboard(updated.items, language),
+        ).catch((error) => { console.log(error); });
     }
 
     async done(ctx) {
-        let holonId = ctx.chat.id;
+        const holonId = ctx.chat.id;
         const language = await this.settings.getLanguage(holonId);
 
-        // Get the shopping checklist
-        let shoppingList = await this.db.get(holonId.toString(), 'checklists', 'shopping');
-
-        if (!shoppingList || !shoppingList.items) {
+        const current = await this._loadList(holonId);
+        if (!current) {
             console.log('[Shopping done] Shopping list not found');
             return;
         }
 
-        // Remove checked items
-        const beforeCount = shoppingList.items.length;
-        shoppingList.items = shoppingList.items.filter(item => !item.checked);
-        const removedCount = beforeCount - shoppingList.items.length;
+        const before = current.items.length;
+        const updated = removeChecked(current);
+        const removedCount = before - updated.items.length;
 
-        await this.db.put(holonId.toString(), 'checklists', shoppingList);
-
-        console.log('[Shopping done] Removed', removedCount, 'items, remaining:', shoppingList.items.length);
+        await this._saveList(holonId, updated);
+        console.log('[Shopping done] Removed', removedCount, 'items, remaining:', updated.items.length);
 
         ctx.editMessageText(
-            utils.i18next.t('shoppingcompleted', { remaining: shoppingList.items.length, lng: language })
-        ).catch((error) => {console.log(error)});
+            utils.i18next.t('shoppingcompleted', { remaining: updated.items.length, lng: language }),
+        ).catch((error) => { console.log(error); });
     }
 
     async addItem(ctx) {
         await ctx.answerCbQuery().catch(() => {});
-        let holonId = ctx.chat.id;
+        const holonId = ctx.chat.id;
         const language = await this.settings.getLanguage(holonId);
 
-        // Enter InputScene to collect new items
         return ctx.scene.enter('input_scene', {
             promptText: utils.i18next.t('shoppingprompt', { lng: language }),
-            inputType: 'array',  // Auto-splits by comma/newline
+            inputType: 'array',
             allowEmpty: false,
-            onComplete: async (ctx, items) => {
-                // Get holonId fresh from the callback context
-                const callbackholonId = ctx.chat.id;
-                const callbackLanguage = await this.settings.getLanguage(callbackholonId);
+            onComplete: async (sceneCtx, sceneItems) => {
+                const callbackHolonId = sceneCtx.chat.id;
+                const callbackLanguage = await this.settings.getLanguage(callbackHolonId);
 
-                console.log('[Shopping addItem] Adding items:', items);
+                console.log('[Shopping addItem] Adding items:', sceneItems);
+                const updated = await this._appendItems(callbackHolonId, sceneItems, sceneCtx.from?.id);
 
-                // Get or create the shopping checklist
-                let shoppingList = await this.db.get(callbackholonId.toString(), 'checklists', 'shopping');
-
-                if (!shoppingList) {
-                    console.log('[Shopping addItem] Creating new shopping checklist');
-                    shoppingList = {
-                        id: 'shopping',
-                        type: 'shopping',
-                        title: 'Shopping List',
-                        items: [],
-                        createdAt: Date.now()
-                    };
-                }
-
-                // Add items to checklist
-                const newItems = items.map(item => ({
-                    id: Date.now() + Math.random(),
-                    text: item,
-                    checked: false,
-                    createdBy: ctx.from.id
+                await sceneCtx.reply(utils.i18next.t('shoppingadded', {
+                    items: sceneItems.join(", "),
+                    lng: callbackLanguage,
                 }));
 
-                shoppingList.items.push(...newItems);
-                console.log('[Shopping addItem] Updated shopping list:', shoppingList);
-
-                // Save to checklists
-                await this.db.put(callbackholonId.toString(), 'checklists', shoppingList);
-
-                await ctx.reply(utils.i18next.t('shoppingadded', {
-                    items: items.join(", "),
-                    lng: callbackLanguage
-                }));
-
-                // Show updated shopping list
-                await ctx.reply(
+                await sceneCtx.reply(
                     utils.i18next.t("shoppinglist", { lng: callbackLanguage }),
-                    this.getShoppingListKeyboard(shoppingList.items, callbackLanguage)
+                    this.getShoppingListKeyboard(updated.items, callbackLanguage),
                 );
-            }
+            },
         });
     }
 
     getShoppingListKeyboard(items, language) {
-        let mu = [];
-        items.forEach(function (item) {
-            mu.push([Markup.button.callback(
+        const mu = items.map((item) => [
+            Markup.button.callback(
                 (item.checked ? '✅ ' : '☑️ ') + item.text,
-                `toggle_shopping_${item.id}`
-            )]);
-        });
+                `toggle_shopping_${item.id}`,
+            ),
+        ]);
         // Add "Add Item" and "Remove Selected" buttons at the bottom
         mu.push([
             Markup.button.callback(utils.i18next.t("shoppingadd", { lng: language }), 'add_shopping_item'),
-            Markup.button.callback(utils.i18next.t("shoppingclear", { lng: language }), 'done_shopping')
+            Markup.button.callback(utils.i18next.t("shoppingclear", { lng: language }), 'done_shopping'),
         ]);
         return Markup.inlineKeyboard(mu);
     }


### PR DESCRIPTION
## Summary

Extracts the shopping-list domain into the shared `@holons/core/shopping` module so the Svelte web app and the Telegram bot operate on identical shopping records.

- New `packages/core/src/shopping/{types,operations,index}.ts` exports `ShoppingItem`, `ShoppingChecklist`, the `SHOPPING_KEY` / `CHECKLISTS_COLLECTION` storage constants, and pure CRUD helpers (`createShoppingItem`, `addItem(s)`, `toggleItem`, `removeItem`, `removeChecked`, `clearChecked`, `normalizeChecklist`, `isShoppingDoc`). All operations are immutable — they take a checklist in and return a new one, leaving I/O to the caller.
- `packages/telegram-ui/src/Shopping.js` now delegates the storage layer (load / append items / toggle / remove-checked) to the shared module while keeping its Telegraf scenes and inline keyboards. Net -80 lines.
- `apps/web/src/types/shoppingItem.ts` is now a thin re-export of the shared types so future web refactors can drop the inline interface.
- Excluded `*.test.ts`/`*.spec.ts` from the core package's compiled output (added vitest unit tests for the new operations).

## Test plan

- [x] `pnpm install`
- [x] `pnpm -r --if-present typecheck` (5/5 packages green)
- [x] `pnpm -r --if-present build` (all packages, including `harvest-web` SvelteKit build, succeed)
- [x] `pnpm -F @holons/core test` (7/7 vitest cases pass)
- [x] Smoke: `node -e "import('./packages/core/dist/shopping/index.js').then(...)"` resolves and exposes `addItem` + `createShoppingItem`
- [x] `pnpm -F harvest-web exec svelte-kit sync`
- [ ] Manual: `/buy milk, bread` in Telegram and Add Item in Web both read/write the same `(holonId, checklists, shopping)` document

ud83eudd16 Generated with [Claude Code](https://claude.com/claude-code)