### PR TITLE
core/users: extract user profile + values/needs + membership into @holons/core

### DIFF
--- a/packages/core/src/users/index.ts
+++ b/packages/core/src/users/index.ts
@@ -1,0 +1,50 @@
+/**
+ * `@holons/core/users` — user profile, values/needs, and holon membership.
+ *
+ * UI-agnostic. Pass any object that implements the {@link UserDB} surface
+ * (Holosphere instances satisfy it natively) plus a {@link TelegramUserLike}
+ * descriptor for the acting user.
+ */
+
+/** Minimal user shape — matches Telegram's `from` object but not exclusive to it. */
+export interface TelegramUserLike {
+  id: string | number;
+  username?: string;
+  first_name?: string;
+  last_name?: string;
+  is_bot?: boolean;
+}
+
+/** Holosphere-shaped storage surface used by this module. */
+export interface UserDB {
+  get(holon: string, lens: string, key: string): Promise<unknown>;
+  put(holon: string, lens: string, data: object): Promise<unknown>;
+  delete(holon: string, lens: string, key: string): Promise<boolean>;
+  getAll(holon: string, lens: string): Promise<unknown[]>;
+}
+
+/** Persisted user profile shape (REA-aware, version 0.3). */
+export interface UserProfile {
+  id: string | number;
+  version: string;
+  username: string;
+  first_name?: string;
+  last_name?: string;
+  values: string[];
+  needs: string[];
+  participated: Record<string, unknown>;
+  // Aggregates may be merged in by callers; keep open for forward-compat.
+  [key: string]: unknown;
+}
+
+export {
+  createDefaultProfile,
+  getUserProfile,
+  ensureUserProfile,
+  saveUserProfile,
+  getUsers,
+} from './profile.js';
+
+export { addUserValues, addUserNeeds } from './values-needs.js';
+
+export { joinHolon, leaveHolon, type JoinResult } from './membership.js';

--- a/packages/core/src/users/membership.ts
+++ b/packages/core/src/users/membership.ts
@@ -1,0 +1,51 @@
+/**
+ * Holon membership operations: join / leave.
+ *
+ * "Join" is implemented as ensuring the user profile exists — there is no
+ * separate membership record in the holosphere model. "Leave" deletes the
+ * profile from the holon's `users` lens.
+ */
+import { getUserProfile } from './profile.js';
+import type { TelegramUserLike, UserDB, UserProfile } from './index.js';
+
+const USERS_LENS = 'users';
+
+export interface JoinResult {
+  /** Loaded (or newly-created) profile, or `null` if join was rejected. */
+  profile: UserProfile | null;
+  /** True iff the user has a usable username. */
+  hasUsername: boolean;
+}
+
+/**
+ * Add a user to a holon by ensuring their profile exists.
+ *
+ * Returns the loaded profile and a `hasUsername` flag so callers can decide
+ * whether to nudge the user to set one (Telegram-specific concern, but
+ * exposed here so the bot doesn't need to re-fetch).
+ */
+export async function joinHolon(
+  db: UserDB,
+  user: TelegramUserLike,
+  holonId: string | number,
+): Promise<JoinResult> {
+  const profile = await getUserProfile(db, user, holonId);
+  // Original behaviour: only "true" once the profile loaded successfully
+  // (so bot users / missing holon are treated as no-username).
+  return {
+    profile,
+    hasUsername: Boolean(profile && user.username),
+  };
+}
+
+/**
+ * Remove a user from a holon by deleting their profile entry.
+ * Returns `true` when the underlying delete reported success.
+ */
+export async function leaveHolon(
+  db: UserDB,
+  userId: string | number,
+  holonId: string | number,
+): Promise<boolean> {
+  return db.delete(String(holonId), USERS_LENS, String(userId));
+}

