### PR TITLE
core/federation: extract publishToFederation into @holons/core

### DIFF
--- a/apps/web/src/lib/holosphere/publish.ts
+++ b/apps/web/src/lib/holosphere/publish.ts
@@ -1,183 +1,48 @@
 /**
- * Publish to Federation
+ * Publish to Federation — web wrapper.
  *
- * Single source of truth for "publish this item as a hologram" across the app.
- * Replaces the duplicated publishToFederatedChats() handlers in TaskModal,
- * Offers, and the older share-dialog flow in Tasks.svelte.
+ * Thin Svelte-aware adapter around `@holons/core/federation`. Re-exports the
+ * core API surface and provides a `publishToFederation` that wires in:
+ *   - the current `nostrPublicKey` store (federation source identity), and
+ *   - the local `notifyWriteDenied` toast for write-permission errors.
  *
- * Three target shapes:
- *   - 'all'     → propagate() to every federated partner (current default)
- *   - 'partner' → put(targetHolonId, lens, hologram) to one specific partner
- *   - 'hex'     → put(h3Cell, lens, hologram) to one H3 cell
- *
- * Always wraps the item in a hologram first so receivers' SourceBadge
- * sees correct provenance metadata. Stamping the source item with
- * `published`/`publishedAt`/`publishedTo` is the caller's responsibility.
+ * The core implementation lives in `packages/core/src/federation/`.
  */
 
 import { get } from 'svelte/store';
-import type { HoloSphere } from 'holosphere';
+import {
+	publishToFederation as corePublishToFederation,
+	type PublishContext,
+	type PublishOptions,
+	type PublishOutcome,
+	type PublishTarget
+} from '@holons/core/federation';
 import { nostrPublicKey } from '$lib/stores/nostr';
 import { notifyWriteDenied } from '$lib/stores/writeNotifications';
 
-export type PublishTarget =
-	| { kind: 'all' }
-	| { kind: 'partner'; holonId: string }
-	| { kind: 'hex'; cell: string };
+export {
+	getFederationSnapshot,
+	readSettingsHex,
+	type FederationSnapshot
+} from '@holons/core/federation';
 
