### PR TITLE
core/commands: abstract command/intent layer + 3 example commands

### DIFF
--- a/packages/core/src/commands/built-in.ts
+++ b/packages/core/src/commands/built-in.ts
@@ -1,0 +1,235 @@
+// @holons/core/commands — built-in commands
+//
+// Three example commands wired end-to-end so text-ui (Unit 19) and ai-ui (Unit
+// 20) have something concrete to call. Each delegates to a sibling
+// `@holons/core/<domain>` module via dynamic relative import so we don't hard-
+// fail typecheck/build if the sibling unit hasn't landed yet — instead we
+// throw a clear "TODO: depends on @holons/core/<X> (Unit Y)" at execute time.
+
+import { commandRegistry } from './registry.js';
+import type { CommandContext, CommandError, CoreCommand } from './types.js';
+
+// ---------- shared helpers ----------
+
+type DomainModule = Record<string, unknown>;
+type AnyFn = (...args: unknown[]) => unknown;
+
+function todo(domain: string, unit: string, detail: string): Error {
+	return new Error(`TODO: depends on @holons/core/${domain} (${unit}) — ${detail}`);
+}
+
+/**
+ * Load a sibling domain module via relative path so the import resolves
+ * against the built `dist/<domain>/index.js` (or `src/<domain>/index.ts` under
+ * a TS-aware loader). Throws a clear TODO error if the sibling unit hasn't
+ * shipped yet so failures are loud and self-explanatory.
+ */
+async function loadDomain(domain: string, unit: string): Promise<DomainModule> {
+	let mod: DomainModule;
+	try {
+		mod = (await import(`../${domain}/index.js`)) as DomainModule;
+	} catch (err) {
+		throw todo(
+			domain,
+			unit,
+			`module not importable yet: ${err instanceof Error ? err.message : String(err)}`
+		);
+	}
+	if (!mod || Object.keys(mod).length === 0) {
+		throw todo(domain, unit, 'module is a placeholder (no exports)');
+	}
+	return mod;
+}
+
+/** Find the first export matching one of `names`; throw a TODO error otherwise. */
+function pickFn(mod: DomainModule, names: string[], domain: string, unit: string): AnyFn {
+	for (const n of names) {
+		const candidate = mod[n];
+		if (typeof candidate === 'function') return candidate as AnyFn;
+	}
+	throw todo(
+		domain,
+		unit,
+		`expected exported function ${names.map((n) => `"${n}"`).join(' / ')}`
+	);
+}
+
+function requireString(params: Record<string, unknown>, key: string): string {
+	const v = params[key];
+	if (typeof v !== 'string' || v.length === 0) {
+		throw new Error(`Missing required string param "${key}"`);
+	}
+	return v;
+}
+
+function asObject(params: unknown): Record<string, unknown> {
+	if (!params || typeof params !== 'object' || Array.isArray(params)) {
+		throw new Error('Params must be an object');
+	}
+	return params as Record<string, unknown>;
+}
+
+/**
+ * Wrap a validation function so any thrown error becomes a structured
+ * `invalid_params` CommandError, matching what executor.ts already does for
+ * thrown errors but keeping each command's `validate` body free of try/catch.
+ */
+function validateBy(
+	fn: (params: Record<string, unknown>) => true | void | CommandError
+): (raw: unknown) => true | void | CommandError {
+	return (raw) => {
+		try {
+			return fn(asObject(raw));
+		} catch (err) {
+			return {
+				code: 'invalid_params',
+				message: err instanceof Error ? err.message : String(err)
+			};
+		}
+	};
+}
+
+// ---------- createTask ----------
+
+export interface CreateTaskParams {
+	holonId: string;
+	title: string;
+	description?: string;
+	location?: string;
+}
+
+export const createTaskCommand: CoreCommand<CreateTaskParams, unknown> = {
+	name: 'createTask',
+	description: 'Create a new task in the given holon',
+	paramsSchema: {
+		type: 'object',
+		required: ['holonId', 'title'],
+		properties: {
+			holonId: { type: 'string' },
+			title: { type: 'string' },
+			description: { type: 'string' },
+			location: { type: 'string' }
+		}
+	},
+	validate: validateBy((p) => {
+		requireString(p, 'holonId');
+		requireString(p, 'title');
+	}),
+	async execute(params, ctx: CommandContext) {
+		const mod = await loadDomain('tasks', 'Unit 7');
+		const fn = pickFn(mod, ['createTask', 'addTask', 'create'], 'tasks', 'Unit 7');
+		return await fn(params, ctx);
+	}
+};
+
+// ---------- logHours ----------
+
+export interface LogHoursParams {
+	holonId: string;
+	taskId: string;
+	userId: string;
+	hours: number;
+}
+
+export const logHoursCommand: CoreCommand<LogHoursParams, unknown> = {
+	name: 'logHours',
+	description: 'Log hours worked by a user on a task',
+	paramsSchema: {
+		type: 'object',
+		required: ['holonId', 'taskId', 'userId', 'hours'],
+		properties: {
+			holonId: { type: 'string' },
+			taskId: { type: 'string' },
+			userId: { type: 'string' },
+			hours: { type: 'number', minimum: 0 }
+		}
+	},
+	validate: validateBy((p) => {
+		requireString(p, 'holonId');
+		requireString(p, 'taskId');
+		requireString(p, 'userId');
+		const h = p.hours;
+		if (typeof h !== 'number' || !isFinite(h) || h < 0) {
+			return { code: 'invalid_params', message: 'hours must be a non-negative number' };
+		}
+	}),
+	async execute(params, ctx: CommandContext) {
+		// Try scoring first (more specific), then fall back to tasks.
+		let mod: DomainModule;
+		let domain: 'scoring' | 'tasks' = 'scoring';
+		let unit = 'Unit 5';
+		try {
+			mod = await loadDomain('scoring', 'Unit 5');
+		} catch {
+			try {
+				mod = await loadDomain('tasks', 'Unit 7');
+				domain = 'tasks';
+				unit = 'Unit 7';
+			} catch (err) {
+				throw new Error(
+					`TODO: depends on @holons/core/scoring (Unit 5) or @holons/core/tasks (Unit 7) — neither importable yet: ${
+						err instanceof Error ? err.message : String(err)
+					}`
+				);
+			}
+		}
+		const fn = pickFn(mod, ['logHours', 'recordHours', 'addHours'], domain, unit);
+		return await fn(params, ctx);
+	}
+};
+
+// ---------- addToShoppingList ----------
+
+export interface AddToShoppingListParams {
+	holonId: string;
+	name: string;
+	quantity?: number;
+}
+
+export const addToShoppingListCommand: CoreCommand<AddToShoppingListParams, unknown> = {
+	name: 'addToShoppingList',
+	description: 'Add an item to the shopping list of the given holon',
+	paramsSchema: {
+		type: 'object',
+		required: ['holonId', 'name'],
+		properties: {
+			holonId: { type: 'string' },
+			name: { type: 'string' },
+			quantity: { type: 'number', minimum: 0 }
+		}
+	},
+	validate: validateBy((p) => {
+		requireString(p, 'holonId');
+		requireString(p, 'name');
+		if (p.quantity !== undefined) {
+			const q = p.quantity;
+			if (typeof q !== 'number' || !isFinite(q) || q < 0) {
+				return { code: 'invalid_params', message: 'quantity must be a non-negative number' };
+			}
+		}
+	}),
+	async execute(params, ctx: CommandContext) {
+		const mod = await loadDomain('shopping', 'Unit 9');
+		const fn = pickFn(mod, ['addToShoppingList', 'addItem', 'add'], 'shopping', 'Unit 9');
+		return await fn(params, ctx);
+	}
+};
+
+// ---------- registration ----------
+
+let installed = false;
+
+/**
+ * Idempotently register the built-in commands on the shared registry.
+ * Called automatically at module load (side-effect of importing `built-in.ts`),
+ * but exported for tests/UIs that want to opt in explicitly.
+ */
+export function installBuiltInCommands(): void {
+	if (installed) return;
+	commandRegistry.replace(createTaskCommand as CoreCommand);
+	commandRegistry.replace(logHoursCommand as CoreCommand);
+	commandRegistry.replace(addToShoppingListCommand as CoreCommand);
+	installed = true;
+}
+
+installBuiltInCommands();