--- a/packages/core/src/users/profile.ts
+++ b/packages/core/src/users/profile.ts
@@ -1,0 +1,88 @@
+/**
+ * User profile CRUD against a Holosphere-shaped DB.
+ *
+ * All functions are UI-agnostic. Callers (Telegram bot, web app, etc.)
+ * adapt their user-shape to {@link TelegramUserLike} before calling.
+ */
+import type { TelegramUserLike, UserDB, UserProfile } from './index.js';
+
+const USERS_LENS = 'users';
+const PROFILE_VERSION = '0.3'; // REA-aware profile
+
+/** Normalise a holonId to its persisted string form, or `null` if unusable. */
+function normaliseHolonId(holonId: string | number | null | undefined): string | null {
+  if (holonId === undefined || holonId === null || holonId === '') return null;
+  return String(holonId);
+}
+
+/**
+ * Build a fresh profile object for a never-seen user.
+ * Pure — does not touch the DB.
+ */
+export function createDefaultProfile(user: TelegramUserLike): UserProfile {
+  return {
+    id: user.id,
+    version: PROFILE_VERSION,
+    username: user.username ? user.username : String(user.id),
+    first_name: user.first_name,
+    last_name: user.last_name,
+    values: [],
+    needs: [],
+    participated: {},
+  };
+}
+
+/**
+ * Load a user's profile for a holon. If absent, a default profile is
+ * created and persisted. Returns `null` for bots or when `holonId` is missing.
+ */
+export async function getUserProfile(
+  db: UserDB,
+  user: TelegramUserLike,
+  holonId: string | number,
+): Promise<UserProfile | null> {
+  if (user?.is_bot) return null;
+  const holonIdStr = normaliseHolonId(holonId);
+  if (!holonIdStr) return null;
+
+  const existing = await db.get(holonIdStr, USERS_LENS, String(user.id));
+  if (existing && existing !== '') return existing as UserProfile;
+
+  const profile = createDefaultProfile(user);
+  await db.put(holonIdStr, USERS_LENS, profile);
+  return profile;
+}
+
+/**
+ * Make sure a user profile exists for the given holon. No-op for bots
+ * or missing holon ids. Delegates to {@link getUserProfile} which performs
+ * the read+create-if-absent pattern.
+ */
+export async function ensureUserProfile(
+  db: UserDB,
+  user: TelegramUserLike,
+  holonId: string | number,
+): Promise<void> {
+  await getUserProfile(db, user, holonId);
+}
+
+/**
+ * Persist an updated profile. Caller is responsible for shape.
+ */
+export async function saveUserProfile(
+  db: UserDB,
+  holonId: string | number,
+  profile: UserProfile,
+): Promise<void> {
+  await db.put(String(holonId), USERS_LENS, profile);
+}
+
+/**
+ * List every stored user profile in a holon.
+ */
+export async function getUsers(
+  db: UserDB,
+  holonId: string | number,
+): Promise<UserProfile[]> {
+  return (await db.getAll(String(holonId), USERS_LENS)) as UserProfile[];
+}