-export interface PublishContext {
-	holosphere: HoloSphere;
-	holonId: string;
-	lens: string;
-	item: { id: string; [k: string]: any };
-}
-
-export interface PublishOptions {
-	/** When true, also write to settings.hex if one is configured. Default true. */
-	includeSettingsHex?: boolean;
-	/** Override the federation source. Defaults to $nostrPublicKey || holonId. */
-	federationSourceId?: string;
-}
-
-export interface PublishOutcome {
-	publishedTo: number;
-	destinations: string[];
-	errors: string[];
-	usedHolograms: boolean;
-}
-
-interface FederationSnapshot {
-	federated: string[];
-	partnerNames: Record<string, string>;
-}
-
-/** Read federation list + partner names for the current home holon. */
-export async function getFederationSnapshot(
-	holosphere: HoloSphere,
-	holonId: string,
-	federationSourceId?: string
-): Promise<FederationSnapshot> {
-	const sourceId = federationSourceId ?? get(nostrPublicKey) ?? holonId;
-	const fedInfo = await holosphere.getFederation(sourceId);
-	return {
-		federated: Array.isArray(fedInfo?.federated) ? fedInfo!.federated : [],
-		partnerNames: fedInfo?.partnerNames ?? {}
-	};
-}
-
-/** Read settings.hex for a holon, returning null if absent or unreachable. */
-export async function readSettingsHex(
-	holosphere: HoloSphere,
-	holonId: string
-): Promise<string | null> {
-	try {
-		const settings = await holosphere.get(holonId, 'settings', holonId);
-		return settings && typeof settings.hex === 'string' && settings.hex
-			? settings.hex
-			: null;
-	} catch {
-		return null;
-	}
-}
-
-function isH3(holosphere: HoloSphere, holonId: string): boolean {
-	try {
-		return !!(holosphere as any).isValidH3?.(holonId);
-	} catch {
-		return false;
-	}
-}
-
-function ensureItemHasId(item: { id?: string; [k: string]: any }): asserts item is { id: string } {
-	if (!item || typeof item.id !== 'string' || !item.id) {
-		throw new Error('publishToFederation: item.id is required to create a hologram');
-	}
-}
+export type { PublishContext, PublishOptions, PublishOutcome, PublishTarget };
 
 export async function publishToFederation(
 	ctx: PublishContext,
 	target: PublishTarget,
 	opts: PublishOptions = {}
 ): Promise<PublishOutcome> {
-	const { holosphere, holonId, lens, item } = ctx;
-	ensureItemHasId(item);
+	const federationSourceId =
+		opts.federationSourceId ?? get(nostrPublicKey) ?? ctx.holonId;
 
-	const hologram = await holosphere.createHologram(holonId, lens, item);
-	const errors: string[] = [];
-	const destinations: string[] = [];
-
-	if (target.kind === 'partner') {
-		try {
-			await holosphere.put(target.holonId, lens, hologram);
-			destinations.push(target.holonId);
-		} catch (err: any) {
-			handlePutError(err, lens, errors, target.holonId);
-		}
-		return { publishedTo: destinations.length, destinations, errors, usedHolograms: true };
-	}
-
-	if (target.kind === 'hex') {
-		try {
-			await holosphere.put(target.cell, lens, hologram);
-			destinations.push(target.cell);
-		} catch (err: any) {
-			handlePutError(err, lens, errors, target.cell);
-		}
-		return { publishedTo: destinations.length, destinations, errors, usedHolograms: true };
-	}
-
-	// target.kind === 'all'
-	const includeSettingsHex = opts.includeSettingsHex !== false;
-	const settingsHex = includeSettingsHex ? await readSettingsHex(holosphere, holonId) : null;
-	const snapshot = await getFederationSnapshot(holosphere, holonId, opts.federationSourceId);
-	const hasFederated = snapshot.federated.length > 0;
-
-	if (settingsHex) {
-		try {
-			await holosphere.put(settingsHex, lens, hologram);
-			destinations.push(settingsHex);
-		} catch (err: any) {
-			handlePutError(err, lens, errors, settingsHex);
-		}
-	}
-
-	if (hasFederated) {
-		const h3 = isH3(holosphere, holonId);
-		try {
-			const result = await holosphere.propagate(holonId, lens, hologram, {
-				useHolograms: true,
-				propagateToParents: h3,
-				maxParentLevels: h3 ? 1 : 0
-			});
-
-			const directSuccess = (result as any)?.success ?? 0;
-			const parentSuccess = (result as any)?.parentPropagation?.success ?? 0;
-			for (let i = 0; i < directSuccess + parentSuccess; i++) {
-				destinations.push(`federated:${i}`);
-			}
-
-			const directMessages = (result as any)?.messages ?? (result as any)?.errorDetails ?? [];
-			const parentMessages = (result as any)?.parentPropagation?.messages ?? [];
-			for (const m of directMessages) errors.push(typeof m === 'string' ? m : m?.error ?? String(m));
-			for (const m of parentMessages) errors.push(typeof m === 'string' ? m : m?.error ?? String(m));
-		} catch (err: any) {
-			errors.push(`Propagation error: ${err?.message ?? 'unknown'}`);
-		}
-	}
-
-	return {
-		publishedTo: destinations.length,
-		destinations,
-		errors,
-		usedHolograms: true
-	};
-}
-
-function handlePutError(err: any, lens: string, errors: string[], target: string) {
-	if (err?.name === 'AuthorizationError' || err?.message?.includes('Write access denied')) {
-		notifyWriteDenied(`Unable to publish to ${target.slice(0, 12)}… — no write permission for ${lens}`);
-		errors.push(`${target.slice(0, 8)}…: write denied`);
-		return;
-	}
-	errors.push(`${target.slice(0, 8)}…: ${err?.message ?? 'unknown error'}`);
+	return corePublishToFederation(ctx, target, {
+		...opts,
+		federationSourceId,
+		onWriteDenied:
+			opts.onWriteDenied ??
+			(({ message }) => {
+				notifyWriteDenied(message);
+			})
+	});
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -11,7 +11,7 @@
 		"sourceMap": true,
 		"strict": true,
 		"verbatimModuleSyntax": false,
-		"moduleResolution": "node",
+		"moduleResolution": "bundler",
 		"module": "esnext",
 		"target": "esnext",
 		"isolatedModules": true,

--- a/packages/core/src/federation/index.ts
+++ b/packages/core/src/federation/index.ts
@@ -1,0 +1,18 @@
+/**
+ * @holons/core/federation
+ *
+ * Shared federation publishing primitives. UI-agnostic: callers inject the
+ * federation source id and (optionally) a write-denied notifier.
+ */
+
+export {
+	publishToFederation,
+	type PublishContext,
+	type PublishOptions,
+	type PublishOutcome,
+	type PublishTarget
+} from './publish.js';
+
+export { getFederationSnapshot, type FederationSnapshot } from './snapshot.js';
+
+export { readSettingsHex } from './settings-hex.js';

--- a/packages/core/src/federation/publish.test.ts
+++ b/packages/core/src/federation/publish.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest';
+import { publishToFederation } from './publish.js';
+import type { HoloSphere } from 'holosphere';
+
+interface MockOpts {
+	federated?: string[];
+	settingsHex?: string | null;
+	isH3?: boolean;
+	propagateResult?: any;
+	putError?: Error;
+}
+
+function mockHolosphere(opts: MockOpts = {}): {
+	holosphere: HoloSphere;
+	put: ReturnType<typeof vi.fn>;
+	propagate: ReturnType<typeof vi.fn>;
+	createHologram: ReturnType<typeof vi.fn>;
+} {
+	const put = vi.fn(async () => {
+		if (opts.putError) throw opts.putError;
+	});
+	const propagate = vi.fn(async () => opts.propagateResult ?? { success: 0 });
+	const createHologram = vi.fn(async (_h: string, _l: string, item: any) => ({
+		_hologram: { isHologram: true },
+		...item
+	}));
+
+	const holosphere = {
+		put,
+		propagate,
+		createHologram,
+		getFederation: vi.fn(async () => ({ federated: opts.federated ?? [] })),
+		get: vi.fn(async (_h: string, lens: string) =>
+			lens === 'settings' ? { hex: opts.settingsHex ?? null } : null
+		),
+		isValidH3: () => !!opts.isH3
+	} as unknown as HoloSphere;
+
+	return { holosphere, put, propagate, createHologram };
+}
+
+const ctx = (holosphere: HoloSphere) => ({
+	holosphere,
+	holonId: 'home-holon',
+	lens: 'quests',
+	item: { id: 'q-1', title: 'Test' }
+});
+
+describe('publishToFederation', () => {
+	it('throws when item.id is missing', async () => {
+		const { holosphere } = mockHolosphere();
+		await expect(
+			publishToFederation(
+				{ ...ctx(holosphere), item: {} as any },
+				{ kind: 'partner', holonId: 'p1' }
+			)
+		).rejects.toThrow(/item\.id is required/);
+	});
+
+	it('partner target writes once via put', async () => {
+		const m = mockHolosphere();
+		const out = await publishToFederation(ctx(m.holosphere), { kind: 'partner', holonId: 'p1' });
+		expect(m.put).toHaveBeenCalledWith('p1', 'quests', expect.any(Object));
+		expect(out.publishedTo).toBe(1);
+		expect(out.destinations).toEqual(['p1']);
+	});
+
+	it('hex target writes to the cell', async () => {
+		const m = mockHolosphere();
+		const out = await publishToFederation(ctx(m.holosphere), { kind: 'hex', cell: '8928308280fffff' });
+		expect(m.put).toHaveBeenCalledWith('8928308280fffff', 'quests', expect.any(Object));
+		expect(out.destinations).toEqual(['8928308280fffff']);
+	});
+
+	it('all target propagates and writes to settings.hex', async () => {
+		const m = mockHolosphere({
+			federated: ['p1', 'p2'],
+			settingsHex: 'hex-cell',
+			propagateResult: { success: 2, messages: [] }
+		});
+		const out = await publishToFederation(ctx(m.holosphere), { kind: 'all' });
+		expect(m.put).toHaveBeenCalledWith('hex-cell', 'quests', expect.any(Object));
+		expect(m.propagate).toHaveBeenCalledOnce();
+		expect(out.publishedTo).toBe(3); // hex-cell + 2 federated
+	});
+
+	it('all target skips settings.hex when includeSettingsHex is false', async () => {
+		const m = mockHolosphere({ federated: [], settingsHex: 'hex-cell' });
+		const out = await publishToFederation(
+			ctx(m.holosphere),
+			{ kind: 'all' },
+			{ includeSettingsHex: false }
+		);
+		expect(m.put).not.toHaveBeenCalled();
+		expect(out.publishedTo).toBe(0);
+	});
+
+	it('all target skips propagate when no federated partners', async () => {
+		const m = mockHolosphere({ federated: [] });
+		const out = await publishToFederation(ctx(m.holosphere), { kind: 'all' });
+		expect(m.propagate).not.toHaveBeenCalled();
+		expect(out.publishedTo).toBe(0);
+	});
+
+	it('write-denied errors fire onWriteDenied callback', async () => {
+		const m = mockHolosphere({ putError: Object.assign(new Error('Write access denied'), {}) });
+		const onWriteDenied = vi.fn();
+		const out = await publishToFederation(
+			ctx(m.holosphere),
+			{ kind: 'partner', holonId: 'p1' },
+			{ onWriteDenied }
+		);
+		expect(onWriteDenied).toHaveBeenCalledOnce();
+		expect(out.errors[0]).toMatch(/write denied/);
+		expect(out.publishedTo).toBe(0);
+	});
+
+	it('h3 home holon enables propagateToParents', async () => {
+		const m = mockHolosphere({ federated: ['p1'], isH3: true });
+		await publishToFederation(ctx(m.holosphere), { kind: 'all' });
+		expect(m.propagate).toHaveBeenCalledWith(
+			'home-holon',
+			'quests',
+			expect.any(Object),
+			expect.objectContaining({ propagateToParents: true, maxParentLevels: 1 })
+		);
+	});
+});

--- a/packages/core/src/federation/publish.ts
+++ b/packages/core/src/federation/publish.ts
@@ -1,0 +1,161 @@
+/**
+ * Publish to Federation — UI-agnostic core.
+ *
+ * Single source of truth for "publish this item as a hologram" across UIs
+ * (web, telegram, text, ai). Always wraps the item in a hologram first so
+ * receivers' provenance metadata is correct. Stamping the source item with
+ * `published`/`publishedAt`/`publishedTo` is the caller's responsibility.
+ *
+ * Three target shapes:
+ *   - 'all'     → propagate() to every federated partner (current default)
+ *                 + optional write to settings.hex if configured
+ *   - 'partner' → put(targetHolonId, lens, hologram) to one specific partner
+ *   - 'hex'     → put(h3Cell, lens, hologram) to one H3 cell
+ *
+ * UI-injected concerns (Svelte stores, nostr identity, toast notifications)
+ * stay UI-side: pass `federationSourceId` explicitly and supply an
+ * `onWriteDenied` callback if you want write-permission errors surfaced.
+ */
+
+import type { HoloSphere } from 'holosphere';
+import { getFederationSnapshot } from './snapshot.js';
+import { readSettingsHex } from './settings-hex.js';
+
+export type PublishTarget =
+	| { kind: 'all' }
+	| { kind: 'partner'; holonId: string }
+	| { kind: 'hex'; cell: string };
+
+export interface PublishContext {
+	holosphere: HoloSphere;
+	holonId: string;
+	lens: string;
+	item: { id: string; [k: string]: any };
+}
+
+export interface PublishOptions {
+	/** When true, also write to settings.hex if one is configured. Default true. */
+	includeSettingsHex?: boolean;
+	/** Federation source identity (e.g. nostr pubkey). Defaults to `holonId`. */
+	federationSourceId?: string;
+	/**
+	 * Optional callback fired when a put is rejected by HoloSphere ACL
+	 * (AuthorizationError / "Write access denied"). UIs can surface a toast.
+	 */
+	onWriteDenied?: (info: { target: string; lens: string; message: string }) => void;
+}
+
+export interface PublishOutcome {
+	publishedTo: number;
+	destinations: string[];
+	errors: string[];
+	usedHolograms: boolean;
+}
+
+function isH3(holosphere: HoloSphere, holonId: string): boolean {
+	try {
+		return !!(holosphere as any).isValidH3?.(holonId);
+	} catch {
+		return false;
+	}
+}
+
+function ensureItemHasId(item: { id?: string; [k: string]: any }): asserts item is { id: string } {
+	if (!item || typeof item.id !== 'string' || !item.id) {
+		throw new Error('publishToFederation: item.id is required to create a hologram');
+	}
+}
+
+/** Put a hologram at `target` and record the outcome in `destinations`/`errors`. */
+async function putToTarget(
+	holosphere: HoloSphere,
+	target: string,
+	lens: string,
+	hologram: unknown,
+	destinations: string[],
+	errors: string[],
+	onWriteDenied?: PublishOptions['onWriteDenied']
+): Promise<void> {
+	try {
+		await (holosphere as any).put(target, lens, hologram);
+		destinations.push(target);
+	} catch (err: any) {
+		if (err?.name === 'AuthorizationError' || err?.message?.includes('Write access denied')) {
+			const message = `Unable to publish to ${target.slice(0, 12)}… — no write permission for ${lens}`;
+			onWriteDenied?.({ target, lens, message });
+			errors.push(`${target.slice(0, 8)}…: write denied`);
+			return;
+		}
+		errors.push(`${target.slice(0, 8)}…: ${err?.message ?? 'unknown error'}`);
+	}
+}
+
+function collectMessages(messages: any, errors: string[]): void {
+	for (const m of messages ?? []) {
+		errors.push(typeof m === 'string' ? m : (m?.error ?? String(m)));
+	}
+}
+
+export async function publishToFederation(
+	ctx: PublishContext,
+	target: PublishTarget,
+	opts: PublishOptions = {}
+): Promise<PublishOutcome> {
+	const { holosphere, holonId, lens, item } = ctx;
+	ensureItemHasId(item);
+
+	const hologram = await (holosphere as any).createHologram(holonId, lens, item);
+	const errors: string[] = [];
+	const destinations: string[] = [];
+	const single = (t: string) =>
+		putToTarget(holosphere, t, lens, hologram, destinations, errors, opts.onWriteDenied);
+
+	if (target.kind === 'partner') {
+		await single(target.holonId);
+		return { publishedTo: destinations.length, destinations, errors, usedHolograms: true };
+	}
+
+	if (target.kind === 'hex') {
+		await single(target.cell);
+		return { publishedTo: destinations.length, destinations, errors, usedHolograms: true };
+	}
+
+	const includeSettingsHex = opts.includeSettingsHex !== false;
+	const [settingsHex, snapshot] = await Promise.all([
+		includeSettingsHex ? readSettingsHex(holosphere, holonId) : Promise.resolve(null),
+		getFederationSnapshot(holosphere, holonId, opts.federationSourceId)
+	]);
+
+	if (settingsHex) {
+		await single(settingsHex);
+	}
+
+	if (snapshot.federated.length > 0) {
+		const h3 = isH3(holosphere, holonId);
+		try {
+			const result: any = await (holosphere as any).propagate(holonId, lens, hologram, {
+				useHolograms: true,
+				propagateToParents: h3,
+				maxParentLevels: h3 ? 1 : 0
+			});
+
+			const directSuccess = result?.success ?? 0;
+			const parentSuccess = result?.parentPropagation?.success ?? 0;
+			for (let i = 0; i < directSuccess + parentSuccess; i++) {
+				destinations.push(`federated:${i}`);
+			}
+
+			collectMessages(result?.messages ?? result?.errorDetails, errors);
+			collectMessages(result?.parentPropagation?.messages, errors);
+		} catch (err: any) {
+			errors.push(`Propagation error: ${err?.message ?? 'unknown'}`);
+		}
+	}
+
+	return {
+		publishedTo: destinations.length,
+		destinations,
+		errors,
+		usedHolograms: true
+	};
+}

--- a/packages/core/src/federation/settings-hex.ts
+++ b/packages/core/src/federation/settings-hex.ts
@@ -1,0 +1,22 @@
+/**
+ * Settings-hex helper.
+ *
+ * Reads `settings.hex` for a holon. Returns `null` when absent or unreachable
+ * (callers should treat both the same).
+ */
+
+import type { HoloSphere } from 'holosphere';
+
+export async function readSettingsHex(
+	holosphere: HoloSphere,
+	holonId: string
+): Promise<string | null> {
+	try {
+		const settings: any = await (holosphere as any).get(holonId, 'settings', holonId);
+		return settings && typeof settings.hex === 'string' && settings.hex
+			? settings.hex
+			: null;
+	} catch {
+		return null;
+	}
+}

--- a/packages/core/src/federation/snapshot.ts
+++ b/packages/core/src/federation/snapshot.ts
@@ -1,0 +1,32 @@
+/**
+ * Federation snapshot helpers.
+ *
+ * Read-only views of a holon's federation configuration. UI-agnostic;
+ * accepts an explicit federation source id (caller resolves nostr key etc.).
+ */
+
+import type { HoloSphere } from 'holosphere';
+
+export interface FederationSnapshot {
+	federated: string[];
+	partnerNames: Record<string, string>;
+}
+
+/**
+ * Read federation list + partner names for the given home holon.
+ *
+ * `federationSourceId` defaults to `holonId`; UIs that key federation off a
+ * nostr public key (or other identity) should pass it explicitly.
+ */
+export async function getFederationSnapshot(
+	holosphere: HoloSphere,
+	holonId: string,
+	federationSourceId?: string
+): Promise<FederationSnapshot> {
+	const sourceId = federationSourceId ?? holonId;
+	const fedInfo: any = await (holosphere as any).getFederation(sourceId);
+	return {
+		federated: Array.isArray(fedInfo?.federated) ? fedInfo.federated : [],
+		partnerNames: fedInfo?.partnerNames ?? {}
+	};
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts", "src/**/*.spec.ts"]
 }


### PR DESCRIPTION
Phase B Unit 3 of 20.

Extracts `publishToFederation`, `getFederationSnapshot`, `readSettingsHex` from `apps/web/src/lib/holosphere/publish.ts` into `@holons/core/federation` (UI-agnostic, no Svelte/Telegraf imports).

- New: `packages/core/src/federation/{publish,snapshot,settings-hex,index}.ts` + 8 vitest cases
- Replaced: `apps/web/src/lib/holosphere/publish.ts` is now a 47-line Svelte adapter wiring `nostrPublicKey` + `notifyWriteDenied` into core
- Tweak: `apps/web/tsconfig.json` `moduleResolution` switched to `bundler` so `@holons/core/federation` subpath resolves
- Telegram-ui untouched: bot uses `propagate`/`propagateData` (lens-rule based) which is a different operation than web `put`-based publish — left intact per contract; core now available when bot opts in

Verification: `pnpm -r typecheck` clean, `pnpm -F @holons/core test` 8/8, `pnpm -F harvest-web build` clean, smoke OK.