### PR TITLE
core/checklists: extract checklist CRUD into @holons/core

### DIFF
--- a/packages/core/src/checklists/index.ts
+++ b/packages/core/src/checklists/index.ts
@@ -1,0 +1,7 @@
+// @holons/core/checklists — public surface.
+// UI-agnostic checklist subtask CRUD shared by the web (Svelte) and
+// telegram (Telegraf) UIs. See ./operations.ts for behavior, ./types.ts
+// for data shape.
+
+export * from './types.js';
+export * from './operations.js';

--- a/packages/core/src/checklists/operations.test.ts
+++ b/packages/core/src/checklists/operations.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CHECKLIST_TYPES,
+  appendItems,
+  clearChecklist,
+  createChecklist,
+  createChecklistObject,
+  deleteChecklist,
+  deleteCheckedItems,
+  getAllChecklists,
+  getChecklist,
+  getChecklistDisplayTitle,
+  getChecklistIcon,
+  getTypeDisplayName,
+  isSpecialChecklist,
+  migrateLegacyChecklistType,
+  parseItemsText,
+  removeItemAt,
+  removeItemByText,
+  toggleItem,
+} from './index.js';
+import type { Checklist, ChecklistStore } from './index.js';
+
+/** In-memory ChecklistStore matching the Holosphere DB shape. */
+function memStore(): ChecklistStore & {
+  data: Map<string, Map<string, Map<string, any>>>;
+} {
+  const data = new Map<string, Map<string, Map<string, any>>>();
+  const bucket = (h: string, b: string) => {
+    if (!data.has(h)) data.set(h, new Map());
+    const holon = data.get(h)!;
+    if (!holon.has(b)) holon.set(b, new Map());
+    return holon.get(b)!;
+  };
+  return {
+    data,
+    async get(h, b, k) {
+      return bucket(h, b).get(k) ?? null;
+    },
+    async getAll(h, b) {
+      return Array.from(bucket(h, b).values());
+    },
+    async put(h, b, value: any) {
+      bucket(h, b).set(value.id, value);
+    },
+    async delete(h, b, k) {
+      bucket(h, b).delete(k);
+    },
+  };
+}
+
+describe('checklists/helpers', () => {
+  it('createChecklistObject sets type-specific fields', () => {
+    const cl = createChecklistObject('q1', CHECKLIST_TYPES.QUEST, {
+      questId: 'q1',
+      parentTitle: 'My Quest',
+      holonId: 'h',
+      creator: 'u1',
+    });
+    expect(cl).toMatchObject({
+      id: 'q1',
+      type: 'quest',
+      questId: 'q1',
+      parentTitle: 'My Quest',
+      holonId: 'h',
+      creator: 'u1',
+      items: [],
+    });
+  });
+
+  it('migrateLegacyChecklistType infers from properties', () => {
+    expect(migrateLegacyChecklistType({ id: 'agenda', items: [] }).type).toBe(
+      'agenda'
+    );
+    expect(
+      migrateLegacyChecklistType({ id: 'x', items: [], questId: 'q' }).type
+    ).toBe('quest');
+    expect(
+      migrateLegacyChecklistType({ id: 'x', items: [], roleId: 'r' }).type
+    ).toBe('role');
+    expect(migrateLegacyChecklistType({ id: 'x', items: [] }).type).toBe(
+      'checklist'
+    );
+  });
+
+  it('isSpecialChecklist works for ids and records', () => {
+    expect(isSpecialChecklist('agenda')).toBe(true);
+    expect(isSpecialChecklist('shopping')).toBe(true);
+    expect(isSpecialChecklist('x')).toBe(false);
+    expect(
+      isSpecialChecklist({ id: 'x', items: [], type: CHECKLIST_TYPES.AGENDA })
+    ).toBe(true);
+  });
+
+  it('display + icon helpers', () => {
+    expect(getChecklistDisplayTitle({ id: 'foo', items: [] } as Checklist)).toBe(
+      'FOO'
+    );
+    expect(
+      getChecklistDisplayTitle({
+        id: 'x',
+        items: [],
+        parentTitle: 'Parent',
+      } as Checklist)
+    ).toBe('Parent');
+    expect(getChecklistIcon('agenda')).toBe('📅');
+    expect(getChecklistIcon('shopping')).toBe('🛒');
+    expect(getChecklistIcon({ id: 'x', items: [], type: 'role' })).toBe('👥');
+    expect(getTypeDisplayName('quest')).toBe('task');
+    expect(getTypeDisplayName('shopping')).toBe('shopping list');
+  });
+
+  it('parseItemsText drops blanks', () => {
+    expect(parseItemsText('a, , b , ,c')).toEqual([
+      { text: 'a', checked: false },
+      { text: 'b', checked: false },
+      { text: 'c', checked: false },
+    ]);
+    expect(parseItemsText('')).toEqual([]);
+  });
+});
+
+describe('checklists/CRUD', () => {
+  it('createChecklist rejects underscores and dupes', async () => {
+    const store = memStore();
+    expect((await createChecklist(store, 'h', 'bad_name')).ok).toBe(false);
+    const ok = await createChecklist(store, 'h', 'morning');
+    expect(ok.ok).toBe(true);
+    const dupe = await createChecklist(store, 'h', 'morning');
+    expect(dupe.ok).toBe(false);
+    if (!dupe.ok) expect(dupe.reason).toBe('exists');
+  });
+
+  it('getChecklist migrates legacy records on read', async () => {
+    const store = memStore();
+    await store.put('h', 'checklists', {
+      id: 'q1',
+      items: [],
+      questId: 'q1',
+    });
+    const cl = await getChecklist(store, 'h', 'q1');
+    expect(cl?.type).toBe('quest');
+  });
+
+  it('appendItems creates the checklist if missing', async () => {
+    const store = memStore();
+    const cl = await appendItems(
+      store,
+      'h',
+      'fresh',
+      [{ text: 'one', checked: false }],
+      { type: CHECKLIST_TYPES.CHECKLIST }
+    );
+    expect(cl.items).toHaveLength(1);
+    const reloaded = await getChecklist(store, 'h', 'fresh');
+    expect(reloaded?.items[0].text).toBe('one');
+  });
+
+  it('toggleItem flips checked', async () => {
+    const store = memStore();
+    await createChecklist(store, 'h', 'a');
+    await appendItems(store, 'h', 'a', [{ text: 'x', checked: false }]);
+    const after = await toggleItem(store, 'h', 'a', 0);
+    expect(after?.items[0].checked).toBe(true);
+    const back = await toggleItem(store, 'h', 'a', 0);
+    expect(back?.items[0].checked).toBe(false);
+    expect(await toggleItem(store, 'h', 'a', 99)).toBeNull();
+  });
+
+  it('removeItemAt + removeItemByText', async () => {
+    const store = memStore();
+    await createChecklist(store, 'h', 'a');
+    await appendItems(store, 'h', 'a', [
+      { text: 'x', checked: false },
+      { text: 'y', checked: false },
+      { text: 'z', checked: false },
+    ]);
+    const r1 = await removeItemAt(store, 'h', 'a', 1);
+    expect(r1?.removed.text).toBe('y');
+    expect(r1?.checklist.items.map((i) => i.text)).toEqual(['x', 'z']);
+
+    const r2 = await removeItemByText(store, 'h', 'a', 'z');
+    expect(r2.ok).toBe(true);
+    const r3 = await removeItemByText(store, 'h', 'a', 'nope');
+    expect(r3.ok).toBe(false);
+    if (!r3.ok) expect(r3.reason).toBe('item_missing');
+  });
+
+  it('deleteCheckedItems', async () => {
+    const store = memStore();
+    await createChecklist(store, 'h', 'a');
+    await appendItems(store, 'h', 'a', [
+      { text: 'x', checked: true },
+      { text: 'y', checked: false },
+      { text: 'z', checked: true },
+    ]);
+    const result = await deleteCheckedItems(store, 'h', 'a');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.removed).toHaveLength(2);
+      expect(result.checklist.items).toHaveLength(1);
+    }
+    const empty = await deleteCheckedItems(store, 'h', 'a');
+    expect(empty.ok).toBe(false);
+  });
+
+  it('clearChecklist behavior differs by type', async () => {
+    const store = memStore();
+    // Regular -> uncheck all
+    await createChecklist(store, 'h', 'a');
+    await appendItems(store, 'h', 'a', [
+      { text: 'x', checked: true },
+      { text: 'y', checked: true },
+    ]);
+    const r1 = await clearChecklist(store, 'h', 'a');
+    expect(r1.ok && r1.mode === 'unchecked_all').toBe(true);
+    if (r1.ok && r1.mode === 'unchecked_all') {
+      expect(r1.checklist.items.every((i) => !i.checked)).toBe(true);
+    }
+
+    // Agenda -> remove checked
+    await createChecklist(store, 'h', 'agenda', {
+      type: CHECKLIST_TYPES.AGENDA,
+    });
+    await appendItems(store, 'h', 'agenda', [
+      { text: 'a', checked: true },
+      { text: 'b', checked: false },
+    ]);
+    const r2 = await clearChecklist(store, 'h', 'agenda');
+    expect(r2.ok && r2.mode === 'removed_checked').toBe(true);
+    if (r2.ok && r2.mode === 'removed_checked') {
+      expect(r2.count).toBe(1);
+      expect(r2.checklist.items).toHaveLength(1);
+    }
+  });
+
+  it('deleteChecklist refuses special checklists', async () => {
+    const store = memStore();
+    await store.put('h', 'checklists', {
+      id: 'agenda',
+      type: 'agenda',
+      items: [],
+    });
+    const r = await deleteChecklist(store, 'h', 'agenda');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('special');
+    expect(await getChecklist(store, 'h', 'agenda')).not.toBeNull();
+  });
+
+  it('getAllChecklists migrates every record', async () => {
+    const store = memStore();
+    await store.put('h', 'checklists', { id: 'agenda', items: [] });
+    await store.put('h', 'checklists', { id: 'x', items: [], roleId: 'r' });
+    const all = await getAllChecklists(store, 'h');
+    const types = all.map((c) => c.type).sort();
+    expect(types).toEqual(['agenda', 'role']);
+  });
+});