--- a/packages/core/src/users/users.test.ts
+++ b/packages/core/src/users/users.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Behavioural tests for `@holons/core/users`.
+ * Uses an in-memory fake DB that mimics the holosphere shape.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  createDefaultProfile,
+  getUserProfile,
+  ensureUserProfile,
+  getUsers,
+  saveUserProfile,
+  addUserValues,
+  addUserNeeds,
+  joinHolon,
+  leaveHolon,
+  type TelegramUserLike,
+  type UserDB,
+  type UserProfile,
+} from './index.js';
+
+function makeFakeDB(): UserDB & { _store: Map<string, Map<string, unknown>> } {
+  const store = new Map<string, Map<string, unknown>>();
+  const keyFor = (holon: string, lens: string) => `${holon}::${lens}`;
+  return {
+    _store: store,
+    async get(holon, lens, key) {
+      return store.get(keyFor(holon, lens))?.get(String(key)) ?? null;
+    },
+    async put(holon, lens, data: any) {
+      const k = keyFor(holon, lens);
+      if (!store.has(k)) store.set(k, new Map());
+      const id = String(data.id);
+      store.get(k)!.set(id, data);
+      return { ok: true };
+    },
+    async delete(holon, lens, key) {
+      return store.get(keyFor(holon, lens))?.delete(String(key)) ?? false;
+    },
+    async getAll(holon, lens) {
+      return Array.from(store.get(keyFor(holon, lens))?.values() ?? []);
+    },
+  };
+}
+
+const ALICE: TelegramUserLike = {
+  id: 42,
+  username: 'alice',
+  first_name: 'Alice',
+};
+
+const BOT: TelegramUserLike = { id: 1, is_bot: true };
+
+describe('createDefaultProfile', () => {
+  it('falls back to id when no username present', () => {
+    const p = createDefaultProfile({ id: 7, first_name: 'Anon' });
+    expect(p.username).toBe('7');
+    expect(p.values).toEqual([]);
+    expect(p.needs).toEqual([]);
+    expect(p.version).toBe('0.3');
+  });
+
+  it('uses telegram username when present', () => {
+    expect(createDefaultProfile(ALICE).username).toBe('alice');
+  });
+});
+
+describe('getUserProfile', () => {
+  let db: ReturnType<typeof makeFakeDB>;
+  beforeEach(() => { db = makeFakeDB(); });
+
+  it('returns null for bots', async () => {
+    expect(await getUserProfile(db, BOT, 'h1')).toBeNull();
+  });
+
+  it('returns null for missing holonId', async () => {
+    expect(await getUserProfile(db, ALICE, '')).toBeNull();
+  });
+
+  it('creates and persists default profile when missing', async () => {
+    const p = await getUserProfile(db, ALICE, 'h1');
+    expect(p?.username).toBe('alice');
+    const stored = await db.get('h1', 'users', '42');
+    expect(stored).toBeTruthy();
+  });
+
+  it('returns existing profile on second call', async () => {
+    const first = await getUserProfile(db, ALICE, 'h1');
+    first!.values.push('seeded');
+    await saveUserProfile(db, 'h1', first!);
+    const second = await getUserProfile(db, ALICE, 'h1');
+    expect(second?.values).toContain('seeded');
+  });
+
+  it('coerces numeric holonId to string', async () => {
+    await getUserProfile(db, ALICE, 99);
+    expect(await db.get('99', 'users', '42')).toBeTruthy();
+  });
+});
+
+describe('ensureUserProfile', () => {
+  it('is a no-op when profile already exists', async () => {
+    const db = makeFakeDB();
+    await getUserProfile(db, ALICE, 'h1');
+    const before = await db.get('h1', 'users', '42');
+    await ensureUserProfile(db, ALICE, 'h1');
+    const after = await db.get('h1', 'users', '42');
+    expect(after).toBe(before);
+  });
+
+  it('creates profile when absent', async () => {
+    const db = makeFakeDB();
+    await ensureUserProfile(db, ALICE, 'h1');
+    expect(await db.get('h1', 'users', '42')).toBeTruthy();
+  });
+
+  it('skips bots and missing holon', async () => {
+    const db = makeFakeDB();
+    await ensureUserProfile(db, BOT, 'h1');
+    await ensureUserProfile(db, ALICE, '');
+    expect((await getUsers(db, 'h1')).length).toBe(0);
+  });
+});
+
+describe('addUserValues / addUserNeeds', () => {
+  it('appends and dedupes values', async () => {
+    const db = makeFakeDB();
+    await addUserValues(db, ALICE, 'h1', ['freedom', 'love']);
+    const p = await addUserValues(db, ALICE, 'h1', ['love', 'trust']);
+    expect(p?.values.sort()).toEqual(['freedom', 'love', 'trust']);
+  });
+
+  it('appends and dedupes needs', async () => {
+    const db = makeFakeDB();
+    await addUserNeeds(db, ALICE, 'h1', ['hugs']);
+    const p = await addUserNeeds(db, ALICE, 'h1', ['hugs', 'food']);
+    expect(p?.needs.sort()).toEqual(['food', 'hugs']);
+  });
+
+  it('returns null on empty input', async () => {
+    const db = makeFakeDB();
+    expect(await addUserValues(db, ALICE, 'h1', [])).toBeNull();
+    expect(await addUserNeeds(db, ALICE, 'h1', [])).toBeNull();
+  });
+
+  it('returns null for bot users', async () => {
+    const db = makeFakeDB();
+    expect(await addUserValues(db, BOT, 'h1', ['x'])).toBeNull();
+  });
+});
+
+describe('joinHolon / leaveHolon', () => {
+  it('join ensures profile and reports username flag', async () => {
+    const db = makeFakeDB();
+    const r = await joinHolon(db, ALICE, 'h1');
+    expect(r.profile?.username).toBe('alice');
+    expect(r.hasUsername).toBe(true);
+  });
+
+  it('join flags missing username (no telegram username)', async () => {
+    const db = makeFakeDB();
+    const r = await joinHolon(db, { id: 99, first_name: 'NoName' }, 'h1');
+    expect(r.hasUsername).toBe(false);
+    // profile is still created with id-as-username fallback
+    expect(r.profile?.username).toBe('99');
+  });
+
+  it('leave deletes the profile', async () => {
+    const db = makeFakeDB();
+    await getUserProfile(db, ALICE, 'h1');
+    expect(await leaveHolon(db, 42, 'h1')).toBe(true);
+    expect(await db.get('h1', 'users', '42')).toBeNull();
+  });
+});
+
+describe('getUsers', () => {
+  it('returns every stored profile', async () => {
+    const db = makeFakeDB();
+    await getUserProfile(db, ALICE, 'h1');
+    await getUserProfile(db, { id: 2, username: 'bob' }, 'h1');
+    const all = await getUsers(db, 'h1');
+    expect(all.length).toBe(2);
+  });
+});

