### PR TITLE
text-ui + ai-ui: scaffold CLI + Claude tool-use over @holons/core/commands

### DIFF
--- a/packages/ai-ui/src/agent.ts
+++ b/packages/ai-ui/src/agent.ts
@@ -1,0 +1,154 @@
+// Anthropic tool-use loop over the @holons/core/commands registry.
+//
+// Architecture:
+//   - System prompt + tools are cached (cache_control: ephemeral) since they
+//     don't change across turns within a session.
+//   - On each turn we send the running message history. When the assistant
+//     emits tool_use blocks, we dispatch them through the registry and feed
+//     tool_result blocks back. Loop terminates on stop_reason === 'end_turn'
+//     (or when no tool_use blocks are present, defensive against API drift).
+
+import Anthropic from '@anthropic-ai/sdk';
+import { loadTools, type ToolDefinition } from './tools.js';
+import type { CommandRegistry } from './commands.js';
+
+export interface AgentOptions {
+  /** Anthropic model ID. */
+  model?: string;
+  /** Hard cap on tool-use turns (defensive, prevents runaway loops). */
+  maxIterations?: number;
+  /** System prompt — caller can override or extend the default. */
+  system?: string;
+  /** Per-response token budget. */
+  maxTokens?: number;
+  /** Inject a pre-built client (e.g. for tests or custom retry policy). */
+  client?: Anthropic;
+  /** Pre-loaded registry/tools (avoids re-importing for each call). */
+  registry?: CommandRegistry;
+  tools?: ToolDefinition[];
+}
+
+export interface AgentResult {
+  /** Final assistant text concatenated across the run. */
+  text: string;
+  /** Number of API turns executed. */
+  iterations: number;
+  /** Last stop reason returned by the API. */
+  stopReason: string | null;
+  /** Full message transcript (user + assistant) for inspection. */
+  messages: Anthropic.MessageParam[];
+}
+
+const DEFAULT_MODEL = 'claude-sonnet-4-6';
+const DEFAULT_SYSTEM =
+  'You are the Holons assistant. You help users manage tasks, hours, and ' +
+  'shopping lists across their holons by calling the available tools. Always ' +
+  'call a tool when the user requests an action; never fabricate results. ' +
+  'After tools complete, summarize what was done in one sentence.';
+
+/**
+ * Run the agent loop against a natural-language prompt. Returns when the
+ * model stops requesting tools or maxIterations is hit.
+ */
+export async function runAgent(
+  prompt: string,
+  options: AgentOptions = {},
+): Promise<AgentResult> {
+  const client = options.client ?? new Anthropic();
+  const model = options.model ?? DEFAULT_MODEL;
+  const maxIterations = options.maxIterations ?? 10;
+  const maxTokens = options.maxTokens ?? 4096;
+  const system = options.system ?? DEFAULT_SYSTEM;
+
+  let registry = options.registry;
+  let tools = options.tools;
+  if (!registry || !tools) {
+    const loaded = await loadTools();
+    registry = registry ?? loaded.registry;
+    tools = tools ?? loaded.tools;
+  }
+
+  // Render order is tools → system → messages, so a single cache_control
+  // breakpoint on the system block caches both tools and system together.
+  // Keeps us well under the 4-breakpoint cap and avoids needless writes.
+  const systemBlocks: Anthropic.TextBlockParam[] = [
+    { type: 'text', text: system, cache_control: { type: 'ephemeral' } },
+  ];
+
+  const messages: Anthropic.MessageParam[] = [
+    { role: 'user', content: prompt },
+  ];
+
+  let iterations = 0;
+  let stopReason: string | null = null;
+  const textChunks: string[] = [];
+
+  while (iterations < maxIterations) {
+    iterations++;
+    const response = await client.messages.create({
+      model,
+      max_tokens: maxTokens,
+      system: systemBlocks,
+      tools,
+      messages,
+    });
+
+    stopReason = response.stop_reason;
+    messages.push({ role: 'assistant', content: response.content });
+
+    // Collect any text the assistant produced this turn.
+    for (const block of response.content) {
+      if (block.type === 'text') textChunks.push(block.text);
+    }
+
+    const toolUses = response.content.filter(
+      (b): b is Anthropic.ToolUseBlock => b.type === 'tool_use',
+    );
+
+    if (toolUses.length === 0 || response.stop_reason === 'end_turn') {
+      break;
+    }
+
+    const toolResults: Anthropic.ToolResultBlockParam[] = [];
+    for (const tu of toolUses) {
+      const cmd = registry.get(tu.name);
+      if (!cmd) {
+        toolResults.push({
+          type: 'tool_result',
+          tool_use_id: tu.id,
+          content: `error: unknown tool "${tu.name}"`,
+          is_error: true,
+        });
+        continue;
+      }
+      try {
+        const result = await cmd.execute(
+          (tu.input ?? {}) as Record<string, unknown>,
+        );
+        toolResults.push({
+          type: 'tool_result',
+          tool_use_id: tu.id,
+          content: JSON.stringify(result),
+          is_error: !result.ok,
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        toolResults.push({
+          type: 'tool_result',
+          tool_use_id: tu.id,
+          content: `error: ${msg}`,
+          is_error: true,
+        });
+      }
+    }
+
+    messages.push({ role: 'user', content: toolResults });
+  }
+
+  return {
+    text: textChunks.join('\n'),
+    iterations,
+    stopReason,
+    messages,
+  };
+}

--- a/packages/ai-ui/src/cli.ts
+++ b/packages/ai-ui/src/cli.ts
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// Bin entry for the `holons-ai` CLI.
+//
+// Reads a natural-language prompt from argv (joined) or stdin, then runs the
+// agent loop and prints its final text response.
+
+import { runAgent } from './agent.js';
+
+async function readStdin(): Promise<string> {
+  if (process.stdin.isTTY) return '';
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks).toString('utf8').trim();
+}
+
+function printHelp(): void {
+  process.stdout.write(
+    [
+      'holons-ai — Natural-language Holons interpreter (Claude tool-use)',
+      '',
+      'Usage:',
+      '  holons-ai "<prompt>"            Run agent on a single prompt',
+      '  echo "<prompt>" | holons-ai     Read prompt from stdin',
+      '  holons-ai --help                Show this help',
+      '',
+      'Environment:',
+      '  ANTHROPIC_API_KEY               Required for live calls',
+      '  HOLONS_AI_MODEL                 Override the default model',
+      '',
+    ].join('\n'),
+  );
+}
+
+async function main(): Promise<number> {
+  const args = process.argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    printHelp();
+    return 0;
+  }
+
+  const argPrompt = args.join(' ').trim();
+  const prompt = argPrompt !== '' ? argPrompt : await readStdin();
+  if (prompt === '') {
+    printHelp();
+    return 1;
+  }
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    process.stderr.write('error: ANTHROPIC_API_KEY is not set\n');
+    return 2;
+  }
+
+  const result = await runAgent(prompt, {
+    model: process.env.HOLONS_AI_MODEL,
+  });
+  process.stdout.write(result.text + '\n');
+  return 0;
+}
+
+main().then(
+  (code) => process.exit(code),
+  (err) => {
+    process.stderr.write(
+      `error: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.exit(1);
+  },
+);

--- a/packages/ai-ui/src/commands.ts
+++ b/packages/ai-ui/src/commands.ts
@@ -1,0 +1,96 @@
+// FALLBACK: depends on Unit 15 (core/commands)
+//
+// Identical-by-design shape to packages/text-ui/src/commands.ts so a future
+// extraction into `@holons/core/commands` is a no-op. Until then, both
+// packages keep their own copy to avoid a cross-package dependency on a
+// not-yet-published module.
+
+export interface CoreCommandParam {
+  name: string;
+  type: 'string' | 'number' | 'boolean';
+  description: string;
+  required?: boolean;
+}
+
+export interface CoreCommand {
+  name: string;
+  description: string;
+  params: CoreCommandParam[];
+  execute(params: Record<string, unknown>): Promise<{
+    ok: boolean;
+    message?: string;
+    data?: unknown;
+  }>;
+}
+
+export interface CommandRegistry {
+  list(): CoreCommand[];
+  get(name: string): CoreCommand | undefined;
+}
+
+// FALLBACK: depends on Unit 15 (core/commands)
+const fallbackCommands: CoreCommand[] = [
+  {
+    name: 'createTask',
+    description: 'Create a new task in a holon.',
+    params: [
+      { name: 'holonId', type: 'string', description: 'Holon (community) ID', required: true },
+      { name: 'title', type: 'string', description: 'Task title', required: true },
+      { name: 'description', type: 'string', description: 'Task details' },
+    ],
+    async execute(params) {
+      return { ok: true, message: `Task "${params.title}" created in ${params.holonId}`, data: params };
+    },
+  },
+  {
+    name: 'logHours',
+    description: 'Log hours worked against a task.',
+    params: [
+      { name: 'taskId', type: 'string', description: 'Task ID', required: true },
+      { name: 'hours', type: 'number', description: 'Hours worked', required: true },
+      { name: 'note', type: 'string', description: 'Optional note' },
+    ],
+    async execute(params) {
+      return { ok: true, message: `Logged ${params.hours}h on ${params.taskId}`, data: params };
+    },
+  },
+  {
+    name: 'addToShoppingList',
+    description: 'Add an item to a holon shopping list.',
+    params: [
+      { name: 'holonId', type: 'string', description: 'Holon ID', required: true },
+      { name: 'item', type: 'string', description: 'Item name', required: true },
+      { name: 'quantity', type: 'number', description: 'Quantity' },
+    ],
+    async execute(params) {
+      return { ok: true, message: `Added ${params.item} to ${params.holonId} shopping list`, data: params };
+    },
+  },
+];
+
+const fallbackRegistry: CommandRegistry = {
+  list: () => fallbackCommands,
+  get: (name) => fallbackCommands.find((c) => c.name === name),
+};
+
+export async function loadRegistry(): Promise<CommandRegistry> {
+  try {
+    // FALLBACK: depends on Unit 15 (core/commands)
+    const mod: unknown = await import(
+      /* @vite-ignore */ '@holons/core/commands' as string
+    );
+    const candidate = (mod as { registry?: CommandRegistry; default?: CommandRegistry })
+      .registry ?? (mod as { default?: CommandRegistry }).default;
+    if (candidate && typeof candidate.list === 'function' && typeof candidate.get === 'function') {
+      return candidate;
+    }
+  } catch {
+    /* fall through to stub */
+  }
+  return fallbackRegistry;
+}
+
+/** Synchronous stub registry — useful for tests that can't await. */
+export function getFallbackRegistry(): CommandRegistry {
+  return fallbackRegistry;
+}

--- a/packages/ai-ui/src/index.ts
+++ b/packages/ai-ui/src/index.ts
@@ -1,2 +1,20 @@
-// Placeholder. Populated by Phase B unit `text-ui + ai-ui scaffolds`.
-export {};
+// @holons/ai-ui — Claude tool-use loop over @holons/core/commands.
+//
+// Re-exports the agent + tool-conversion helpers so the package can be
+// embedded in another runtime (e.g. a web service, telegram-ui adapter).
+// The bin entry lives in ./cli.ts and is wired via package.json.
+
+export { runAgent, type AgentOptions, type AgentResult } from './agent.js';
+export {
+  toolFromCommand,
+  toolsFromRegistry,
+  loadTools,
+  type ToolDefinition,
+} from './tools.js';
+export {
+  loadRegistry,
+  getFallbackRegistry,
+  type CoreCommand,
+  type CoreCommandParam,
+  type CommandRegistry,
+} from './commands.js';

--- a/packages/ai-ui/src/tools.test.ts
+++ b/packages/ai-ui/src/tools.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { toolsFromRegistry, toolFromCommand } from './tools.js';
+import { getFallbackRegistry } from './commands.js';
+
+describe('toolsFromRegistry', () => {
+  it('produces at least the 3 fallback tools', () => {
+    const tools = toolsFromRegistry();
+    expect(tools.length).toBeGreaterThanOrEqual(3);
+    const names = tools.map((t) => t.name);
+    expect(names).toContain('createTask');
+    expect(names).toContain('logHours');
+    expect(names).toContain('addToShoppingList');
+  });
+
+  it('marks required params in the JSON schema', () => {
+    const cmd = getFallbackRegistry().get('createTask');
+    expect(cmd).toBeDefined();
+    const tool = toolFromCommand(cmd!);
+    const schema = tool.input_schema as {
+      type: string;
+      properties: Record<string, { type: string }>;
+      required?: string[];
+    };
+    expect(schema.type).toBe('object');
+    expect(schema.required).toContain('holonId');
+    expect(schema.required).toContain('title');
+    expect(schema.required).not.toContain('description');
+    expect(schema.properties.holonId.type).toBe('string');
+  });
+
+  it('coerces numeric param types to JSON Schema number', () => {
+    const cmd = getFallbackRegistry().get('logHours')!;
+    const tool = toolFromCommand(cmd);
+    const props = (tool.input_schema as { properties: Record<string, { type: string }> })
+      .properties;
+    expect(props.hours.type).toBe('number');
+  });
+});

--- a/packages/ai-ui/src/tools.ts
+++ b/packages/ai-ui/src/tools.ts
@@ -1,0 +1,67 @@
+// Anthropic tool-use definitions derived from the @holons/core/commands registry.
+//
+// Each CoreCommand becomes an Anthropic tool with a JSON Schema input
+// generated from its `params`. Required-param enforcement, type coercion,
+// and execution are delegated back to the command's own `execute()`.
+
+import type Anthropic from '@anthropic-ai/sdk';
+import {
+  getFallbackRegistry,
+  loadRegistry,
+  type CommandRegistry,
+  type CoreCommand,
+  type CoreCommandParam,
+} from './commands.js';
+
+export type ToolDefinition = Anthropic.Tool;
+
+/** Map a CoreCommand to an Anthropic tool definition. */
+export function toolFromCommand(cmd: CoreCommand): ToolDefinition {
+  const properties: Record<string, { type: string; description: string }> = {};
+  const required: string[] = [];
+  for (const p of cmd.params) {
+    properties[p.name] = { type: jsonType(p.type), description: p.description };
+    if (p.required) required.push(p.name);
+  }
+  return {
+    name: cmd.name,
+    description: cmd.description,
+    input_schema: {
+      type: 'object',
+      properties,
+      ...(required.length > 0 ? { required } : {}),
+    },
+  };
+}
+
+function jsonType(t: CoreCommandParam['type']): string {
+  switch (t) {
+    case 'number':
+      return 'number';
+    case 'boolean':
+      return 'boolean';
+    default:
+      return 'string';
+  }
+}
+
+/**
+ * Synchronous: return tool definitions from the fallback (or the supplied) registry.
+ * Used by smoke tests and embedders that already hold a registry.
+ */
+export function toolsFromRegistry(registry?: CommandRegistry): ToolDefinition[] {
+  const reg = registry ?? getFallbackRegistry();
+  return reg.list().map(toolFromCommand);
+}
+
+/**
+ * Async: load `@holons/core/commands` (or fallback) and return its tools.
+ * Preferred entry point for the agent at runtime.
+ */
+export async function loadTools(): Promise<{
+  tools: ToolDefinition[];
+  registry: CommandRegistry;
+}> {
+  const registry = await loadRegistry();
+  return { tools: registry.list().map(toolFromCommand), registry };
+}

--- a/packages/text-ui/src/cli.ts
+++ b/packages/text-ui/src/cli.ts
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+// Bin entry for the `holons` CLI.
+//
+// Modes:
+//   holons                          → REPL
+//   holons --help                   → list commands
+//   holons <command> --help         → command-specific help
+//   holons <command> [--k=v ...]    → execute and render the result
+
+import { createInterface } from 'node:readline';
+import { parseArgv, parseLine, type ParsedCommand } from './parser.js';
+import { defaultRenderer, type CommandResult, type Renderer } from './renderer.js';
+import { loadRegistry, type CommandRegistry, type CoreCommand } from './commands.js';
+
+async function main(argv: string[]): Promise<number> {
+  const registry = await loadRegistry();
+  const renderer = defaultRenderer;
+  const args = argv.slice(2);
+
+  // No args → REPL.
+  if (args.length === 0) {
+    return runRepl(registry, renderer);
+  }
+
+  // Top-level help.
+  if (args[0] === '--help' || args[0] === '-h' || args[0] === 'help') {
+    printHelp(registry);
+    return 0;
+  }
+
+  return runOnce(args, registry, renderer);
+}
+
+async function runOnce(
+  argv: readonly string[],
+  registry: CommandRegistry,
+  renderer: Renderer,
+): Promise<number> {
+  const parsed = parseArgv(argv);
+  if (!parsed) {
+    printHelp(registry);
+    return 1;
+  }
+  return dispatch(parsed, registry, renderer);
+}
+
+async function dispatch(
+  parsed: ParsedCommand,
+  registry: CommandRegistry,
+  renderer: Renderer,
+): Promise<number> {
+  const cmd = registry.get(parsed.command);
+  if (!cmd) {
+    renderer.error(`unknown command: ${parsed.command}`);
+    printHelp(registry);
+    return 1;
+  }
+
+  if (parsed.params.help === true) {
+    printCommandHelp(cmd);
+    return 0;
+  }
+
+  const missing = cmd.params
+    .filter((p) => p.required && parsed.params[p.name] === undefined)
+    .map((p) => p.name);
+  if (missing.length > 0) {
+    renderer.error(`missing required params: ${missing.join(', ')}`);
+    printCommandHelp(cmd);
+    return 1;
+  }
+
+  try {
+    const raw = await cmd.execute(parsed.params);
+    const result: CommandResult = { ok: raw.ok, message: raw.message, data: raw.data };
+    renderer.render(result);
+    return raw.ok ? 0 : 1;
+  } catch (err) {
+    renderer.error(err);
+    return 1;
+  }
+}
+
+async function runRepl(registry: CommandRegistry, renderer: Renderer): Promise<number> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const prompt = 'holons> ';
+  process.stdout.write(`holons REPL — type "help" or a command, "exit" to quit\n`);
+  rl.setPrompt(prompt);
+  rl.prompt();
+
+  for await (const line of rl) {
+    const trimmed = line.trim();
+    if (trimmed === '' ) {
+      rl.prompt();
+      continue;
+    }
+    if (trimmed === 'exit' || trimmed === 'quit') break;
+    if (trimmed === 'help' || trimmed === '--help') {
+      printHelp(registry);
+      rl.prompt();
+      continue;
+    }
+    const parsed = parseLine(trimmed);
+    if (parsed) await dispatch(parsed, registry, renderer);
+    rl.prompt();
+  }
+  rl.close();
+  return 0;
+}
+
+function printHelp(registry: CommandRegistry): void {
+  const out = process.stdout;
+  out.write('holons — Holons text UI\n\n');
+  out.write('Usage:\n');
+  out.write('  holons                       Start interactive REPL\n');
+  out.write('  holons <command> [--k=v]     Run a command\n');
+  out.write('  holons <command> --help      Show command help\n\n');
+  out.write('Commands:\n');
+  const commands = registry.list();
+  if (commands.length === 0) {
+    out.write('  (no commands registered)\n');
+    return;
+  }
+  const width = Math.max(...commands.map((c) => c.name.length));
+  for (const c of commands) {
+    out.write(`  ${c.name.padEnd(width)}  ${c.description}\n`);
+  }
+}
+
+function printCommandHelp(cmd: CoreCommand): void {
+  const out = process.stdout;
+  out.write(`holons ${cmd.name} — ${cmd.description}\n\n`);
+  if (cmd.params.length === 0) {
+    out.write('  (no parameters)\n');
+    return;
+  }
+  out.write('Parameters:\n');
+  const width = Math.max(...cmd.params.map((p) => p.name.length));
+  for (const p of cmd.params) {
+    const req = p.required ? ' (required)' : '';
+    out.write(`  --${p.name.padEnd(width)}  [${p.type}]${req}  ${p.description}\n`);
+  }
+}
+
+main(process.argv).then(
+  (code) => process.exit(code),
+  (err) => {
+    defaultRenderer.error(err);
+    process.exit(1);
+  },
+);

--- a/packages/text-ui/src/commands.ts
+++ b/packages/text-ui/src/commands.ts
@@ -1,0 +1,95 @@
+// FALLBACK: depends on Unit 15 (core/commands)
+//
+// Once `@holons/core/commands` exists, this module re-exports it. Until then,
+// it ships an in-package stub registry so the CLI is self-bootstrapping for
+// the smoke test. The shape mirrors the target interface so consumers don't
+// need to change when the real registry lands.
+
+export interface CoreCommandParam {
+  name: string;
+  type: 'string' | 'number' | 'boolean';
+  description: string;
+  required?: boolean;
+}
+
+export interface CoreCommand {
+  name: string;
+  description: string;
+  params: CoreCommandParam[];
+  execute(params: Record<string, unknown>): Promise<{
+    ok: boolean;
+    message?: string;
+    data?: unknown;
+  }>;
+}
+
+export interface CommandRegistry {
+  list(): CoreCommand[];
+  get(name: string): CoreCommand | undefined;
+}
+
+// FALLBACK: depends on Unit 15 (core/commands)
+const fallbackCommands: CoreCommand[] = [
+  {
+    name: 'createTask',
+    description: 'Create a new task in a holon.',
+    params: [
+      { name: 'holonId', type: 'string', description: 'Holon (community) ID', required: true },
+      { name: 'title', type: 'string', description: 'Task title', required: true },
+      { name: 'description', type: 'string', description: 'Task details' },
+    ],
+    async execute(params) {
+      return { ok: true, message: `Task "${params.title}" created in ${params.holonId}`, data: params };
+    },
+  },
+  {
+    name: 'logHours',
+    description: 'Log hours worked against a task.',
+    params: [
+      { name: 'taskId', type: 'string', description: 'Task ID', required: true },
+      { name: 'hours', type: 'number', description: 'Hours worked', required: true },
+      { name: 'note', type: 'string', description: 'Optional note' },
+    ],
+    async execute(params) {
+      return { ok: true, message: `Logged ${params.hours}h on ${params.taskId}`, data: params };
+    },
+  },
+  {
+    name: 'addToShoppingList',
+    description: 'Add an item to a holon shopping list.',
+    params: [
+      { name: 'holonId', type: 'string', description: 'Holon ID', required: true },
+      { name: 'item', type: 'string', description: 'Item name', required: true },
+      { name: 'quantity', type: 'number', description: 'Quantity' },
+    ],
+    async execute(params) {
+      return { ok: true, message: `Added ${params.item} to ${params.holonId} shopping list`, data: params };
+    },
+  },
+];
+
+const fallbackRegistry: CommandRegistry = {
+  list: () => fallbackCommands,
+  get: (name) => fallbackCommands.find((c) => c.name === name),
+};
+
+/**
+ * Resolve the command registry. Tries `@holons/core/commands` first; falls
+ * back to the in-package stub if that module isn't published yet (Unit 15).
+ */
+export async function loadRegistry(): Promise<CommandRegistry> {
+  try {
+    // FALLBACK: depends on Unit 15 (core/commands)
+    const mod: unknown = await import(
+      /* @vite-ignore */ '@holons/core/commands' as string
+    );
+    const candidate = (mod as { registry?: CommandRegistry; default?: CommandRegistry })
+      .registry ?? (mod as { default?: CommandRegistry }).default;
+    if (candidate && typeof candidate.list === 'function' && typeof candidate.get === 'function') {
+      return candidate;
+    }
+  } catch {
+    // Module not available yet — use fallback.
+  }
+  return fallbackRegistry;
+}

--- a/packages/text-ui/src/index.ts
+++ b/packages/text-ui/src/index.ts
@@ -1,2 +1,12 @@
-// Placeholder. Populated by Phase B unit `text-ui + ai-ui scaffolds`.
-export {};
+// @holons/text-ui — framework-agnostic CLI/REPL renderer for Holons.
+// Re-exports parser + renderer so the package is also embeddable
+// (the bin entry lives in ./cli.ts and is wired via package.json).
+
+export { parseArgv, parseLine, type ParsedCommand } from './parser.js';
+export {
+  TextRenderer,
+  defaultRenderer,
+  formatResult,
+  type Renderer,
+  type CommandResult,
+} from './renderer.js';

--- a/packages/text-ui/src/parser.test.ts
+++ b/packages/text-ui/src/parser.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { parseArgv, parseLine } from './parser.js';
+
+describe('parser', () => {
+  it('returns null on empty input', () => {
+    expect(parseArgv([])).toBeNull();
+    expect(parseLine('')).toBeNull();
+  });
+
+  it('parses --key=value pairs', () => {
+    const r = parseArgv(['createTask', '--holonId=acme', '--title=ship it']);
+    expect(r).toEqual({
+      command: 'createTask',
+      params: { holonId: 'acme', title: 'ship it' },
+      positional: [],
+    });
+  });
+
+  it('parses --key value pairs with look-ahead', () => {
+    const r = parseArgv(['logHours', '--taskId', 't1', '--hours', '2.5']);
+    expect(r?.params).toEqual({ taskId: 't1', hours: 2.5 });
+  });
+
+  it('coerces numbers and booleans', () => {
+    const r = parseArgv(['cmd', '--count=42', '--active=true']);
+    expect(r?.params).toEqual({ count: 42, active: true });
+  });
+
+  it('handles bare flags and --no-flag', () => {
+    const r = parseArgv(['cmd', '--verbose', '--no-cache']);
+    expect(r?.params).toEqual({ verbose: true, cache: false });
+  });
+
+  it('tokenizes quoted REPL input', () => {
+    const r = parseLine('createTask --title "ship it" --holonId=acme');
+    expect(r?.params).toEqual({ title: 'ship it', holonId: 'acme' });
+  });
+});

--- a/packages/text-ui/src/parser.ts
+++ b/packages/text-ui/src/parser.ts
@@ -1,0 +1,106 @@
+// Slash-command parser for the Holons text UI.
+//
+// Surface:
+//   parseArgv(argv)  — parse process.argv-style tokens
+//   parseLine(line)  — parse a single REPL line (shlex-lite: handles quoted args)
+//
+// Grammar:
+//   <command> [--key=value] [--key value] [--flag] [positional...]
+// Bare `--key` is a boolean flag (true). `--no-key` sets the flag to false.
+
+export interface ParsedCommand {
+  command: string;
+  params: Record<string, unknown>;
+  positional: string[];
+}
+
+/** Parse a process.argv-style token array (already split by the shell). */
+export function parseArgv(argv: readonly string[]): ParsedCommand | null {
+  if (argv.length === 0) return null;
+  const [command, ...rest] = argv;
+  return { command, ...parseTokens(rest) };
+}
+
+/** Parse a single REPL input line (handles single + double quotes). */
+export function parseLine(line: string): ParsedCommand | null {
+  const tokens = tokenize(line);
+  return parseArgv(tokens);
+}
+
+function parseTokens(tokens: readonly string[]): {
+  params: Record<string, unknown>;
+  positional: string[];
+} {
+  const params: Record<string, unknown> = {};
+  const positional: string[] = [];
+
+  for (let i = 0; i < tokens.length; i++) {
+    const tok = tokens[i];
+    if (!tok.startsWith('--')) {
+      positional.push(tok);
+      continue;
+    }
+    const body = tok.slice(2);
+    const eq = body.indexOf('=');
+    if (eq >= 0) {
+      const key = body.slice(0, eq);
+      const value = body.slice(eq + 1);
+      params[key] = coerce(value);
+      continue;
+    }
+    // --no-foo → foo=false
+    if (body.startsWith('no-')) {
+      params[body.slice(3)] = false;
+      continue;
+    }
+    // Look ahead — `--key value` if next token isn't another flag.
+    const next = tokens[i + 1];
+    if (next !== undefined && !next.startsWith('--')) {
+      params[body] = coerce(next);
+      i++;
+    } else {
+      params[body] = true;
+    }
+  }
+
+  return { params, positional };
+}
+
+function coerce(value: string): unknown {
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  if (value !== '' && !isNaN(Number(value))) return Number(value);
+  return value;
+}
+
+function tokenize(line: string): string[] {
+  const out: string[] = [];
+  let buf = '';
+  let quote: '"' | "'" | null = null;
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (quote) {
+      if (ch === quote) {
+        quote = null;
+      } else {
+        buf += ch;
+      }
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t') {
+      if (buf !== '') {
+        out.push(buf);
+        buf = '';
+      }
+      continue;
+    }
+    buf += ch;
+  }
+  if (buf !== '') out.push(buf);
+  return out;
+}

--- a/packages/text-ui/src/renderer.test.ts
+++ b/packages/text-ui/src/renderer.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { formatResult } from './renderer.js';
+
+describe('renderer.formatResult', () => {
+  it('formats an ok status line', () => {
+    expect(formatResult({ ok: true, message: 'done' })).toBe('[ok] done');
+  });
+
+  it('formats an error status line', () => {
+    expect(formatResult({ ok: false, message: 'bad' })).toBe('[error] bad');
+  });
+
+  it('renders a list', () => {
+    const out = formatResult({ ok: true, message: 'items', list: ['a', 'b'] });
+    expect(out).toContain('  - a');
+    expect(out).toContain('  - b');
+  });
+
+  it('renders a table with headers', () => {
+    const out = formatResult({
+      ok: true,
+      message: 'rows',
+      table: { headers: ['id', 'name'], rows: [['1', 'alice'], ['22', 'bob']] },
+    });
+    expect(out).toContain('id  name');
+    expect(out).toMatch(/--\s+----/);
+    expect(out).toContain('1   alice');
+  });
+
+  it('serializes data as JSON', () => {
+    const out = formatResult({ ok: true, data: { x: 1 } });
+    expect(out).toContain('"x": 1');
+  });
+});

--- a/packages/text-ui/src/renderer.ts
+++ b/packages/text-ui/src/renderer.ts
@@ -1,0 +1,91 @@
+// Text-only renderer for CommandResult values.
+//
+// Renderers translate domain results into output bytes. The default
+// implementation prints to stdout/stderr as plain text. Other UIs
+// (web, telegram) can implement Renderer differently against the same
+// CommandResult shape.
+
+export interface CommandResult {
+  ok: boolean;
+  /** Short status line. */
+  message?: string;
+  /** Tabular data — first row is headers if `headers` omitted. */
+  table?: { headers?: string[]; rows: ReadonlyArray<ReadonlyArray<unknown>> };
+  /** Bullet list items. */
+  list?: ReadonlyArray<string>;
+  /** Free-form data appended as JSON for debugging. */
+  data?: unknown;
+}
+
+export interface Renderer {
+  render(result: CommandResult): void;
+  error(err: unknown): void;
+}
+
+/**
+ * Format a CommandResult as a plain-text string. Pure — no I/O.
+ * The default renderer wraps this and writes to stdout.
+ */
+export function formatResult(result: CommandResult): string {
+  const lines: string[] = [];
+  const prefix = result.ok ? 'ok' : 'error';
+  if (result.message) {
+    lines.push(`[${prefix}] ${result.message}`);
+  } else {
+    lines.push(`[${prefix}]`);
+  }
+
+  if (result.list && result.list.length > 0) {
+    for (const item of result.list) lines.push(`  - ${item}`);
+  }
+
+  if (result.table && result.table.rows.length > 0) {
+    lines.push(formatTable(result.table.headers, result.table.rows));
+  }
+
+  if (result.data !== undefined) {
+    lines.push(JSON.stringify(result.data, null, 2));
+  }
+
+  return lines.join('\n');
+}
+
+function formatTable(
+  headers: string[] | undefined,
+  rows: ReadonlyArray<ReadonlyArray<unknown>>,
+): string {
+  const allRows: string[][] = [];
+  if (headers) allRows.push(headers);
+  for (const r of rows) allRows.push(r.map((v) => String(v ?? '')));
+  if (allRows.length === 0) return '';
+
+  const widths = allRows[0].map((_, col) =>
+    Math.max(...allRows.map((r) => (r[col] ?? '').length)),
+  );
+  const fmt = (r: string[]) =>
+    r.map((cell, i) => cell.padEnd(widths[i])).join('  ');
+
+  const out: string[] = [fmt(allRows[0])];
+  if (headers) out.push(widths.map((w) => '-'.repeat(w)).join('  '));
+  for (let i = 1; i < allRows.length; i++) out.push(fmt(allRows[i]));
+  return out.join('\n');
+}
+
+/** Default text renderer — writes formatted output to stdout/stderr. */
+export class TextRenderer implements Renderer {
+  constructor(
+    private readonly out: NodeJS.WritableStream = process.stdout,
+    private readonly err: NodeJS.WritableStream = process.stderr,
+  ) {}
+
+  render(result: CommandResult): void {
+    this.out.write(formatResult(result) + '\n');
+  }
+
+  error(err: unknown): void {
+    const msg = err instanceof Error ? err.message : String(err);
+    this.err.write(`[error] ${msg}\n`);
+  }
+}
+
+export const defaultRenderer = new TextRenderer();


### PR DESCRIPTION
## Summary
- **`@holons/text-ui`** — framework-agnostic CLI/REPL renderer. `holons` bin parses argv into a command + params, dispatches via the registry, formats results through a pluggable `Renderer` interface (default = plain text). With no args it drops into a readline REPL.
- **`@holons/ai-ui`** — Claude tool-use loop. `tools.ts` derives Anthropic tool definitions from the registry; `agent.ts` runs the SDK loop (system prompt cached via `cache_control: ephemeral`, render-order means tools are cached too via the same breakpoint); `holons-ai` bin reads a NL prompt from argv/stdin and prints the agent's reply.
- Both packages design against the **`@holons/core/commands`** target interface (Unit 15) with a local fallback registry exposing `createTask`, `logHours`, `addToShoppingList` so smoke tests pass before Unit 15 lands. All fallback code is tagged `// FALLBACK: depends on Unit 15 (core/commands)`.
- 14 unit tests across both packages (parser, renderer, tool-schema generation) — all passing.

## Conflict-avoidance contract
- All new files live inside `packages/text-ui/src` and `packages/ai-ui/src`.
- No edits to `packages/core/src/index.ts`, root config files, or other packages' `package.json`.
- The two `commands.ts` fallback stubs are intentionally duplicated across the two packages — adding an inter-package import would require editing one of the package.json files (forbidden), and consolidating into `@holons/core` belongs to Unit 15. Both copies disappear when Unit 15 lands.

## Test plan
- [x] `pnpm install`
- [x] `pnpm -r --if-present typecheck` — passes for all packages
- [x] `pnpm -r --if-present build` — passes for all packages (incl. apps/web)
- [x] `pnpm -F @holons/text-ui test` — 11 tests pass
- [x] `pnpm -F @holons/ai-ui test` — 3 tests pass
- [x] Smoke text-ui: `pnpm -F @holons/text-ui exec node ./dist/cli.js --help` prints help with all 3 commands
- [x] Smoke ai-ui: `node -e "import('./packages/ai-ui/dist/tools.js').then(m => console.log(m.toolsFromRegistry().map(t => t.name)))"` prints `[ 'createTask', 'logHours', 'addToShoppingList' ]`
- [ ] Live agent run with `ANTHROPIC_API_KEY` set (manual — not gated by CI)

## Notes
- `@holons/core` test script (`vitest run`) fails on `sharedlogic` because the package has no test files yet. Pre-existing condition, not introduced here. Verified via `git stash` round-trip on the same branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