--- a/packages/core/src/checklists/operations.ts
+++ b/packages/core/src/checklists/operations.ts
@@ -1,0 +1,369 @@
+// @holons/core/checklists — UI-agnostic CRUD + helpers for checklists.
+// Authoritative source: packages/telegram-ui/src/Checklists.js (HolonsBot).
+// Routes all storage through a generic ChecklistStore (Holosphere-shaped).
+
+import {
+  CHECKLIST_TYPES,
+  type Checklist,
+  type ChecklistItem,
+  type ChecklistStore,
+  type ChecklistType,
+  type CreateChecklistOptions,
+} from './types.js';
+
+const BUCKET = 'checklists';
+
+/** Build a fresh checklist record with type-specific fields. */
+export function createChecklistObject(
+  id: string,
+  type: ChecklistType,
+  options: CreateChecklistOptions = {}
+): Checklist {
+  const base: Checklist = {
+    id,
+    type,
+    items: [],
+    created: new Date(),
+    creator: options.creator ?? null,
+  };
+
+  switch (type) {
+    case CHECKLIST_TYPES.QUEST:
+      return {
+        ...base,
+        questId: options.questId,
+        parentTitle: options.parentTitle,
+        holonId: options.holonId,
+      };
+    case CHECKLIST_TYPES.ROLE:
+      return {
+        ...base,
+        roleId: options.roleId,
+        parentTitle: options.parentTitle,
+        holonId: options.holonId,
+      };
+    case CHECKLIST_TYPES.AGENDA:
+    case CHECKLIST_TYPES.SHOPPING:
+    case CHECKLIST_TYPES.CHECKLIST:
+    default:
+      return base;
+  }
+}
+
+/**
+ * Infer the {@link ChecklistType} of a legacy record that pre-dates the
+ * `type` field. Mutates the record in place AND returns it so callers can
+ * chain.
+ */
+export function migrateLegacyChecklistType(checklist: Checklist): Checklist {
+  if (!checklist) return checklist;
+  if (checklist.type) return checklist;
+
+  if (checklist.id === 'agenda' || checklist.id === 'shopping') {
+    checklist.type = checklist.id as ChecklistType;
+  } else if (
+    checklist.questId ||
+    checklist.questTitle ||
+    checklist.isTaskChecklist
+  ) {
+    checklist.type = CHECKLIST_TYPES.QUEST;
+  } else if (
+    checklist.roleId ||
+    checklist.roleTitle ||
+    checklist.isRoleChecklist
+  ) {
+    checklist.type = CHECKLIST_TYPES.ROLE;
+  } else {
+    checklist.type = CHECKLIST_TYPES.CHECKLIST;
+  }
+  return checklist;
+}
+
+/** Special checklists (agenda, shopping) cannot be deleted by users. */
+export function isSpecialChecklist(input: Checklist | string): boolean {
+  if (typeof input === 'string') {
+    return input === 'agenda' || input === 'shopping';
+  }
+  return (
+    input?.type === CHECKLIST_TYPES.AGENDA ||
+    input?.type === CHECKLIST_TYPES.SHOPPING
+  );
+}
+
+/** Display title — parentTitle (quest/role) wins, else uppercase id. */
+export function getChecklistDisplayTitle(checklist: Checklist): string {
+  if (checklist?.parentTitle) return checklist.parentTitle;
+  return (checklist?.id ?? '').toUpperCase();
+}
+
+/** Type-display name used in user-facing strings. */
+export function getTypeDisplayName(type: ChecklistType | undefined): string {
+  switch (type) {
+    case CHECKLIST_TYPES.QUEST:
+      return 'task';
+    case CHECKLIST_TYPES.ROLE:
+      return 'role task';
+    case CHECKLIST_TYPES.AGENDA:
+      return 'agenda';
+    case CHECKLIST_TYPES.SHOPPING:
+      return 'shopping list';
+    case CHECKLIST_TYPES.CHECKLIST:
+    default:
+      return 'checklist';
+  }
+}
+
+/** Emoji icon for a checklist (accepts a record or just an id string). */
+export function getChecklistIcon(input: Checklist | string): string {
+  if (typeof input === 'string') {
+    switch (input) {
+      case 'agenda':
+        return '📅';
+      case 'shopping':
+        return '🛒';
+      default:
+        return '📋';
+    }
+  }
+  switch (input?.type) {
+    case CHECKLIST_TYPES.AGENDA:
+      return '📅';
+    case CHECKLIST_TYPES.SHOPPING:
+      return '🛒';
+    case CHECKLIST_TYPES.ROLE:
+      return '👥';
+    case CHECKLIST_TYPES.QUEST:
+    case CHECKLIST_TYPES.CHECKLIST:
+    default:
+      return '📋';
+  }
+}
+
+/** Parse a comma-separated string into ChecklistItem[]; drops blanks. */
+export function parseItemsText(itemsText: string): ChecklistItem[] {
+  if (!itemsText) return [];
+  return itemsText
+    .split(',')
+    .map((t) => ({ text: t.trim(), checked: false }))
+    .filter((i) => i.text);
+}
+
+// ---------------------------------------------------------------------------
+// Storage operations
+// ---------------------------------------------------------------------------
+
+const hid = (holonId: string | number) => holonId.toString();
+
+/** Fetch a single checklist by id. Returns null if missing. */
+export async function getChecklist(
+  store: ChecklistStore,
+  holonId: string | number,
+  checklistId: string
+): Promise<Checklist | null> {
+  const cl = (await store.get(hid(holonId), BUCKET, checklistId)) as
+    | Checklist
+    | null
+    | undefined;
+  if (!cl) return null;
+  return migrateLegacyChecklistType(cl);
+}
+
+/** Fetch all checklists; legacy records are migrated to the typed shape. */
+export async function getAllChecklists(
+  store: ChecklistStore,
+  holonId: string | number
+): Promise<Checklist[]> {
+  const lists = (await store.getAll(hid(holonId), BUCKET)) ?? [];
+  return (lists as Checklist[]).map(migrateLegacyChecklistType);
+}
+
+/** Persist a checklist record. */
+export async function putChecklist(
+  store: ChecklistStore,
+  holonId: string | number,
+  checklist: Checklist
+): Promise<void> {
+  await store.put(hid(holonId), BUCKET, checklist);
+}
+
+/** Delete a checklist by id. Refuses to delete special (agenda/shopping). */
+export async function deleteChecklist(
+  store: ChecklistStore,
+  holonId: string | number,
+  checklistId: string
+): Promise<{ ok: boolean; reason?: 'special' | 'not_found' }> {
+  const cl = await getChecklist(store, holonId, checklistId);
+  if (cl && isSpecialChecklist(cl)) {
+    return { ok: false, reason: 'special' };
+  }
+  await store.delete(hid(holonId), BUCKET, checklistId);
+  return { ok: true };
+}
+
+/**
+ * Create a checklist if it doesn't exist. Returns `{ ok: false }` when the
+ * name collides or contains an underscore.
+ */
+export async function createChecklist(
+  store: ChecklistStore,
+  holonId: string | number,
+  name: string,
+  options: CreateChecklistOptions & { type?: ChecklistType } = {}
+): Promise<
+  | { ok: true; checklist: Checklist }
+  | { ok: false; reason: 'invalid_name' | 'exists' }
+> {
+  if (!name || name.includes('_')) {
+    return { ok: false, reason: 'invalid_name' };
+  }
+  const existing = await store.get(hid(holonId), BUCKET, name);
+  if (existing) return { ok: false, reason: 'exists' };
+  const type = options.type ?? CHECKLIST_TYPES.CHECKLIST;
+  const checklist = createChecklistObject(name, type, options);
+  await putChecklist(store, holonId, checklist);
+  return { ok: true, checklist };
+}
+
+/** Append items (parsed from comma-separated text) to an existing checklist. */
+export async function addItemsToChecklist(
+  store: ChecklistStore,
+  holonId: string | number,
+  checklistId: string,
+  itemsText: string
+): Promise<
+  | { ok: true; checklist: Checklist; added: ChecklistItem[] }
+  | { ok: false; reason: 'not_found' | 'no_items' }
+> {
+  const checklist = await getChecklist(store, holonId, checklistId);
+  if (!checklist) return { ok: false, reason: 'not_found' };
+  const newItems = parseItemsText(itemsText);
+  if (newItems.length === 0) return { ok: false, reason: 'no_items' };
+  checklist.items.push(...newItems);
+  await putChecklist(store, holonId, checklist);
+  return { ok: true, checklist, added: newItems };
+}
+
+/** Append already-shaped items to an existing-or-new checklist. */
+export async function appendItems(
+  store: ChecklistStore,
+  holonId: string | number,
+  checklistId: string,
+  items: ChecklistItem[],
+  fallbackOptions: CreateChecklistOptions & { type?: ChecklistType } = {}
+): Promise<Checklist> {
+  let checklist = await getChecklist(store, holonId, checklistId);
+  if (!checklist) {
+    checklist = createChecklistObject(
+      checklistId,
+      fallbackOptions.type ?? CHECKLIST_TYPES.CHECKLIST,
+      fallbackOptions
+    );
+  }
+  if (items.length > 0) {
+    checklist.items.push(...items);
+    await putChecklist(store, holonId, checklist);
+  }
+  return checklist;
+}
+
+/** Toggle the checked state of a single item by index. */
+export async function toggleItem(
+  store: ChecklistStore,
+  holonId: string | number,
+  checklistId: string,
+  itemIndex: number
+): Promise<Checklist | null> {
+  const checklist = await getChecklist(store, holonId, checklistId);
+  if (!checklist || !checklist.items[itemIndex]) return null;
+  checklist.items[itemIndex].checked = !checklist.items[itemIndex].checked;
+  await putChecklist(store, holonId, checklist);
+  return checklist;
+}
+
+/** Remove an item by index. */
+export async function removeItemAt(
+  store: ChecklistStore,
+  holonId: string | number,
+  checklistId: string,
+  itemIndex: number
+): Promise<{ checklist: Checklist; removed: ChecklistItem } | null> {
+  const checklist = await getChecklist(store, holonId, checklistId);
+  if (!checklist || !checklist.items[itemIndex]) return null;
+  const [removed] = checklist.items.splice(itemIndex, 1);
+  await putChecklist(store, holonId, checklist);
+  return { checklist, removed };
+}
+
+/** Remove the first item whose text matches exactly. */
+export async function removeItemByText(
+  store: ChecklistStore,
+  holonId: string | number,
+  checklistId: string,
+  text: string
+): Promise<
+  | { ok: true; checklist: Checklist }
+  | { ok: false; reason: 'not_found' | 'item_missing' }
+> {
+  const checklist = await getChecklist(store, holonId, checklistId);
+  if (!checklist) return { ok: false, reason: 'not_found' };
+  const before = checklist.items.length;
+  checklist.items = checklist.items.filter((i) => i.text !== text);
+  if (checklist.items.length === before) {
+    return { ok: false, reason: 'item_missing' };
+  }
+  await putChecklist(store, holonId, checklist);
+  return { ok: true, checklist };
+}
+
+/** Drop all checked items. Returns the removed items. */
+export async function deleteCheckedItems(
+  store: ChecklistStore,
+  holonId: string | number,
+  checklistId: string
+): Promise<
+  | { ok: true; checklist: Checklist; removed: ChecklistItem[] }
+  | { ok: false; reason: 'not_found' | 'none_checked' }
+> {
+  const checklist = await getChecklist(store, holonId, checklistId);
+  if (!checklist) return { ok: false, reason: 'not_found' };
+  const removed = checklist.items.filter((i) => i.checked);
+  if (removed.length === 0) return { ok: false, reason: 'none_checked' };
+  checklist.items = checklist.items.filter((i) => !i.checked);
+  await putChecklist(store, holonId, checklist);
+  return { ok: true, checklist, removed };
+}
+
+/**
+ * Clear-completion behavior used by the "🔄 Clear All" / "🗑️ Clear Completed"
+ * buttons. For agenda lists this removes checked items; for everything else
+ * it un-checks every item.
+ */
+export async function clearChecklist(
+  store: ChecklistStore,
+  holonId: string | number,
+  checklistId: string
+): Promise<
+  | { ok: true; checklist: Checklist; mode: 'removed_checked'; count: number }
+  | { ok: true; checklist: Checklist; mode: 'unchecked_all' }
+  | { ok: false; reason: 'not_found' | 'nothing_to_remove' }
+> {
+  const checklist = await getChecklist(store, holonId, checklistId);
+  if (!checklist) return { ok: false, reason: 'not_found' };
+
+  if (checklist.type === CHECKLIST_TYPES.AGENDA) {
+    const checkedCount = checklist.items.filter((i) => i.checked).length;
+    if (checkedCount === 0) return { ok: false, reason: 'nothing_to_remove' };
+    checklist.items = checklist.items.filter((i) => !i.checked);
+    await putChecklist(store, holonId, checklist);
+    return {
+      ok: true,
+      checklist,
+      mode: 'removed_checked',
+      count: checkedCount,
+    };
+  }
+
+  checklist.items = checklist.items.map((i) => ({ ...i, checked: false }));
+  await putChecklist(store, holonId, checklist);
+  return { ok: true, checklist, mode: 'unchecked_all' };
+}