--- a/packages/core/src/users/values-needs.ts
+++ b/packages/core/src/users/values-needs.ts
@@ -1,0 +1,50 @@
+/**
+ * Values & needs management for a user inside a holon.
+ *
+ * Both lists are stored as deduplicated string arrays on the user profile.
+ */
+import { getUserProfile, saveUserProfile } from './profile.js';
+import type { TelegramUserLike, UserDB, UserProfile } from './index.js';
+
+type ListField = 'values' | 'needs';
+
+async function appendUnique(
+  db: UserDB,
+  user: TelegramUserLike,
+  holonId: string | number,
+  field: ListField,
+  additions: string[],
+): Promise<UserProfile | null> {
+  if (!additions?.length) return null;
+  const profile = await getUserProfile(db, user, holonId);
+  if (!profile) return null;
+
+  profile[field] = Array.from(new Set([...(profile[field] ?? []), ...additions]));
+  await saveUserProfile(db, holonId, profile);
+  return profile;
+}
+
+/**
+ * Append values to a user profile. Returns `null` when the profile cannot be
+ * loaded (bot user, missing holonId) or `additions` is empty.
+ */
+export function addUserValues(
+  db: UserDB,
+  user: TelegramUserLike,
+  holonId: string | number,
+  values: string[],
+): Promise<UserProfile | null> {
+  return appendUnique(db, user, holonId, 'values', values);
+}
+
+/**
+ * Append needs to a user profile. Mirror of {@link addUserValues}.
+ */
+export function addUserNeeds(
+  db: UserDB,
+  user: TelegramUserLike,
+  holonId: string | number,
+  needs: string[],
+): Promise<UserProfile | null> {
+  return appendUnique(db, user, holonId, 'needs', needs);
+}

--- a/packages/telegram-ui/src/Users.js
+++ b/packages/telegram-ui/src/Users.js
@@ -1,11 +1,25 @@
 /**
  * @fileoverview User management for HolonsBot holons.
+ *
+ * Telegraf command bindings + REA orchestration. All profile / values / needs
+ * / membership data operations are delegated to `@holons/core/users` so the
+ * web UI and bot share the same persistence semantics.
+ *
  * @module src/Users
  */
 import { t } from "i18next";
 import * as utils from './utilities.js';
 import { Markup } from 'telegraf';
 import { REAEventStore, REAEventFactory, REAAggregator } from './domain/rea/index.js';