--- a/packages/core/src/commands/commands.test.ts
+++ b/packages/core/src/commands/commands.test.ts
@@ -1,0 +1,156 @@
+// @holons/core/commands — tests
+//
+// Cover the registry/executor contract end-to-end without depending on
+// sibling domain modules (which other Phase B units own). Built-in commands
+// are also exercised: validation paths run in-process, while the execute path
+// is asserted to fail loudly with a "TODO: depends on @holons/core/<X>" error
+// while the upstream domains are still placeholders.
+
+import { describe, expect, it } from 'vitest';
+import {
+	CommandRegistry,
+	addToShoppingListCommand,
+	commandRegistry,
+	createTaskCommand,
+	executeCommand,
+	installBuiltInCommands,
+	logHoursCommand,
+	type CoreCommand
+} from './index.js';
+
+describe('CommandRegistry', () => {
+	it('registers and looks up commands by name', () => {
+		const reg = new CommandRegistry();
+		const cmd: CoreCommand = { name: 'noop', execute: () => 'ok' };
+		reg.register(cmd);
+		expect(reg.has('noop')).toBe(true);
+		expect(reg.get('noop')).toBe(cmd);
+		expect(reg.list()).toEqual(['noop']);
+		expect(reg.size).toBe(1);
+	});
+
+	it('rejects duplicate registrations but allows replace()', () => {
+		const reg = new CommandRegistry();
+		const a: CoreCommand = { name: 'x', execute: () => 1 };
+		const b: CoreCommand = { name: 'x', execute: () => 2 };
+		reg.register(a);
+		expect(() => reg.register(b)).toThrow(/duplicate command/);
+		reg.replace(b);
+		expect(reg.get('x')).toBe(b);
+	});
+
+	it('rejects nameless commands', () => {
+		const reg = new CommandRegistry();
+		expect(() =>
+			reg.register({ name: '', execute: () => null } as unknown as CoreCommand)
+		).toThrow(/non-empty name/);
+	});
+
+	it('shared singleton has the three built-ins installed', () => {
+		installBuiltInCommands(); // idempotent
+		for (const name of ['createTask', 'logHours', 'addToShoppingList']) {
+			expect(commandRegistry.has(name)).toBe(true);
+		}
+	});
+});
+
+describe('executeCommand', () => {
+	it('returns unknown_command for unregistered names', async () => {
+		const reg = new CommandRegistry();
+		const result = await executeCommand('nope', {}, {}, { registry: reg });
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error.code).toBe('unknown_command');
+	});
+
+	it('runs validate before execute and surfaces invalid_params', async () => {
+		const reg = new CommandRegistry();
+		reg.register({
+			name: 'needsTitle',
+			validate: (p) =>
+				p && typeof (p as { title?: unknown }).title === 'string'
+					? true
+					: { code: 'invalid_params', message: 'title required' },
+			execute: () => 'never reached'
+		});
+		const bad = await executeCommand('needsTitle', {}, {}, { registry: reg });
+		expect(bad.ok).toBe(false);
+		if (!bad.ok) expect(bad.error.code).toBe('invalid_params');
+
+		const good = await executeCommand('needsTitle', { title: 'hi' }, {}, { registry: reg });
+		expect(good.ok).toBe(true);
+		if (good.ok) expect(good.data).toBe('never reached');
+	});
+
+	it('wraps thrown errors from execute as execution_failed', async () => {
+		const reg = new CommandRegistry();
+		reg.register({
+			name: 'boom',
+			execute: () => {
+				throw new Error('kaboom');
+			}
+		});
+		const result = await executeCommand('boom', {}, {}, { registry: reg });
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.code).toBe('execution_failed');
+			expect(result.error.message).toBe('kaboom');
+		}
+	});
+
+	it('passes context through to execute', async () => {
+		const reg = new CommandRegistry();
+		let seen: unknown;
+		reg.register({
+			name: 'ctxEcho',
+			execute: (_p, ctx) => {
+				seen = ctx;
+				return ctx.userId;
+			}
+		});
+		const result = await executeCommand(
+			'ctxEcho',
+			{},
+			{ userId: 'u1', source: 'text' },
+			{ registry: reg }
+		);
+		expect(result.ok).toBe(true);
+		if (result.ok) expect(result.data).toBe('u1');
+		expect((seen as { source?: string }).source).toBe('text');
+	});
+});
+
+describe('built-in commands', () => {
+	it('createTask validates required params', () => {
+		expect(createTaskCommand.validate?.({})).toMatchObject({ code: 'invalid_params' });
+		expect(createTaskCommand.validate?.({ holonId: 'h1', title: 't1' })).toBeFalsy();
+	});
+
+	it('logHours rejects non-numeric hours', () => {
+		const v = logHoursCommand.validate?.({
+			holonId: 'h',
+			taskId: 't',
+			userId: 'u',
+			hours: 'lots'
+		});
+		expect(v).toMatchObject({ code: 'invalid_params' });
+	});
+
+	it('addToShoppingList accepts optional quantity', () => {
+		expect(addToShoppingListCommand.validate?.({ holonId: 'h', name: 'apples' })).toBeFalsy();
+		expect(
+			addToShoppingListCommand.validate?.({ holonId: 'h', name: 'apples', quantity: 3 })
+		).toBeFalsy();
+		expect(
+			addToShoppingListCommand.validate?.({ holonId: 'h', name: 'apples', quantity: -1 })
+		).toMatchObject({ code: 'invalid_params' });
+	});
+
+	it('createTask execute fails loudly while @holons/core/tasks is a placeholder', async () => {
+		const result = await executeCommand('createTask', { holonId: 'h', title: 't' });
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.code).toBe('execution_failed');
+			expect(result.error.message).toMatch(/TODO: depends on @holons\/core\/tasks/);
+		}
+	});
+});