--- a/packages/core/src/checklists/types.ts
+++ b/packages/core/src/checklists/types.ts
@@ -1,0 +1,69 @@
+// @holons/core/checklists — domain types for checklist subtask CRUD.
+// UI-agnostic. Mirrors the data shape used by the Telegram bot
+// (packages/telegram-ui/src/Checklists.js) and the web Svelte UI
+// (apps/web/src/components/Checklists.svelte).
+
+/** Standard checklist types supported across Holons UIs. */
+export const CHECKLIST_TYPES = {
+  CHECKLIST: 'checklist',
+  AGENDA: 'agenda',
+  SHOPPING: 'shopping',
+  QUEST: 'quest',
+  ROLE: 'role',
+} as const;
+
+export type ChecklistType =
+  (typeof CHECKLIST_TYPES)[keyof typeof CHECKLIST_TYPES];
+
+/** A single checkbox item on a checklist. */
+export interface ChecklistItem {
+  text: string;
+  checked: boolean;
+}
+
+/** Persisted checklist record. */
+export interface Checklist {
+  id: string;
+  type?: ChecklistType;
+  items: ChecklistItem[];
+  created?: Date | string;
+  creator?: string | number | null;
+  // Quest/role linkage (optional, present on subtask checklists)
+  questId?: string;
+  roleId?: string;
+  parentTitle?: string;
+  holonId?: string | number;
+  // Legacy fields used only for migration of old records
+  questTitle?: string;
+  roleTitle?: string;
+  isTaskChecklist?: boolean;
+  isRoleChecklist?: boolean;
+}
+
+/** Options accepted by {@link createChecklistObject}. */
+export interface CreateChecklistOptions {
+  creator?: string | number | null;
+  questId?: string;
+  roleId?: string;
+  parentTitle?: string;
+  holonId?: string | number;
+}
+
+/**
+ * Minimal storage interface required by core checklist operations.
+ * Matches the Holosphere DB shape used by HolonsBot:
+ *   db.get(holonId, bucket, key)
+ *   db.getAll(holonId, bucket)
+ *   db.put(holonId, bucket, value)
+ *   db.delete(holonId, bucket, key)
+ */
+export interface ChecklistStore {
+  get(
+    holonId: string,
+    bucket: string,
+    key: string
+  ): Promise<any> | any;
+  getAll(holonId: string, bucket: string): Promise<any[]> | any[];
+  put(holonId: string, bucket: string, value: any): Promise<unknown> | unknown;
+  delete(holonId: string, bucket: string, key: string): Promise<unknown> | unknown;
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts", "src/**/*.spec.ts"]
 }