+import {
+  getUserProfile as coreGetUserProfile,
+  ensureUserProfile as coreEnsureUserProfile,
+  getUsers as coreGetUsers,
+  addUserValues,
+  addUserNeeds,
+  joinHolon as coreJoinHolon,
+  leaveHolon as coreLeaveHolon,
+} from '@holons/core/users';
 
 /**
  * User management class for handling holon members and their contributions.
@@ -62,11 +76,10 @@ class Users {
   }
 
   async join(ctx) {
-    let userinfo = await this.getUserInfo(ctx.message.from, ctx.message.chat.id)
-    if (userinfo.username == undefined) {
+    const { hasUsername } = await coreJoinHolon(this.db, ctx.message.from, ctx.message.chat.id);
+    if (!hasUsername) {
       ctx.reply('Please set a username in your telegram settings to join the group.');
-    }
-    else {
+    } else {
       ctx.reply('🎉 Welcome ' + ctx.message.from.first_name + '! 🎉');
     }
   }
@@ -74,42 +87,28 @@ class Users {
   async leave(ctx) {
     const holonId = ctx.message.chat.id;
     const user = ctx.message.from;
-    await this.db.delete(holonId, 'users', user.id)
+    await coreLeaveHolon(this.db, user.id, holonId);
     ctx.reply('Goodbye ' + user.first_name + '!');
   }
 
 
   async addValue(ctx) {
-    const holonId = ctx.message.chat.id;
-    const user = ctx.message.from;
     const values = utils.parseList(ctx.message.text);
-    if (!values) {
+    if (!values?.length) {
       ctx.reply('Please specify a value or list of values to add. eg: /value freedom, non-violence');
       return;
     }
-
-    let userinfo = await this.getUserProfile(user, holonId)
-    if (!userinfo.values) userinfo.values = []
-    userinfo.values = Array.from(new Set(userinfo.values.concat(values)))
-
-    await this.db.put(holonId, 'users', userinfo)
+    await addUserValues(this.db, ctx.message.from, ctx.message.chat.id, values);
     ctx.reply(`Added ${values.join(', ')} to your values.`);
   }
 
   async addNeed(ctx) {
-    const holonId = ctx.message.chat.id;
-    const user = ctx.message.from;
     const needs = utils.parseList(ctx.message.text);
-    if (!needs) {
+    if (!needs?.length) {
       ctx.reply('Please specify a need or comma separated list of needs to add. eg: /need hugs, massages');
       return;
     }
-
-    let userinfo = await this.getUserProfile(user, holonId)
-    if (!userinfo.needs) userinfo.needs = []
-    userinfo.needs = Array.from(new Set(userinfo.needs.concat(needs)))
-
-    await this.db.put(holonId, 'users', userinfo)
+    await addUserNeeds(this.db, ctx.message.from, ctx.message.chat.id, needs);
     ctx.reply(`Added ${needs.join(', ')} to your needs.`);
   }
 
@@ -117,7 +116,7 @@ class Users {
 
   async listUsersActions(ctx) {
     const holonId = ctx.message.chat.id;
-    let users = await this.db.getAll(holonId, 'users')
+    const users = await coreGetUsers(this.db, holonId);
 
     let message = ''
     for (let i = 0; i < users.length; i++) {
@@ -269,56 +268,28 @@ class Users {
   }
 
   async getUsers(holonId) {
-    return await this.db.getAll(holonId, 'users')
+    return coreGetUsers(this.db, holonId);
   }
 
   /**
-   * Get user profile (without computed aggregates)
-   * Use this for profile data updates
+   * Get user profile (without computed aggregates).
+   * Thin wrapper over `@holons/core/users`.
    * @param {Object} user - User object
    * @param {string} holonId - Holon context
    * @returns {Promise<Object>} User profile
    */
   async getUserProfile(user, holonId) {
-    if (user?.is_bot) {
-      return null;
-    }
-    if (!holonId) return null;
-
-    // Ensure holonId is a string (required by holosphere)
-    const holonIdStr = String(holonId);
-
-    let userinfo = await this.db.get(holonIdStr, 'users', user.id)
-    if (!userinfo || userinfo == '') {
-      userinfo = {
-        id: user.id,
-        version: '0.3',  // REA version
-        username: user.username ? user.username : user.id,
-        first_name: user.first_name,
-        last_name: user.last_name,
-        // Profile data only - no action counts (computed from events)
-        values: [],
-        needs: [],
-        participated: {}
-      }
-      await this.db.put(holonIdStr, 'users', userinfo)
-    }
-    return userinfo
+    return coreGetUserProfile(this.db, user, holonId);
   }
 
   /**
-   * Ensure user profile exists
+   * Ensure user profile exists.
+   * Thin wrapper over `@holons/core/users`.
    * @param {Object} user - User object
    * @param {string} holonId - Holon context
    */
   async ensureUserProfile(user, holonId) {
-    if (user?.is_bot) return;
-    if (!holonId) return;
-
-    let userinfo = await this.db.get(holonId, 'users', user.id)
-    if (!userinfo || userinfo == '') {
-      await this.getUserProfile(user, holonId);
-    }
+    return coreEnsureUserProfile(this.db, user, holonId);
   }
 
   /**


### PR DESCRIPTION
Phase B Unit 8 of 20.

Extracts user CRUD, values/needs append, and join/leave from `packages/telegram-ui/src/Users.js` into `@holons/core/users` (4 new files + 18 vitest cases).

- `profile.ts` — `createDefaultProfile`, `getUserProfile` (read-or-create), `ensureUserProfile`, `saveUserProfile`, `getUsers`
- `values-needs.ts` — `addUserValues`, `addUserNeeds` (deduped append, shared helper)
- `membership.ts` — `joinHolon` (returns `hasUsername`), `leaveHolon`
- `Users.js` rewired to delegate; Telegraf bindings, REA orchestration and reply rendering stay in the bot
- Web has no equivalent user helpers today, so no apps/web changes

Verification: typecheck/build clean, 18/18 core tests pass, telegram-ui tests pass (30/1 skipped), smoke OK.