--- a/packages/core/src/commands/executor.ts
+++ b/packages/core/src/commands/executor.ts
@@ -1,0 +1,60 @@
+// @holons/core/commands — executor
+//
+// Thin wrapper that resolves a command from the registry, runs `validate` if
+// present, invokes `execute`, and normalises any thrown error into a failure
+// `CommandResult`. UIs should call this rather than touching commands directly
+// so error handling stays consistent.
+
+import { commandRegistry, CommandRegistry } from './registry.js';
+import type { CommandContext, CommandError, CommandResult, CoreCommand } from './types.js';
+
+export interface ExecuteOptions {
+	/** Override the registry (defaults to the shared singleton). */
+	registry?: CommandRegistry;
+}
+
+export async function executeCommand<TResult = unknown>(
+	name: string,
+	params: unknown,
+	ctx: CommandContext = {},
+	options: ExecuteOptions = {}
+): Promise<CommandResult<TResult>> {
+	const registry = options.registry ?? commandRegistry;
+	const command = registry.get(name);
+
+	if (!command) {
+		return failure(name, {
+			code: 'unknown_command',
+			message: `No command registered with name "${name}"`
+		});
+	}
+
+	if (typeof command.validate === 'function') {
+		try {
+			const result = command.validate(params);
+			if (result && typeof result === 'object' && 'code' in result) {
+				return failure(name, result as CommandError);
+			}
+		} catch (err) {
+			return failure(name, normaliseError('invalid_params', err));
+		}
+	}
+
+	try {
+		const data = (await (command as CoreCommand<unknown, TResult>).execute(params, ctx)) as TResult;
+		return { ok: true, command: name, data };
+	} catch (err) {
+		return failure(name, normaliseError('execution_failed', err));
+	}
+}
+
+function failure(command: string, error: CommandError): CommandResult<never> {
+	return { ok: false, command, error };
+}
+
+function normaliseError(code: CommandError['code'], err: unknown): CommandError {
+	if (err instanceof Error) {
+		return { code, message: err.message, details: err };
+	}
+	return { code, message: String(err), details: err };
+}

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -1,0 +1,38 @@
+// @holons/core/commands — public barrel
+//
+// Subpath import surface for the abstract command/intent layer:
+//
+//   import {
+//     commandRegistry,
+//     executeCommand,
+//     type CoreCommand,
+//     type CommandContext,
+//     type CommandResult
+//   } from '@holons/core/commands';
+//
+// Importing this module also installs the built-in commands as a side effect,
+// so any UI that touches the registry sees `createTask`, `logHours`, and
+// `addToShoppingList` without further setup.
+
+export type {
+	CommandContext,
+	CommandError,
+	CommandLogger,
+	CommandResult,
+	CoreCommand
+} from './types.js';
+
+export { CommandRegistry, commandRegistry } from './registry.js';
+export { executeCommand, type ExecuteOptions } from './executor.js';
+
+// Re-exporting from `./built-in.js` evaluates the module, which installs the
+// built-in commands on the shared registry as a side effect.
+export {
+	addToShoppingListCommand,
+	createTaskCommand,
+	installBuiltInCommands,
+	logHoursCommand,
+	type AddToShoppingListParams,
+	type CreateTaskParams,
+	type LogHoursParams
+} from './built-in.js';