--- a/packages/telegram-ui/src/Checklists.js
+++ b/packages/telegram-ui/src/Checklists.js
@@ -1,22 +1,35 @@
 /**
  * @fileoverview Checklist management for HolonsBot.
+ *
+ * Telegraf UI shell. All storage + domain helpers live in
+ * `@holons/core/checklists` and are re-exported below so existing
+ * static call sites (e.g. `Checklists.CHECKLIST_TYPES`) keep working.
+ *
  * @module src/Checklists
  */
 import { Markup } from 'telegraf';
 import i18next from 'i18next';
 import * as utils from './utilities.js';
-
-/**
- * Standard checklist types supported by the system.
- * @constant {Object.<string, string>}
- */
-const CHECKLIST_TYPES = {
-    CHECKLIST: 'checklist',
-    AGENDA: 'agenda',
-    SHOPPING: 'shopping',
-    QUEST: 'quest',
-    ROLE: 'role'
-};
+import {
+    CHECKLIST_TYPES,
+    createChecklistObject,
+    isSpecialChecklist,
+    getChecklistDisplayTitle,
+    getTypeDisplayName,
+    getChecklistIcon,
+    getChecklist,
+    getAllChecklists,
+    deleteChecklist as coreDeleteChecklist,
+    createChecklist as coreCreateChecklist,
+    addItemsToChecklist as coreAddItemsToChecklist,
+    appendItems as coreAppendItems,
+    toggleItem as coreToggleItem,
+    removeItemAt as coreRemoveItemAt,
+    removeItemByText as coreRemoveItemByText,
+    deleteCheckedItems as coreDeleteCheckedItems,
+    clearChecklist as coreClearChecklist,
+    parseItemsText,
+} from '@holons/core/checklists';
 
 /**
  * Checklist management class for creating and managing various types of checklists.
@@ -79,59 +92,17 @@ class Checklists {
         this.bot.action('back_to_all_checklists', (ctx) => this.handleBackToChecklists(ctx));
     }
 
-    // Helper method to create a standardized checklist object
+    // Thin delegations to @holons/core/checklists.
     createChecklistObject(id, type, options = {}) {
-        const baseChecklist = {
-            id: id,
-            type: type,
-            items: [],
-            created: new Date(),
-            creator: options.creator || null
-        };
-
-        // Add type-specific fields
-        switch (type) {
-            case CHECKLIST_TYPES.QUEST:
-                return {
-                    ...baseChecklist,
-                    questId: options.questId,
-                    parentTitle: options.parentTitle,
-                    holonId: options.holonId
-                };
-            case CHECKLIST_TYPES.ROLE:
-                return {
-                    ...baseChecklist,
-                    roleId: options.roleId,
-                    parentTitle: options.parentTitle,
-                    holonId: options.holonId
-                };
-            case CHECKLIST_TYPES.AGENDA:
-            case CHECKLIST_TYPES.SHOPPING:
-                return baseChecklist;
-            case CHECKLIST_TYPES.CHECKLIST:
-            default:
-                return baseChecklist;
-        }
+        return createChecklistObject(id, type, options);
     }
 
-    // Helper method to get display title for any checklist
     getChecklistDisplayTitle(checklist) {
-        if (checklist.parentTitle) {
-            return checklist.parentTitle;
-        }
-        return checklist.id.toUpperCase();
+        return getChecklistDisplayTitle(checklist);
     }
 
-    // Helper method to get checklist type display name
     getTypeDisplayName(type) {
-        switch (type) {
-            case CHECKLIST_TYPES.QUEST: return 'task';
-            case CHECKLIST_TYPES.ROLE: return 'role task';
-            case CHECKLIST_TYPES.AGENDA: return 'agenda';
-            case CHECKLIST_TYPES.SHOPPING: return 'shopping list';
-            case CHECKLIST_TYPES.CHECKLIST: 
-            default: return 'checklist';
-        }
+        return getTypeDisplayName(type);
     }
 
 
@@ -153,7 +124,7 @@ class Checklists {
                 }
 
                 // Check if checklist already exists
-                if (await this.db.get(holonId.toString(), 'checklists', name)) {
+                if (await getChecklist(this.db, holonId, name)) {
                     return { valid: false, error: `Checklist "${name}" already exists.` };
                 }
 
@@ -163,9 +134,15 @@ class Checklists {
                 const holonId = ctx.chat.id;
 
                 // Create the new empty checklist with standardized type
-                const checklist = this.createChecklistObject(name, CHECKLIST_TYPES.CHECKLIST, { creator: ctx.from.id });
-
-                await this.db.put(holonId.toString(), 'checklists', checklist);
+                const result = await coreCreateChecklist(this.db, holonId, name, {
+                    creator: ctx.from.id,
+                    type: CHECKLIST_TYPES.CHECKLIST,
+                });
+                if (!result.ok) {
+                    // Validation already gates this path; bail silently if a
+                    // race produced a duplicate / bad name.
+                    return;
+                }
 
                 // Re-show the list of all checklists
                 await this.showAllChecklists(ctx, { editMessageId: originalMessageId, holonId: holonId });
@@ -187,29 +164,11 @@ class Checklists {
             return;
         }
 
-        let lists = await this.db.getAll(holonId.toString(), 'checklists');
-        
-        // Ensure all lists have a type, defaulting to 'checklist' for backward compatibility
-        lists = lists.map(list => {
-            if (!list.type) {
-                // Migrate legacy checklists based on their properties
-                if (['agenda', 'shopping'].includes(list.id)) {
-                    list.type = list.id;
-                } else if (list.questId || list.questTitle || list.isTaskChecklist) {
-                    list.type = CHECKLIST_TYPES.QUEST;
-                } else if (list.roleId || list.roleTitle || list.isRoleChecklist) {
-                    list.type = CHECKLIST_TYPES.ROLE;
-                } else {
-                    list.type = CHECKLIST_TYPES.CHECKLIST;
-                }
-            }
-            return list;
-        });
-
-        // Filter out subtask checklists and show only regular and special checklists
-        lists = lists.filter(list => 
-            list.type === CHECKLIST_TYPES.CHECKLIST || 
-            list.type === CHECKLIST_TYPES.AGENDA || 
+        // Fetch + migrate via core; filter to user-visible top-level checklists.
+        let lists = await getAllChecklists(this.db, holonId);
+        lists = lists.filter(list =>
+            list.type === CHECKLIST_TYPES.CHECKLIST ||
+            list.type === CHECKLIST_TYPES.AGENDA ||
             list.type === CHECKLIST_TYPES.SHOPPING
         );
         
@@ -277,35 +236,31 @@ class Checklists {
 
     async createChecklist(ctx) {
         const name = ctx.message.text.split('/newchecklist ')[1]?.trim(); // Extract name after command
-        
+
         // Delete the user's command message immediately
         await ctx.deleteMessage(ctx.message.message_id).catch(() => {});
-        
+
         if (!name) {
              await ctx.reply('Please specify a checklist name. eg: /newchecklist morning')
                          .then(msg => setTimeout(() => ctx.deleteMessage(msg.message_id).catch(() => {}), 5000)); // Delete after 5s
             return;
         }
 
-        // Validate name: no underscores
-        if (name.includes('_')) {
-             await ctx.reply('Checklist names cannot contain underscores (_). Please use a different name.')
-                         .then(msg => setTimeout(() => ctx.deleteMessage(msg.message_id).catch(() => {}), 5000)); // Delete after 5s
-            return;
-        }
-
         let holonId = ctx.chat.id;
-        if (await this.db.get(holonId.toString(), 'checklists', name)) {
-             await ctx.reply(`Checklist "${name}" already exists.`)
-                         .then(msg => setTimeout(() => ctx.deleteMessage(msg.message_id).catch(() => {}), 5000)); // Delete after 5s
+        const result = await coreCreateChecklist(this.db, holonId, name, {
+            creator: ctx.from.id,
+            type: CHECKLIST_TYPES.CHECKLIST,
+        });
+
+        if (!result.ok) {
+            const message = result.reason === 'invalid_name'
+                ? 'Checklist names cannot contain underscores (_). Please use a different name.'
+                : `Checklist "${name}" already exists.`;
+            await ctx.reply(message)
+                        .then(msg => setTimeout(() => ctx.deleteMessage(msg.message_id).catch(() => {}), 5000));
             return;
         }
 
-        // Create the new empty checklist with standardized type
-        const checklist = this.createChecklistObject(name, CHECKLIST_TYPES.CHECKLIST, { creator: ctx.from.id });
-
-        await this.db.put(holonId.toString(), 'checklists', checklist);
-        
         // Confirm creation and delete the confirmation after a few seconds
          await ctx.reply(`Created checklist "${name}".`)
                      .then(msg => setTimeout(() => ctx.deleteMessage(msg.message_id).catch(() => {}), 3000)); // Delete after 3s
@@ -357,35 +312,35 @@ class Checklists {
         
         try {
             // Get or create the checklist
-            const checklist = await this.db.get(holonId.toString(), 'checklists', checklistId);
+            const checklist = await getChecklist(this.db, holonId, checklistId);
 
             if (!checklist) {
                 // Check if this might be a quest ID instead, by looking for a quest with this ID
                 const quest = await this.db.get(holonId.toString(), 'quests', checklistId);
-                
+
                 if (quest) {
                     // This might be a quest's task list - check if it has a checklistId
                     if (quest.checklistId) {
                         // Try to get the actual checklist
-                        const questChecklist = await this.db.get(holonId.toString(), 'checklists', quest.checklistId.toString());
+                        const questChecklist = await getChecklist(this.db, holonId, quest.checklistId.toString());
                         if (questChecklist) {
                             // Process items for the quest's checklist
                             return await this.processChecklistItems(questChecklist, itemsText, holonId, ctx);
                         }
                     }
-                    
+
                     // Checklist doesn't exist yet, but this is a valid quest ID
                     // Create a new checklist for this quest
-                    const newChecklist = this.createChecklistObject(checklistId, CHECKLIST_TYPES.QUEST, {
+                    const newChecklist = createChecklistObject(checklistId, CHECKLIST_TYPES.QUEST, {
                         creator: ctx.from.id,
                         questId: quest.id,
                         parentTitle: quest.title,
                         holonId: holonId
                     });
-                    
+
                     return await this.processChecklistItems(newChecklist, itemsText, holonId, ctx);
                 }
-                
+
                 // Check if this might be a role ID instead
                 const role = await this.db.get(holonId.toString(), 'roles', checklistId);
 
@@ -393,83 +348,73 @@ class Checklists {
                     // This might be a role's task list - check if it has a checklistId
                     if (role.checklistId) {
                         // Try to get the actual checklist
-                        const roleChecklist = await this.db.get(holonId.toString(), 'checklists', role.checklistId.toString());
+                        const roleChecklist = await getChecklist(this.db, holonId, role.checklistId.toString());
                         if (roleChecklist) {
                             // Process items for the role's checklist
                             return await this.processChecklistItems(roleChecklist, itemsText, holonId, ctx);
                         }
                     }
-                    
+
                     // Checklist doesn't exist yet, but this is a valid role ID
                     // Create a new checklist for this role
-                    const newChecklist = this.createChecklistObject(checklistId, CHECKLIST_TYPES.ROLE, {
+                    const newChecklist = createChecklistObject(checklistId, CHECKLIST_TYPES.ROLE, {
                         creator: ctx.from.id,
                         roleId: role.id,
                         parentTitle: role.title,
                         holonId: holonId
                     });
-                    
+
                     return await this.processChecklistItems(newChecklist, itemsText, holonId, ctx);
                 }
-                
+
                 // Create a new regular checklist
-                const newChecklist = this.createChecklistObject(checklistId, CHECKLIST_TYPES.CHECKLIST, {
+                const newChecklist = createChecklistObject(checklistId, CHECKLIST_TYPES.CHECKLIST, {
                     creator: ctx.from.id
                 });
-                
+
                 return await this.processChecklistItems(newChecklist, itemsText, holonId, ctx);
             }
-            
-            // Existing checklist found - Migrate legacy type if needed
-            if (!checklist.type) {
-                if (['agenda', 'shopping'].includes(checklist.id)) {
-                    checklist.type = checklist.id;
-                } else if (checklist.questId || checklist.questTitle || checklist.isTaskChecklist) {
-                    checklist.type = CHECKLIST_TYPES.QUEST;
-                } else if (checklist.roleId || checklist.roleTitle || checklist.isRoleChecklist) {
-                    checklist.type = CHECKLIST_TYPES.ROLE;
-                } else {
-                    checklist.type = CHECKLIST_TYPES.CHECKLIST;
-                }
-            }
+
+            // Existing checklist already migrated by getChecklist()
             return await this.processChecklistItems(checklist, itemsText, holonId, ctx);
-            
+
         } catch (error) {
             console.error('Error adding items with /additem command:', error);
             ctx.reply('Error adding items to checklist');
         }
     }
-    
+
     // Helper method to process items for a checklist
     async processChecklistItems(checklist, itemsText, holonId, ctx) {
-        // Parse and add items
-        const newItems = itemsText.split(',').map(text => ({
-            text: text.trim(),
-            checked: false
-        })).filter(item => item.text);
-        
+        const newItems = parseItemsText(itemsText);
+
         if (newItems.length === 0) {
             ctx.reply('No valid items found. Please use comma-separated list: /additem [checklist-name] [item1, item2, item3]');
             return null;
         }
-        
-        // Add the items to the checklist
-        checklist.items.push(...newItems);
-        await this.db.put(holonId.toString(), 'checklists', checklist);
-        
-        // Show success message with added items
+
+        // Append + persist via core (creates the checklist if it isn't saved yet).
+        // Use the returned record so the keyboard reflects the new items.
+        const updated = await coreAppendItems(this.db, holonId, checklist.id, newItems, {
+            type: checklist.type,
+            creator: checklist.creator,
+            questId: checklist.questId,
+            roleId: checklist.roleId,
+            parentTitle: checklist.parentTitle,
+            holonId: checklist.holonId,
+        });
+
         const addedItemsText = newItems.map(item => `"${item.text}"`).join(', ');
-        const checklistTypeName = this.getTypeDisplayName(checklist.type);
-        const displayTitle = this.getChecklistDisplayTitle(checklist);
+        const checklistTypeName = this.getTypeDisplayName(updated.type);
+        const displayTitle = this.getChecklistDisplayTitle(updated);
         ctx.reply(`Added ${newItems.length} items to ${checklistTypeName} "${displayTitle}": ${addedItemsText}`);
-        
-        // Show the updated checklist
+
         await ctx.reply(
-            `${this.getChecklistIcon(checklist)} ${displayTitle}:`,
-            this.getChecklistKeyboard(checklist)
+            `${this.getChecklistIcon(updated)} ${displayTitle}:`,
+            this.getChecklistKeyboard(updated)
         );
-        
-        return checklist;
+
+        return updated;
     }
 
     async removeChecklistItem(ctx) {
@@ -480,23 +425,18 @@ class Checklists {
         }
 
         const itemText = itemWords.join(' ');
-        let holonId = ctx.chat.id;
-        let checklist = await this.db.get(holonId.toString(), 'checklists', listName);
+        const holonId = ctx.chat.id;
+        const result = await coreRemoveItemByText(this.db, holonId, listName, itemText);
 
-        if (!checklist) {
-            ctx.reply(`Checklist "${listName}" not found.`);
+        if (!result.ok) {
+            if (result.reason === 'not_found') {
+                ctx.reply(`Checklist "${listName}" not found.`);
+            } else {
+                ctx.reply(`Item "${itemText}" not found in checklist "${listName}".`);
+            }
             return;
         }
 
-        const initialLength = checklist.items.length;
-        checklist.items = checklist.items.filter(item => item.text !== itemText);
-
-        if (checklist.items.length === initialLength) {
-            ctx.reply(`Item "${itemText}" not found in checklist "${listName}".`);
-            return;
-        }
-
-        await this.db.put(holonId.toString(), 'checklists', checklist);
         ctx.reply(`Removed "${itemText}" from checklist "${listName}".`);
     }
 
@@ -507,8 +447,8 @@ class Checklists {
             return;
         }
 
-        let holonId = ctx.chat.id;
-        await this.db.delete(holonId.toString(), 'checklists', name);
+        const holonId = ctx.chat.id;
+        await coreDeleteChecklist(this.db, holonId, name);
         ctx.reply(`Removed checklist "${name}".`);
     }
 
@@ -519,7 +459,7 @@ class Checklists {
             return;
         }
         try {
-            const checklist = await this.db.get(holonId.toString(), 'checklists', checklistId);
+            const checklist = await getChecklist(this.db, holonId, checklistId);
             if (!checklist) {
                 await ctx.answerCbQuery('Checklist not found');
                 return;
@@ -530,7 +470,7 @@ class Checklists {
                 `${this.getChecklistIcon(checklist)} ${this.getChecklistDisplayTitle(checklist)}:`,
                 this.getChecklistKeyboard(checklist)
             ).catch((err) => { console.log(err) });
-            
+
             await ctx.answerCbQuery().catch()
         } catch (error) {
             console.error('Error showing checklist:', error);
@@ -540,16 +480,13 @@ class Checklists {
 
     async toggleCheckItem(ctx) {
         const [listName, itemIndex] = ctx.match[1].split('_');
-        let holonId = ctx.chat.id;
-        let checklist = await this.db.get(holonId.toString(), 'checklists', listName);
+        const holonId = ctx.chat.id;
+        const checklist = await coreToggleItem(this.db, holonId, listName, parseInt(itemIndex, 10));
 
-        if (!checklist || !checklist.items[itemIndex]) {
+        if (!checklist) {
             await ctx.answerCbQuery('Item not found');
             return;
         }
-
-        checklist.items[itemIndex].checked = !checklist.items[itemIndex].checked;
-        await this.db.put(holonId.toString(), 'checklists', checklist);
 
         const icon = this.getChecklistIcon(checklist);
         const title = `${icon} ${this.getChecklistDisplayTitle(checklist)}:`;
@@ -563,25 +500,12 @@ class Checklists {
     async handleChecklistButton(ctx) {
         await ctx.answerCbQuery().catch()
         const listName = ctx.match[1];
-        let holonId = ctx.chat.id;
-        let checklist = await this.db.get(holonId.toString(), 'checklists', listName);
-        
+        const holonId = ctx.chat.id;
+        const checklist = await getChecklist(this.db, holonId, listName);
+
         if (!checklist) {
             console.log(`Checklist "${listName}" not found for chat ${holonId}.`);
             return;
-        }
-
-        // Migrate legacy checklist type if needed
-        if (!checklist.type) {
-            if (['agenda', 'shopping'].includes(checklist.id)) {
-                checklist.type = checklist.id;
-            } else if (checklist.questId || checklist.questTitle || checklist.isTaskChecklist) {
-                checklist.type = CHECKLIST_TYPES.QUEST;
-            } else if (checklist.roleId || checklist.roleTitle || checklist.isRoleChecklist) {
-                checklist.type = CHECKLIST_TYPES.ROLE;
-            } else {
-                checklist.type = CHECKLIST_TYPES.CHECKLIST;
-            }
         }
 
         // Get the standard keyboard
@@ -610,34 +534,23 @@ class Checklists {
 
     async clearChecklist(ctx) {
         const listName = ctx.match[1];
-        let holonId = ctx.chat.id;
-        let checklist = await this.db.get(holonId.toString(), 'checklists', listName);
+        const holonId = ctx.chat.id;
+        const result = await coreClearChecklist(this.db, holonId, listName);
 
-        if (!checklist) {
-            await ctx.answerCbQuery('Checklist not found');
+        if (!result.ok) {
+            const message = result.reason === 'not_found'
+                ? 'Checklist not found'
+                : 'No checked items to remove';
+            await ctx.answerCbQuery(message);
             return;
         }
 
-        if (checklist.type === CHECKLIST_TYPES.AGENDA) {
-            // For agenda, only remove checked items
-            const checkedItems = checklist.items.filter(item => item.checked);
-            if (checkedItems.length === 0) {
-                await ctx.answerCbQuery('No checked items to remove');
-                return;
-            }
-            checklist.items = checklist.items.filter(item => !item.checked);
-            await ctx.answerCbQuery(`Removed ${checkedItems.length} completed items ✓`);
-        } else {
-            // For other checklists, clear all checks
-            checklist.items = checklist.items.map(item => ({
-                ...item,
-                checked: false
-            }));
-            await ctx.answerCbQuery('Cleared all items');
-        }
+        const cb = result.mode === 'removed_checked'
+            ? `Removed ${result.count} completed items ✓`
+            : 'Cleared all items';
+        await ctx.answerCbQuery(cb);
 
-        await this.db.put(holonId.toString(), 'checklists', checklist);
-        
+        const checklist = result.checklist;
         const icon = this.getChecklistIcon(checklist);
         const title = `${icon} ${this.getChecklistDisplayTitle(checklist)}:`;
 
@@ -730,20 +643,19 @@ class Checklists {
                 const holonId = ctx.chat.id;
 
                 try {
-                    const checklist = await this.db.get(holonId.toString(), 'checklists', checklistId.toString()) ||
-                        this.createChecklistObject(checklistId, CHECKLIST_TYPES.CHECKLIST, { creator: ctx.from.id });
-
                     // Convert array items to checklist item objects
                     const newItems = newItemsArray.map(text => ({
                         text: text,
-                        checked: false
+                        checked: false,
                     }));
 
-                    // Add items
-                    if (newItems.length > 0) {
-                        checklist.items.push(...newItems);
-                        await this.db.put(holonId.toString(), 'checklists', checklist);
-                    }
+                    const checklist = await coreAppendItems(
+                        this.db,
+                        holonId,
+                        checklistId.toString(),
+                        newItems,
+                        { type: CHECKLIST_TYPES.CHECKLIST, creator: ctx.from.id }
+                    );
 
                     // Update the original checklist message
                     const icon = this.getChecklistIcon(checklist);
@@ -771,9 +683,9 @@ class Checklists {
     async enterRemoveMode(ctx) {
         await ctx.answerCbQuery().catch()
         const listName = ctx.match[1];
-        let holonId = ctx.chat.id;
-        let checklist = await this.db.get(holonId.toString(), 'checklists', listName);
-        
+        const holonId = ctx.chat.id;
+        const checklist = await getChecklist(this.db, holonId, listName);
+
         if (!checklist) {
             // Use reply or editMessageText based on context
             if (ctx.callbackQuery) {
@@ -805,25 +717,18 @@ class Checklists {
     async removeItem(ctx) {
         await ctx.answerCbQuery().catch()
         const [listName, itemIndex] = ctx.match[1].split('_');
-        let holonId = ctx.chat.id;
-        let checklist = await this.db.get(holonId.toString(), 'checklists', listName);
+        const holonId = ctx.chat.id;
+        const result = await coreRemoveItemAt(this.db, holonId, listName, parseInt(itemIndex, 10));
 
-        if (!checklist || !checklist.items[itemIndex]) {
+        if (!result) {
             ctx.reply('Item not found.');
             return;
         }
 
-        // Store the item text before removing it
-        const removedItemText = checklist.items[itemIndex].text;
-
-        // Remove the item
-        checklist.items = checklist.items.filter((_, index) => index !== parseInt(itemIndex));
-        await this.db.put(holonId.toString(), 'checklists', checklist);
-
         // Update the message with the new keyboard, staying in remove mode
         await ctx.editMessageText(
-            `📋 ${listName.toUpperCase()} Checklist:\nRemoved "${removedItemText}"`,
-            this.getChecklistKeyboard(checklist, true)
+            `📋 ${listName.toUpperCase()} Checklist:\nRemoved "${result.removed.text}"`,
+            this.getChecklistKeyboard(result.checklist, true)
         ).catch(error => console.log(error));
     }
 
@@ -834,72 +739,48 @@ class Checklists {
             return;
         }
 
-        let holonId = ctx.chat.id;
-        let checklist = await this.db.get(holonId.toString(), 'checklists', listName);
+        const holonId = ctx.chat.id;
+        const result = await coreDeleteCheckedItems(this.db, holonId, listName);
 
-        if (!checklist) {
-            ctx.reply(`Checklist "${listName}" not found.`);
+        if (!result.ok) {
+            const message = result.reason === 'not_found'
+                ? `Checklist "${listName}" not found.`
+                : `No checked items found in checklist "${listName}".`;
+            ctx.reply(message);
             return;
         }
 
-        const initialLength = checklist.items.length;
-        const checkedItems = checklist.items.filter(item => item.checked);
+        const removedItems = result.removed.map(item => `"${item.text}"`).join(', ');
+        await ctx.reply(`Removed ${result.removed.length} checked items from checklist "${listName}": ${removedItems}`);
 
-        if (checkedItems.length === 0) {
-            ctx.reply(`No checked items found in checklist "${listName}".`);
-            return;
-        }
-
-        // Remove checked items
-        checklist.items = checklist.items.filter(item => !item.checked);
-        await this.db.put(holonId.toString(), 'checklists', checklist);
-
-        const removedCount = initialLength - checklist.items.length;
-        const removedItems = checkedItems.map(item => `"${item.text}"`).join(', ');
-        
-        await ctx.reply(`Removed ${removedCount} checked items from checklist "${listName}": ${removedItems}`);
-        
         // Show the updated checklist
         await ctx.reply(
-            `📋 ${listName.toUpperCase()} Checklist:`, 
-            this.getChecklistKeyboard(checklist)
+            `📋 ${listName.toUpperCase()} Checklist:`,
+            this.getChecklistKeyboard(result.checklist)
         );
     }
 
     async addItemsToChecklist(listName, itemsText, holonId, ctx) {
-        let checklist = await this.db.get(holonId.toString(), 'checklists', listName);
+        const result = await coreAddItemsToChecklist(this.db, holonId, listName, itemsText);
 
-        if (!checklist) {
-            await ctx.reply(`Checklist "${listName}" not found.`);
+        if (!result.ok) {
+            const message = result.reason === 'not_found'
+                ? `Checklist "${listName}" not found.`
+                : 'No valid items provided.';
+            await ctx.reply(message);
             return null;
         }
 
-        // Split by commas and create items
-        const newItems = itemsText.split(',')
-            .map(item => ({
-                text: item.trim(),
-                checked: false
-            }))
-            .filter(item => item.text); // Filter out empty items
+        const itemsAdded = result.added.map(item => `"${item.text}"`).join(', ');
+        await ctx.reply(`Added ${result.added.length} items to checklist "${listName}": ${itemsAdded}`);
 
-        if (newItems.length === 0) {
-            await ctx.reply('No valid items provided.');
-            return null;
-        }
-
-        checklist.items.push(...newItems);
-        await this.db.put(holonId.toString(), 'checklists', checklist);
-
-        const itemsAdded = newItems.map(item => `"${item.text}"`).join(', ');
-        await ctx.reply(`Added ${newItems.length} items to checklist "${listName}": ${itemsAdded}`);
-        
         // Show the updated checklist
         await ctx.reply(
-            `📋 ${listName.toUpperCase()} Checklist:`, 
-            this.getChecklistKeyboard(checklist)
+            `📋 ${listName.toUpperCase()} Checklist:`,
+            this.getChecklistKeyboard(result.checklist)
         );
 
-        return checklist;
+        return result.checklist;
     }
 
     async handleBackToQuest(ctx) {
@@ -946,11 +827,8 @@ class Checklists {
 
     async showSpecialChecklist(ctx, type, icon) {
         const holonId = ctx.chat.id;
-        let checklist = await this.db.get(holonId.toString(), 'checklists', type) || {
-            id: type,
-            items: [],
-            created: new Date()
-        };
+        const stored = await getChecklist(this.db, holonId, type);
+        const checklist = stored || createChecklistObject(type, type);
 
         await ctx.reply(
             `${icon} ${type.toUpperCase()}:`,
@@ -958,37 +836,13 @@ class Checklists {
         );
     }
 
-    // Helper method to determine if a checklist is special
+    // Thin delegations to @holons/core/checklists.
     isSpecialChecklist(checklist) {
-        // Handle legacy calls with just ID
-        if (typeof checklist === 'string') {
-            return ['agenda', 'shopping'].includes(checklist);
-        }
-        
-        // New type-based logic
-        return checklist.type === CHECKLIST_TYPES.AGENDA || checklist.type === CHECKLIST_TYPES.SHOPPING;
+        return isSpecialChecklist(checklist);
     }
 
-    // Helper method to get checklist icon
     getChecklistIcon(checklist) {
-        // Handle legacy calls with just ID
-        if (typeof checklist === 'string') {
-            switch(checklist) {
-                case 'agenda': return '📅';
-                case 'shopping': return '🛒';
-                default: return '📋';
-            }
-        }
-        
-        // New type-based logic
-        switch(checklist.type) {
-            case CHECKLIST_TYPES.AGENDA: return '📅';
-            case CHECKLIST_TYPES.SHOPPING: return '🛒';
-            case CHECKLIST_TYPES.QUEST: return '📋';
-            case CHECKLIST_TYPES.ROLE: return '👥';
-            case CHECKLIST_TYPES.CHECKLIST:
-            default: return '📋';
-        }
+        return getChecklistIcon(checklist);
     }
 
     getSpecialChecklistKeyboard(checklist) {
@@ -1028,20 +882,16 @@ class Checklists {
 
     async deleteChecklist(ctx) {
         const listName = ctx.match[1];
-        let holonId = ctx.chat.id;
+        const holonId = ctx.chat.id;
 
-        // Get the checklist to check its type
-        const checklist = await this.db.get(holonId.toString(), 'checklists', listName);
-
-        // Don't allow deletion of special checklists
-        if (checklist && this.isSpecialChecklist(checklist)) {
+        const result = await coreDeleteChecklist(this.db, holonId, listName);
+        if (!result.ok && result.reason === 'special') {
             await ctx.answerCbQuery('Cannot delete special checklists');
             return;
         }
 
-        await this.db.delete(holonId.toString(), 'checklists', listName);
         await ctx.answerCbQuery(`Deleted checklist "${listName}"`);
-        
+
         // Refresh the delete mode view using options
         await this.showAllChecklists(ctx, { deleteMode: true });
     }


### PR DESCRIPTION
## Summary

Phase B Unit 12 of 20. Extracts checklist subtask CRUD from
`packages/telegram-ui/src/Checklists.js` (the authoritative HolonsBot
source) into a UI-agnostic `@holons/core/checklists` module so the Svelte
web UI and the Telegram bot can share one source of truth.

- New module `packages/core/src/checklists/{index,types,operations}.ts`.
  Exposes get/getAll/put/delete plus item-level helpers (toggle, append,
  remove, clear, deleteChecked) and the pure helpers used by both UIs
  (createChecklistObject, migrateLegacyChecklistType, isSpecialChecklist,
  getChecklistDisplayTitle, getTypeDisplayName, getChecklistIcon,
  parseItemsText). Storage is abstracted behind a `ChecklistStore`
  interface matching Holosphere's `db.{get,getAll,put,delete}`.
- 14 unit tests against an in-memory store cover legacy migration, CRUD,
  and the agenda-vs-regular `clearChecklist` semantics.
- `packages/telegram-ui/src/Checklists.js` rewired to delegate. Telegraf
  command/action surface unchanged; legacy type-migration blocks deleted
  (handled by core on read). Public class methods kept as thin facades so
  static call sites (e.g. `Checklists.CHECKLIST_TYPES`) keep working.
- `packages/core/tsconfig.json` excludes `*.test.ts`/`*.spec.ts` so they
  stay out of `dist/`.

## Test plan

- [x] `pnpm install`
- [x] `pnpm -r --if-present typecheck` (5/6 projects, web has no typecheck)
- [x] `pnpm -r --if-present build` (all projects build)
- [x] `pnpm -F @holons/core test` (14/14 pass)
- [x] Smoke: `node -e "import('./packages/core/dist/checklists/index.js').then(m => console.log(Object.keys(m)))"` -> 20 named exports
- [x] `pnpm -F harvest-web exec svelte-kit sync` succeeds
- [x] `node --check packages/telegram-ui/src/Checklists.js` passes
- [ ] Manual: exercise `/checklist`, `/newchecklist`, `/addcheck`, `/agenda`, `/deletechecked`, and the inline-keyboard actions (toggle, remove mode, clear) in a live HolonsBot to confirm parity.

Note: pre-existing `pnpm -r test` failure in `packages/ai-ui` (no test files) is unchanged by this PR.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>