--- a/packages/core/src/commands/registry.ts
+++ b/packages/core/src/commands/registry.ts
@@ -1,0 +1,65 @@
+// @holons/core/commands — registry
+//
+// In-memory registry mapping command name → CoreCommand. Exposes a default
+// singleton (`commandRegistry`) that built-ins register themselves on, plus the
+// class for tests/UIs that want isolated registries.
+
+import type { CoreCommand } from './types.js';
+
+export class CommandRegistry {
+	#commands = new Map<string, CoreCommand>();
+
+	/** Register a command. Throws if `name` is already taken (use `replace` to override). */
+	register(command: CoreCommand): void {
+		if (!command || typeof command.name !== 'string' || command.name.length === 0) {
+			throw new Error('CommandRegistry.register: command must have a non-empty name');
+		}
+		if (this.#commands.has(command.name)) {
+			throw new Error(
+				`CommandRegistry.register: duplicate command "${command.name}" (use replace() to override)`
+			);
+		}
+		this.#commands.set(command.name, command as CoreCommand);
+	}
+
+	/** Register or replace a command. */
+	replace(command: CoreCommand): void {
+		this.#commands.set(command.name, command as CoreCommand);
+	}
+
+	/** Look up a command by name; returns undefined if absent. */
+	get(name: string): CoreCommand | undefined {
+		return this.#commands.get(name);
+	}
+
+	has(name: string): boolean {
+		return this.#commands.has(name);
+	}
+
+	/** List registered command names (sorted for stable output). */
+	list(): string[] {
+		return Array.from(this.#commands.keys()).sort();
+	}
+
+	/** All registered commands, sorted by name. */
+	all(): CoreCommand[] {
+		return this.list().map((n) => this.#commands.get(n)!);
+	}
+
+	/** Remove a command (mainly for tests). */
+	unregister(name: string): boolean {
+		return this.#commands.delete(name);
+	}
+
+	/** Wipe all commands (mainly for tests). */
+	clear(): void {
+		this.#commands.clear();
+	}
+
+	get size(): number {
+		return this.#commands.size;
+	}
+}
+
+/** Default shared registry. Built-ins register themselves here. */
+export const commandRegistry = new CommandRegistry();

--- a/packages/core/src/commands/types.ts
+++ b/packages/core/src/commands/types.ts
@@ -1,0 +1,87 @@
+// @holons/core/commands — types
+//
+// Abstract command/intent layer shared by all UIs (web buttons, telegram slash
+// commands, text-ui CLI, ai-ui Claude tools). Each UI translates its surface
+// (a click, a `/cmd`, a typed line, a tool-use call) into a CoreCommand
+// invocation, then renders the CommandResult in its own idiom.
+
+/**
+ * Optional ambient context passed to every command. Fields are intentionally
+ * loose so each UI can populate what it has without forcing all UIs to provide
+ * everything.
+ */
+export interface CommandContext {
+	/** Identifier of the invoking user (e.g. telegram user id, web auth uid). */
+	userId?: string;
+	/** Optional human-readable name for the invoking user. */
+	userName?: string;
+	/** Holon/community scope for the command, when relevant. */
+	holonId?: string;
+	/** UI surface that originated the command. */
+	source?: 'web' | 'telegram' | 'text' | 'ai' | string;
+	/** Optional holosphere instance (or any storage/transport handle). */
+	holosphere?: unknown;
+	/** Optional structured logger; defaults to a no-op when omitted. */
+	logger?: CommandLogger;
+	/** Free-form extension bag for UI-specific context. */
+	extra?: Record<string, unknown>;
+}
+
+export interface CommandLogger {
+	debug?: (msg: string, meta?: Record<string, unknown>) => void;
+	info?: (msg: string, meta?: Record<string, unknown>) => void;
+	warn?: (msg: string, meta?: Record<string, unknown>) => void;
+	error?: (msg: string, meta?: Record<string, unknown>) => void;
+}
+
+/** Discriminated union returned by the executor. */
+export type CommandResult<TData = unknown> =
+	| {
+			ok: true;
+			command: string;
+			data: TData;
+	  }
+	| {
+			ok: false;
+			command: string;
+			error: CommandError;
+	  };
+
+export interface CommandError {
+	/** Stable machine-readable code. */
+	code:
+		| 'unknown_command'
+		| 'invalid_params'
+		| 'missing_dependency'
+		| 'execution_failed'
+		| string;
+	message: string;
+	/** Optional details (e.g. zod-style issues, original error). */
+	details?: unknown;
+}
+
+/**
+ * A typed command. Implementations declare a `name`, an optional
+ * `validate(params)` hook (returning `true` for ok or a `CommandError` for
+ * failure), and an `execute(params, ctx)` that performs the work.
+ *
+ * Note: parameter validation is intentionally lightweight — we accept any
+ * `unknown` and rely on the command's own `validate` to narrow. This keeps the
+ * registry usable from JS UIs (telegram-ui) without forcing schema deps.
+ */
+export interface CoreCommand<TParams = unknown, TResult = unknown> {
+	/** Unique command name (e.g. `createTask`). */
+	readonly name: string;
+	/** One-line human description, surfaced by help/listing UIs. */
+	readonly description?: string;
+	/** Best-effort JSON-Schema-ish description of params for AI/help UIs. */
+	readonly paramsSchema?: Record<string, unknown>;
+	/**
+	 * Optional pre-execute validation. Return `true` (or `void`) if valid; or a
+	 * `CommandError` describing the failure. Throwing is also acceptable and
+	 * will be normalised to `invalid_params` by the executor.
+	 */
+	validate?: (params: unknown) => true | void | CommandError;
+	/** Run the command. May throw; the executor wraps thrown errors. */
+	execute: (params: TParams, ctx: CommandContext) => Promise<TResult> | TResult;
+}


### PR DESCRIPTION
## Summary

Adds `@holons/core/commands` — a typed command/intent layer that all UIs (web buttons, telegram slash commands, text-ui CLI, ai-ui Claude tools) can route through. A click, a `/cmd`, a typed line, and a tool-use call all funnel into the same domain logic with consistent validation and error shaping.

- `types.ts` — `CoreCommand<TParams, TResult>`, `CommandContext` (loose: `userId`, `userName`, `holonId`, `source`, `holosphere`, `logger`, `extra`), `CommandResult` (`{ ok: true, data } | { ok: false, error }`), `CommandError` with stable `code`s (`unknown_command`, `invalid_params`, `missing_dependency`, `execution_failed`, ...).
- `registry.ts` — `CommandRegistry` (`register`/`replace`/`get`/`has`/`list`/`all`/`unregister`/`clear`/`size`) plus a default singleton `commandRegistry` shared across UIs.
- `executor.ts` — `executeCommand(name, params, ctx, { registry? })` that resolves the command, runs `validate` (if present), invokes `execute`, and normalises any thrown error into a structured failure result.
- `built-in.ts` — three example commands wired end-to-end:
  - `createTask` — `{ holonId, title, description?, location? }` → `@holons/core/tasks` (Unit 7)
  - `logHours` — `{ holonId, taskId, userId, hours }` → `@holons/core/scoring` (Unit 5) with fallback to `@holons/core/tasks` (Unit 7)
  - `addToShoppingList` — `{ holonId, name, quantity? }` → `@holons/core/shopping` (Unit 9)

  Sibling domain modules don't exist yet, so each command uses a defensive dynamic relative import. While upstream units are placeholders, the commands fail loudly at execute time with a clear `TODO: depends on @holons/core/<X> (Unit Y) — ...` error rather than silently no-opping. Function lookup probes a few likely names (`createTask`/`addTask`/`create`, `logHours`/`recordHours`/`addHours`, `addToShoppingList`/`addItem`/`add`) so the wiring works regardless of which name the sibling unit picks.
- `index.ts` — barrel; importing it installs the three built-ins on the shared registry as a side effect.
- `commands.test.ts` — 12 vitest cases covering registry semantics, executor wrapping, validation, context propagation, and the loud-failure path for unbuilt sibling domains.

## Conflict-avoidance contract

- All files NEW under `packages/core/src/commands/`.
- `packages/core/src/index.ts` left untouched (subpath imports preferred).
- No edits to root configs or other packages' `package.json`.

## Test plan

- [x] `pnpm install`
- [x] `pnpm -F @holons/core typecheck` — clean
- [x] `pnpm -r --if-present typecheck` — clean across core / ai-ui / text-ui / telegram-ui
- [x] `pnpm -F @holons/core test` — 12/12 passing
- [x] `pnpm -F @holons/core build` — emits `dist/commands/{index,registry,executor,types,built-in}.{js,d.ts}`
- [x] `pnpm -r --if-present build` — full workspace build green (apps/web bundles fine)
- [x] Smoke: `node -e "import('./packages/core/dist/commands/index.js').then(m => console.log(m.commandRegistry.list()))"` → `[ 'addToShoppingList', 'createTask', 'logHours' ]`
- [x] Negative-path smoke: executing `createTask` while `@holons/core/tasks` is still a placeholder returns `{ ok: false, error: { code: 'execution_failed', message: /TODO: depends on @holons\/core\/tasks/ } }`

## Follow-ups (other Phase B units)

Once Units 5/7/9 land their `@holons/core/{scoring,tasks,shopping}` exports with one of the probed function names, the built-in commands light up automatically with no further changes here. Unit 19 (text-ui) and Unit 20 (ai-ui) can already wire their surfaces against `executeCommand`/`commandRegistry` today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)