### PR TITLE
core/expenses: extract balance computation into @holons/core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,6 +6,11 @@
   "description": "Shared domain logic for Holons UIs (web, telegram, text, ai). UI-agnostic.",
   "exports": {
     ".": "./src/index.ts",
+    "./expenses": {
+      "types": "./dist/expenses/index.d.ts",
+      "import": "./dist/expenses/index.js",
+      "default": "./dist/expenses/index.js"
+    },
     "./*": "./src/*/index.ts"
   },
   "scripts": {

--- a/packages/core/src/expenses/balance.test.ts
+++ b/packages/core/src/expenses/balance.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+  coerceSplitWith,
+  computeBalances,
+  computeUserCurrencyBalance,
+  normalizeCurrency,
+} from './balance.js';
+import type { Expense, User } from './types.js';
+
+const users: User[] = [
+  { id: 1, first_name: 'Alice' },
+  { id: 2, first_name: 'Bob' },
+  { id: 3, first_name: 'Carol' },
+];
+
+const baseExpense = (overrides: Partial<Expense>): Expense => ({
+  id: 1,
+  date: 0,
+  amount: 30,
+  currency: 'eur',
+  description: 'dinner',
+  paidBy: 1,
+  splitWith: [1, 2, 3],
+  ...overrides,
+});
+
+describe('normalizeCurrency', () => {
+  it('lowercases, strips trailing s and non-letters', () => {
+    expect(normalizeCurrency('EUROS')).toBe('euro');
+    expect(normalizeCurrency('USD$')).toBe('usd');
+    expect(normalizeCurrency('')).toBe('');
+    expect(normalizeCurrency(null)).toBe('');
+  });
+});
+
+describe('coerceSplitWith', () => {
+  it('passes arrays through and wraps scalars', () => {
+    expect(coerceSplitWith([1, 2])).toEqual([1, 2]);
+    expect(coerceSplitWith(7)).toEqual([7]);
+    expect(coerceSplitWith('x')).toEqual(['x']);
+    expect(coerceSplitWith('[1,2]')).toEqual([1, 2]);
+    expect(coerceSplitWith(null)).toEqual([]);
+  });
+});
+
+describe('computeBalances', () => {
+  it('splits a 30 EUR dinner three ways: payer is owed 20', () => {
+    const { balances } = computeBalances([baseExpense({})], users, 'eur');
+    expect(balances.find((b) => b.userId === 1)!.net).toBeCloseTo(20);
+    expect(balances.find((b) => b.userId === 2)!.net).toBeCloseTo(-10);
+    expect(balances.find((b) => b.userId === 3)!.net).toBeCloseTo(-10);
+  });
+
+  it('ignores expenses in another currency', () => {
+    const { balances } = computeBalances(
+      [baseExpense({ currency: 'usd' })],
+      users,
+      'eur'
+    );
+    expect(balances.every((b) => b.net === 0)).toBe(true);
+  });
+
+  it('honours allowedCurrencies gating', () => {
+    const result = computeBalances([baseExpense({})], users, 'eur', ['usd']);
+    expect(result.balances.every((b) => b.net === 0)).toBe(true);
+  });
+
+  it('drops expenses whose payer is not in the user list', () => {
+    const result = computeBalances(
+      [baseExpense({ paidBy: 999 })],
+      users,
+      'eur'
+    );
+    expect(result.balances.every((b) => b.net === 0)).toBe(true);
+  });
+});
+
+describe('computeUserCurrencyBalance', () => {
+  it('matches the matrix-row sum for the payer', () => {
+    expect(computeUserCurrencyBalance([baseExpense({})], 1, 'eur')).toBeCloseTo(20);
+  });
+
+  it('returns 0 when the currency has no expenses', () => {
+    expect(computeUserCurrencyBalance([baseExpense({})], 1, 'jpy')).toBe(0);
+  });
+});

--- a/packages/core/src/expenses/balance.ts
+++ b/packages/core/src/expenses/balance.ts
@@ -1,0 +1,144 @@
+// Pure balance computation for shared expenses.
+//
+// All functions are deterministic and side-effect free; storage and i18n are
+// caller responsibilities. Behaviour mirrors the bot's
+// `Expenses.calculateCredits` / `getUserCurrencyBalance` and the web's
+// `expenseCalculations.calculateCurrencyBalance`.
+import type { AgentId, BalancesResult, Expense, User, UserBalance } from './types.js';
+
+/**
+ * Lowercase, strip a trailing 's' (naive de-pluralization) and remove any
+ * non-letter characters. Matches both the bot and the web normalization rules
+ * so that expenses recorded via either UI compare equal.
+ */
+export function normalizeCurrency(currency: string | null | undefined): string {
+  if (!currency || typeof currency !== 'string') return '';
+  return currency.toLowerCase().replace(/s$/, '').replace(/[^a-z]/g, '');
+}
+
+/**
+ * Coerce a stored `splitWith` value into an array. Older Gun records sometimes
+ * store a single id as a number/string, or a JSON-encoded string.
+ */
+export function coerceSplitWith(value: unknown): AgentId[] {
+  if (value == null) return [];
+  if (Array.isArray(value)) return value as AgentId[];
+  if (typeof value === 'number') return [value];
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      return Array.isArray(parsed) ? (parsed as AgentId[]) : [parsed as AgentId];
+    } catch {
+      return [value];
+    }
+  }
+  return [];
+}
+
+/**
+ * Build the NxN credit matrix for `currency` over `expenses`.
+ *
+ * Convention: `matrix[payer][debtor] += share` and the inverse is decremented,
+ * so summing a user's row yields their net position (positive = others owe
+ * them, negative = they owe others).
+ *
+ * - Expenses in other currencies are skipped.
+ * - `allowedCurrencies`, when non-empty, gates which currencies count.
+ * - Expenses whose payer is unknown are skipped.
+ * - Self-shares (payer in their own splitWith) are not double-counted.
+ */
+export function computeCreditMatrix(
+  expenses: Expense[],
+  users: User[],
+  currency: string,
+  allowedCurrencies: string[] = []
+): { creditMatrix: number[][]; userIds: AgentId[] } {
+  const userIds = users.map((u) => u.id);
+  if (userIds.length === 0) return { creditMatrix: [], userIds: [] };
+
+  const normalizedCurrency = normalizeCurrency(currency);
+  if (!normalizedCurrency) return { creditMatrix: [], userIds };
+
+  const indexById = new Map<string, number>(userIds.map((id, i) => [String(id), i]));
+  const matrix: number[][] = userIds.map(() => new Array(userIds.length).fill(0));
+
+  for (const expense of expenses) {
+    if (!expense) continue;
+    const expenseCurrency = normalizeCurrency(expense.currency);
+    if (expenseCurrency !== normalizedCurrency) continue;
+    if (allowedCurrencies.length > 0 && !allowedCurrencies.includes(expenseCurrency)) continue;
+
+    const payerIdx = indexById.get(String(expense.paidBy)) ?? -1;
+    if (payerIdx === -1) continue;
+
+    const splitWith = coerceSplitWith(expense.splitWith);
+    const share = expense.amount / (splitWith.length > 0 ? splitWith.length : 1);
+
+    for (const memberId of splitWith) {
+      const memberIdx = indexById.get(String(memberId)) ?? -1;
+      if (memberIdx === -1 || memberIdx === payerIdx) continue;
+      matrix[payerIdx][memberIdx] += share;
+      matrix[memberIdx][payerIdx] -= share;
+    }
+  }
+
+  return { creditMatrix: matrix, userIds };
+}
+
+/**
+ * Compute net per-user balances for a currency. The credit matrix is also
+ * returned so callers (e.g. the bot's image renderer) can show pairwise debts
+ * without recomputing.
+ */
+export function computeBalances(
+  expenses: Expense[],
+  users: User[],
+  currency: string,
+  allowedCurrencies: string[] = []
+): BalancesResult {
+  const { creditMatrix, userIds } = computeCreditMatrix(expenses, users, currency, allowedCurrencies);
+  const balances: UserBalance[] = userIds.map((userId, i) => ({
+    userId,
+    net: creditMatrix[i].reduce((sum, val) => sum + val, 0),
+  }));
+  return { creditMatrix, userIds, balances };
+}
+
+/**
+ * Net balance for a single user using the bot's payer/sharer accounting. This
+ * does not require a full user list — useful for "what do I owe?" lookups.
+ *
+ * Sign matches `computeBalances`: positive = user is owed; negative = owes.
+ */
+export function computeUserCurrencyBalance(
+  expenses: Expense[],
+  userId: AgentId,
+  currency: string
+): number {
+  const normalizedCurrency = normalizeCurrency(currency);
+  if (!normalizedCurrency || !expenses?.length) return 0;
+
+  const userKey = String(userId);
+  let net = 0;
+  for (const expense of expenses) {
+    if (!expense || normalizeCurrency(expense.currency) !== normalizedCurrency) continue;
+
+    const splitWith = coerceSplitWith(expense.splitWith);
+    const share = expense.amount / (splitWith.length > 0 ? splitWith.length : 1);
+    const userInSplit = splitWith.some((id) => String(id) === userKey);
+    const isPayer = String(expense.paidBy) === userKey;
+
+    if (isPayer) {
+      net += expense.amount;
+      if (userInSplit) net -= share;
+    } else if (userInSplit) {
+      net -= share;
+    }
+  }
+  return net;
+}
+
+// Aliases kept to match the smoke-test contract (`computeBalances` OR
+// `calculateBalance`) and the existing web utility's naming.
+export const calculateBalance = computeUserCurrencyBalance;
+export const calculateCreditMatrix = computeCreditMatrix;

--- a/packages/core/src/expenses/index.ts
+++ b/packages/core/src/expenses/index.ts
@@ -1,0 +1,23 @@
+// Public surface for `@holons/core/expenses`.
+//
+// Authoritative source: packages/telegram-ui/src/Expenses.js (storage shape +
+// balance accounting). Designed to be UI-agnostic so the web, telegram, text
+// and AI UIs can share computation.
+export * from './types.js';
+export {
+  calculateBalance,
+  calculateCreditMatrix,
+  coerceSplitWith,
+  computeBalances,
+  computeCreditMatrix,
+  computeUserCurrencyBalance,
+  normalizeCurrency,
+} from './balance.js';
+export {
+  addParticipant,
+  createExpense,
+  removeParticipant,
+  splitAmongAll,
+  toggleParticipant,
+} from './operations.js';
+export type { CreateExpenseInput } from './operations.js';

--- a/packages/core/src/expenses/operations.test.ts
+++ b/packages/core/src/expenses/operations.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import {
+  addParticipant,
+  createExpense,
+  removeParticipant,
+  splitAmongAll,
+  toggleParticipant,
+} from './operations.js';
+import type { Expense } from './types.js';
+
+const expense: Expense = {
+  id: 1,
+  date: 0,
+  amount: 12,
+  currency: 'eur',
+  description: 'beers',
+  paidBy: 1,
+  splitWith: [1, 2],
+};
+
+describe('createExpense', () => {
+  it('rejects non-positive or non-numeric amounts', () => {
+    expect(createExpense({ id: 1, holonId: 100, amount: 0, currency: 'eur', description: 'x', paidBy: 1 })).toBeNull();
+    expect(createExpense({ id: 1, holonId: 100, amount: NaN, currency: 'eur', description: 'x', paidBy: 1 })).toBeNull();
+  });
+
+  it('normalizes currency and strips leading prepositions', () => {
+    const e = createExpense({
+      id: 1,
+      holonId: 100,
+      amount: 5,
+      currency: 'EUR',
+      description: 'for pizza',
+      paidBy: 1,
+    });
+    expect(e).not.toBeNull();
+    expect(e!.currency).toBe('eur');
+    expect(e!.description).toBe('pizza');
+  });
+
+  it('falls back to [holonId] when splitWith is empty', () => {
+    const e = createExpense({
+      id: 1,
+      holonId: 100,
+      amount: 5,
+      currency: 'eur',
+      description: 'solo',
+      paidBy: 1,
+    });
+    expect(e!.splitWith).toEqual([100]);
+  });
+});
+
+describe('toggleParticipant', () => {
+  it('adds when absent and removes the holon sentinel', () => {
+    const seeded: Expense = { ...expense, splitWith: [100] };
+    const next = toggleParticipant(seeded, 2, 100);
+    expect(next.splitWith).toEqual([2]);
+  });
+
+  it('removes when present and falls back to [holonId] if empty', () => {
+    const seeded: Expense = { ...expense, splitWith: [2] };
+    const next = toggleParticipant(seeded, 2, 100);
+    expect(next.splitWith).toEqual([100]);
+  });
+
+  it('does not mutate the input', () => {
+    const original = { ...expense, splitWith: [...expense.splitWith] };
+    toggleParticipant(expense, 3, 100);
+    expect(expense).toEqual(original);
+  });
+});
+
+describe('addParticipant / removeParticipant / splitAmongAll', () => {
+  it('addParticipant is idempotent', () => {
+    expect(addParticipant(expense, 2).splitWith).toEqual([1, 2]);
+    expect(addParticipant(expense, 3).splitWith).toEqual([1, 2, 3]);
+  });
+
+  it('removeParticipant filters by string-equality', () => {
+    expect(removeParticipant(expense, '2').splitWith).toEqual([1]);
+  });
+
+  it('splitAmongAll replaces the split', () => {
+    expect(splitAmongAll(expense, [10, 20]).splitWith).toEqual([10, 20]);
+  });
+});

--- a/packages/core/src/expenses/operations.ts
+++ b/packages/core/src/expenses/operations.ts
@@ -1,0 +1,102 @@
+// Pure expense operations: validation, normalization and split mutations.
+//
+// Each function returns a *new* Expense (never mutates input) so callers can
+// persist the result through whatever storage layer they own. The bot's
+// Telegraf class keeps its UI flow but routes data shaping through here.
+import { coerceSplitWith, normalizeCurrency } from './balance.js';
+import type { AgentId, Expense } from './types.js';
+
+/** Input used to construct a fresh expense before persistence. */
+export interface CreateExpenseInput {
+  id: AgentId;
+  holonId: AgentId;
+  amount: number;
+  currency: string;
+  description: string;
+  paidBy: AgentId;
+  splitWith?: AgentId[];
+  picture?: string | null;
+  /** Override timestamp (defaults to `Date.now()`). */
+  date?: number;
+}
+
+/** Strip leading prepositions in the languages the bot supports. */
+function stripDescriptionPreposition(description: string): string {
+  return description
+    .replace(/^for /i, '')
+    .replace(/^per /i, '')
+    .replace(/^voor /i, '')
+    .replace(/^für /i, '')
+    .replace(/^por /i, '')
+    .replace(/^pour /i, '');
+}
+
+/**
+ * Validate inputs and produce a normalized expense. Returns `null` when the
+ * amount is non-positive — same contract as the bot's `addExpense` so callers
+ * can keep their existing reply-on-failure code paths.
+ *
+ * Currency is normalized here too, so callers don't have to remember to do it.
+ * If `splitWith` is omitted or empty we default to `[holonId]` to match the
+ * bot's "this holon eats the cost" sentinel.
+ */
+export function createExpense(input: CreateExpenseInput): Expense | null {
+  const amount = Number(input.amount);
+  if (!Number.isFinite(amount) || amount <= 0) return null;
+
+  const currency = normalizeCurrency(input.currency);
+  const description = stripDescriptionPreposition(String(input.description ?? ''));
+  const splitWith =
+    input.splitWith && input.splitWith.length > 0 ? [...input.splitWith] : [input.holonId];
+
+  return {
+    id: input.id,
+    date: input.date ?? Date.now(),
+    amount,
+    currency,
+    description,
+    paidBy: input.paidBy,
+    splitWith,
+    picture: input.picture ?? null,
+  };
+}
+
+const sameId = (a: AgentId, b: AgentId): boolean => String(a) === String(b);
+
+/**
+ * Toggle a single user in/out of the split. Removing the last participant
+ * falls back to `[holonId]` so the expense still has at least one bearer.
+ */
+export function toggleParticipant(expense: Expense, userId: AgentId, holonId: AgentId): Expense {
+  const current = coerceSplitWith(expense.splitWith);
+  const isPresent = current.some((id) => sameId(id, userId));
+  let next: AgentId[];
+
+  if (isPresent) {
+    next = current.filter((id) => !sameId(id, userId));
+    if (next.length === 0) next = [holonId];
+  } else {
+    next = current.filter((id) => !sameId(id, holonId));
+    next.push(userId);
+  }
+
+  return { ...expense, splitWith: next };
+}
+
+/** Ensure `userId` is part of the split (no-op if already there). */
+export function addParticipant(expense: Expense, userId: AgentId): Expense {
+  const current = coerceSplitWith(expense.splitWith);
+  if (current.some((id) => sameId(id, userId))) return { ...expense, splitWith: current };
+  return { ...expense, splitWith: [...current, userId] };
+}
+
+/** Remove `userId` from the split, if present. */
+export function removeParticipant(expense: Expense, userId: AgentId): Expense {
+  const next = coerceSplitWith(expense.splitWith).filter((id) => !sameId(id, userId));
+  return { ...expense, splitWith: next };
+}
+
+/** Replace the split with every known user (excluding the holon sentinel). */
+export function splitAmongAll(expense: Expense, userIds: AgentId[]): Expense {
+  return { ...expense, splitWith: [...userIds] };
+}

--- a/packages/core/src/expenses/types.ts
+++ b/packages/core/src/expenses/types.ts
@@ -1,0 +1,62 @@
+// @holons/core/expenses — UI-agnostic expense domain types.
+//
+// Sourced from packages/telegram-ui/src/Expenses.js (authoritative shape) and
+// apps/web/src/utils/expenseCalculations.ts. Both bot and web persist expenses
+// under HoloSphere/Gun, so IDs may arrive as number or string. We normalize at
+// the edges (storage) but accept loose input here.
+
+/** A user/holon ID as it appears on the wire (Gun stores numbers and strings). */
+export type AgentId = string | number;
+
+/** A monetary expense within a holon, split among participants. */
+export interface Expense {
+  /** Stable identifier (telegram message id in the bot, uuid in web). */
+  id: AgentId;
+  /** Unix epoch ms when the expense was recorded. */
+  date: number;
+  /** Total amount in `currency` units. */
+  amount: number;
+  /** Currency code; persisted normalized (lowercase, singular, a-z only). */
+  currency: string;
+  /** Free-form description provided by the payer. */
+  description: string;
+  /** ID of the user (or holon) who paid. */
+  paidBy: AgentId;
+  /**
+   * IDs of agents that share the cost. May contain the holonId itself when
+   * "this holon" is treated as a single participant (legacy bot behaviour).
+   * May arrive as a non-array from older records; consumers should normalize
+   * via `coerceSplitWith`.
+   */
+  splitWith: AgentId[];
+  /** Optional Telegram file_id for an attached receipt. */
+  picture?: string | null;
+}
+
+/** Minimal user shape used for balance display. */
+export interface User {
+  id: AgentId;
+  username?: string | null;
+  first_name?: string | null;
+  last_name?: string | null;
+}
+
+/** Per-user net balance (positive = is owed, negative = owes). */
+export interface UserBalance {
+  userId: AgentId;
+  net: number;
+}
+
+/** Result of computing balances across all users in a holon. */
+export interface BalancesResult {
+  /**
+   * NxN matrix where `creditMatrix[i][j]` is the net amount user i is owed by
+   * user j (positive) or owes to user j (negative). Rows and columns share the
+   * same ordering as `userIds`.
+   */
+  creditMatrix: number[][];
+  /** User IDs in the same order as the matrix axes. */
+  userIds: AgentId[];
+  /** Per-user net balance derived by summing each row of the matrix. */
+  balances: UserBalance[];
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts", "src/**/*.spec.ts"]
 }

--- a/packages/telegram-ui/src/Expenses.js
+++ b/packages/telegram-ui/src/Expenses.js
@@ -8,6 +8,16 @@ import i18next from 'i18next';
 import * as utils from './utilities.js';
 import { createPaddedCaption } from './utilities.js';
 import { REAEventStore, REAEventFactory, REAAggregator } from './domain/rea/index.js';
+import {
+    computeBalances,
+    computeUserCurrencyBalance,
+    createExpense,
+    normalizeCurrency,
+    toggleParticipant as toggleParticipantSplit,
+    addParticipant as addParticipantSplit,
+    removeParticipant as removeParticipantSplit,
+    splitAmongAll,
+} from '@holons/core/expenses';
 
 const DASHBOARD_ADDRESS = process.env.DASHBOARD_ADDRESS || 'https://dashboard.holons.io';
 
@@ -224,8 +234,8 @@ export default class Expenses {
         const currentSettings = await this.settings.getSettings(holonId);
         const allowedCurrencies = currentSettings.currencies || [];
         
-        // Normalize input currency (lowercase, singular - assuming singular is stored)
-        const normalizedCurrency = currencyInput.toLowerCase().replace(/s$/, '').replace(/[^a-z]/g, ''); 
+        // Normalize input currency via shared @holons/core/expenses rule.
+        const normalizedCurrency = normalizeCurrency(currencyInput);
 
         if (allowedCurrencies.length > 0 && !allowedCurrencies.includes(normalizedCurrency)) {
             return ctx.reply(i18next.t('expensecurrencyinvalid', {
@@ -251,33 +261,18 @@ export default class Expenses {
     };
 
     async addExpense(messageId, holonId, amount, currency, description, paidBy, splitWith, picture = null) {
-        //do health check on currency: remove uppercase, check if it's a valid currency, remove plural
-        if (isNaN(amount) || amount <= 0 ) { // Currency validation moved to 'spent'
-            return false;
-        }
-
-        // amount = parseFloat(amount); // Already float from 'spent'
-
-        // currency is already normalized (lowercase, singular, no special chars) by the caller (`spent` method)
-        // description = description.replace(/^for /, ''); //EN (already done in `spent` if needed, but usually fine here)
-        description = description.replace(/^for /i, ''); // Case-insensitive
-        description = description.replace(/^per /i, '');
-        description = description.replace(/^voor /i, '');
-        description = description.replace(/^für /i, '');
-        description = description.replace(/^por /i, '');
-        description = description.replace(/^pour /i, '');
-
-
-        const expense = {
+        // Validation, currency normalization and description cleanup live in core.
+        const expense = createExpense({
             id: messageId,
-            date: Date.now(),
+            holonId,
             amount,
             currency,
             description,
             paidBy,
             splitWith,
-            picture: picture || null
-        };
+            picture,
+        });
+        if (!expense) return false;
 
         // Store expense record (for display and backward compatibility)
         await this.db.put(holonId.toString(), 'expenses', expense);
@@ -294,27 +289,14 @@ export default class Expenses {
         return expense;
     }
 
-    // add user to split TODO: BOT ID IS HARDCODED, switch to either holonId or variable bot id
+    // Toggle a user in/out of an expense's split. Pure logic in @holons/core/expenses.
     async joinSplit(holonId, userID, expenseID) {
-        let expense = await this.db.get(holonId.toString(), 'expenses', expenseID)
+        const expense = await this.db.get(holonId.toString(), 'expenses', expenseID);
+        if (!expense) return false;
 
-        if (expense) {
-            if (!expense.splitWith.includes(userID)) { //add user to split
-                expense.splitWith.push(userID);
-                // Remove holonId ("This Holon") if it exists in the array
-                expense.splitWith = expense.splitWith.filter(id => id !== holonId);
-            }
-            else {//remove user from split
-                expense.splitWith = expense.splitWith.filter(function (value, index, arr) { return value != userID; });
-                if (expense.splitWith.length == 0) {
-                    expense.splitWith.push(holonId);
-                }
-            }
-
-            await this.db.put(holonId.toString(), 'expenses', expense)
-            return expense;
-        }
-        return false;
+        const updated = toggleParticipantSplit(expense, userID, holonId);
+        await this.db.put(holonId.toString(), 'expenses', updated);
+        return updated;
     }
 
     async removeFromSplit(ctx) {
@@ -359,14 +341,14 @@ export default class Expenses {
                 return ctx.reply(i18next.t('usernotfound', { lng: language }));
             }
 
-            let expense = await this.db.get(holonId.toString(), 'expenses', expenseID)
+            const expense = await this.db.get(holonId.toString(), 'expenses', expenseID);
             if (expense) {
-                expense.splitWith = expense.splitWith.filter(value => value != chatMember.user.id);
-                await this.db.put(holonId.toString(), 'expenses', expense)
-                ctx.telegram.editMessageText(holonId, expenseID, null, await this.createMessage(holonId,expense), Markup.inlineKeyboard(
-                    [{ text: i18next.t('Split', { lng: language }), callback_data: `split:${expense.id}` }, { text: i18next.t('Split All', { lng: language }), callback_data: `splitall:${expense.id}` }]
-                )).catch(err => console.log(err))
-                return expense;
+                const updated = removeParticipantSplit(expense, chatMember.user.id);
+                await this.db.put(holonId.toString(), 'expenses', updated);
+                ctx.telegram.editMessageText(holonId, expenseID, null, await this.createMessage(holonId, updated), Markup.inlineKeyboard(
+                    [{ text: i18next.t('Split', { lng: language }), callback_data: `split:${updated.id}` }, { text: i18next.t('Split All', { lng: language }), callback_data: `splitall:${updated.id}` }]
+                )).catch(err => console.log(err));
+                return updated;
             }
         } catch (error) {
             console.error('Error getting chat member:', error);
@@ -412,17 +394,14 @@ export default class Expenses {
                 return ctx.reply(i18next.t('usernotfound', { lng: language }));
             }
 
-            let expense = await this.db.get(holonId.toString(), 'expenses', expenseID)
+            const expense = await this.db.get(holonId.toString(), 'expenses', expenseID);
             if (expense) {
-                if (!expense.splitWith)
-                    expense.splitWith = [];
-                if (!expense.splitWith.includes(chatMember.user.id))
-                    expense.splitWith.push(chatMember.user.id);
-                await this.db.put(holonId.toString(), 'expenses', expense)
-                ctx.telegram.editMessageText(holonId, expenseID, null, await this.createMessage(holonId, expense), Markup.inlineKeyboard(
-                    [{ text: i18next.t('Split', { lng: language }), callback_data: `split:${expense.id}` }, { text: i18next.t('Split All', { lng: language }), callback_data: `splitall:${expense.id}` }]
+                const updated = addParticipantSplit(expense, chatMember.user.id);
+                await this.db.put(holonId.toString(), 'expenses', updated);
+                ctx.telegram.editMessageText(holonId, expenseID, null, await this.createMessage(holonId, updated), Markup.inlineKeyboard(
+                    [{ text: i18next.t('Split', { lng: language }), callback_data: `split:${updated.id}` }, { text: i18next.t('Split All', { lng: language }), callback_data: `splitall:${updated.id}` }]
                 )).catch(err => console.log(err));
-                return expense;
+                return updated;
             }
         } catch (error) {
             console.error('Error getting chat member:', error);
@@ -432,197 +411,33 @@ export default class Expenses {
     }
 
     async splitAll(holonId, expenseID) {
-        let expense = await this.db.get(holonId.toString(), 'expenses', expenseID)
-        if (expense) {
-            let users = await this.db.getAll(holonId.toString(), 'users')
-            let userArray = users.map(user => user.id)
-            expense.splitWith = userArray;
-            await this.db.put(holonId.toString(), 'expenses', expense)
-            return expense;
-        }
-        return false;
+        const expense = await this.db.get(holonId.toString(), 'expenses', expenseID);
+        if (!expense) return false;
+        const users = (await this.db.getAll(holonId.toString(), 'users')) || [];
+        const updated = splitAmongAll(expense, users.map(u => u.id));
+        await this.db.put(holonId.toString(), 'expenses', updated);
+        return updated;
     }
 
     async calculateCredits(holonId, currency) {
-        console.log(`\n=== CALCULATING CREDITS ===`);
-        console.log(`Holon ID: ${holonId}`);
-        console.log(`Currency: ${currency}`);
-        
-        // Validate and normalize currency input
         if (!currency || typeof currency !== 'string' || currency.length === 0) {
-            console.error('❌ Invalid currency provided to calculateCredits:', currency);
+            console.error('Invalid currency provided to calculateCredits:', currency);
             return { creditMatrix: [], userNames: [] };
         }
-        
-        const requestedCurrencyNormalized = currency.toLowerCase().replace(/s$/, '').replace(/[^a-z]/g, '');
-        console.log(`✅ Normalized currency: ${requestedCurrencyNormalized}`);
 
-        // Fetch data from the database
-        let expenses = await this.db.getAll(holonId.toString(), 'expenses');
-        let users = await this.db.getAll(holonId.toString(), 'users');
-        const currentSettings = await this.settings.getSettings(holonId); 
-        const allowedCurrenciesSetting = currentSettings.currencies || [];
-
-        console.log(`📊 Data Summary:`);
-        console.log(`  - Total expenses: ${expenses?.length || 0}`);
-        console.log(`  - Total users: ${users?.length || 0}`);
-        console.log(`  - Allowed currencies: [${allowedCurrenciesSetting.join(', ')}]`);
-
-        // Early exit if no users are found
-        if (!users || users.length === 0) {
-            console.log('❌ No users found for credit calculation in chat:', holonId);
-            return { creditMatrix: [], userNames: [] }; // Return empty structure
+        const expenses = (await this.db.getAll(holonId.toString(), 'expenses')) || [];
+        const users = (await this.db.getAll(holonId.toString(), 'users')) || [];
+        if (users.length === 0) {
+            console.log('No users found for credit calculation in chat:', holonId);
+            return { creditMatrix: [], userNames: [] };
         }
 
-        let userArray = users.map(user => user.id);
-        let creditMatrix = Array(userArray.length).fill(0).map(() => Array(userArray.length).fill(0));
+        const currentSettings = await this.settings.getSettings(holonId);
+        const allowedCurrencies = currentSettings.currencies || [];
 
-        console.log(`\n=== PROCESSING EXPENSES ===`);
-        let processedExpenses = 0;
-        let skippedExpenses = 0;
-
-        // Process each expense to calculate credits
-        expenses.forEach(expense => {
-            // Ensure the expense currency matches the requested currency (case-insensitive)
-            const expenseCurrencyNormalized = expense.currency ? expense.currency.toLowerCase().replace(/s$/, '').replace(/[^a-z]/g, '') : '';
-            
-            console.log(`\nExpense ID: ${expense.id}`);
-            console.log(`  Amount: ${expense.amount} ${expense.currency}`);
-            console.log(`  Description: ${expense.description}`);
-            console.log(`  Paid by: ${expense.paidBy}`);
-            
-            // FIX: Add proper type checking for splitWith
-            let splitWithDisplay = 'none';
-            if (expense.splitWith) {
-                if (Array.isArray(expense.splitWith)) {
-                    splitWithDisplay = expense.splitWith.join(', ');
-                } else if (typeof expense.splitWith === 'string') {
-                    splitWithDisplay = expense.splitWith;
-                } else if (typeof expense.splitWith === 'number') {
-                    splitWithDisplay = expense.splitWith.toString();
-                } else {
-                    splitWithDisplay = JSON.stringify(expense.splitWith);
-                }
-            }
-            console.log(`  Split with: [${splitWithDisplay}]`);
-            console.log(`  Currency match: ${expenseCurrencyNormalized} === ${requestedCurrencyNormalized} ? ${expenseCurrencyNormalized === requestedCurrencyNormalized}`);
-            
-            if (expenseCurrencyNormalized === requestedCurrencyNormalized) {
-                // If allowed currencies are defined in settings, ensure this expense's currency is one of them
-                if (allowedCurrenciesSetting.length > 0 && !allowedCurrenciesSetting.includes(expenseCurrencyNormalized)) {
-                    console.warn(`⚠️ Skipping expense ${expense.id} for credit calculation; its currency '${expense.currency}' (normalized: '${expenseCurrencyNormalized}') is not in the allowed list: [${allowedCurrenciesSetting.join(', ')}]`);
-                    skippedExpenses++;
-                    return; 
-                }
-
-                // FIX: Ensure splitWith is an array, default to empty if not
-                let splitWithArray = [];
-                if (expense.splitWith) {
-                    if (Array.isArray(expense.splitWith)) {
-                        splitWithArray = expense.splitWith;
-                    } else if (typeof expense.splitWith === 'string') {
-                        // Try to parse as JSON or treat as single value
-                        try {
-                            const parsed = JSON.parse(expense.splitWith);
-                            splitWithArray = Array.isArray(parsed) ? parsed : [parsed];
-                        } catch {
-                            splitWithArray = [expense.splitWith];
-                        }
-                    } else if (typeof expense.splitWith === 'number') {
-                        splitWithArray = [expense.splitWith];
-                    } else {
-                        console.warn(`⚠️ Unknown splitWith type for expense ${expense.id}:`, typeof expense.splitWith, expense.splitWith);
-                        splitWithArray = [];
-                    }
-                }
-                
-                const numberOfSplitters = splitWithArray.length > 0 ? splitWithArray.length : 1;
-                const amountPerPerson = expense.amount / numberOfSplitters;
-
-                console.log(`  ✅ Processing expense:`);
-                console.log(`    Number of splitters: ${numberOfSplitters}`);
-                console.log(`    Amount per person: ${amountPerPerson.toFixed(2)}`);
-                console.log(`    SplitWith array: [${splitWithArray.join(', ')}]`);
-
-                const payerIndex = userArray.indexOf(expense.paidBy);
-
-                // Ensure payer is found in the user list
-                if (payerIndex === -1) {
-                    console.warn(`⚠️ Payer ID ${expense.paidBy} not found in user list for expense ${expense.id}`);
-                    skippedExpenses++;
-                    return; // Skip this expense if payer not found
-                }
-
-                console.log(`    Payer index: ${payerIndex}`);
-
-                splitWithArray.forEach(memberId => {
-                    const memberIndex = userArray.indexOf(memberId);
-
-                    // Ensure member is found in the user list
-                    if (memberIndex === -1) {
-                        console.warn(`⚠️ Member ID ${memberId} not found in user list for expense ${expense.id}`);
-                        return; // Skip this member if not found
-                    }
-
-                    console.log(`    Processing member ${memberId} (index: ${memberIndex})`);
-
-                    // Update the credit matrix, avoiding self-credit updates
-                    if (payerIndex !== memberIndex) {
-                        // Ensure the matrix indices are valid before assignment
-                        if (creditMatrix[payerIndex] && creditMatrix[memberIndex]) {
-                           creditMatrix[payerIndex][memberIndex] += amountPerPerson;
-                           creditMatrix[memberIndex][payerIndex] -= amountPerPerson;
-                           console.log(`      ✅ Updated matrix: [${payerIndex}][${memberIndex}] += ${amountPerPerson.toFixed(2)}`);
-                           console.log(`      ✅ Updated matrix: [${memberIndex}][${payerIndex}] -= ${amountPerPerson.toFixed(2)}`);
-                        } else {
-                           console.error(`❌ Invalid indices for credit matrix update: payerIndex=${payerIndex}, memberIndex=${memberIndex}`);
-                        }
-                    } else {
-                        console.log(`      ⏭️ Skipping self-credit update for payer ${expense.paidBy}`);
-                    }
-                });
-                
-                processedExpenses++;
-            } else {
-                console.log(`  ⏭️ Skipping - currency mismatch`);
-                skippedExpenses++;
-            }
-        });
-
-        console.log(`\n=== PROCESSING SUMMARY ===`);
-        console.log(`✅ Processed expenses: ${processedExpenses}`);
-        console.log(`⏭️ Skipped expenses: ${skippedExpenses}`);
-
-        // Get display names for the users involved
-        let userNames = await Promise.all(userArray.map(userId => this.getDisplayName(holonId, userId)));
-        
-        console.log(`\n=== FINAL USER LIST ===`);
-        userNames.forEach((name, index) => {
-            console.log(`  ${index}: ${name} (ID: ${userArray[index]})`);
-        });
-
-        // ADD: Detailed credit matrix analysis
-        console.log(`\n=== CREDIT MATRIX ANALYSIS ===`);
-        console.log(`Matrix format: [Row User] owes [Column User] amount`);
-        for (let i = 0; i < creditMatrix.length; i++) {
-            for (let j = 0; j < creditMatrix[i].length; j++) {
-                if (i !== j && creditMatrix[i][j] !== 0) {
-                    console.log(`  ${userNames[i]} owes ${userNames[j]}: ${creditMatrix[i][j].toFixed(2)}`);
-                }
-            }
-        }
-
-        // ADD: Net balance calculation for each user
-        console.log(`\n=== NET BALANCES ===`);
-        for (let i = 0; i < creditMatrix.length; i++) {
-            let netBalance = 0;
-            for (let j = 0; j < creditMatrix[i].length; j++) {
-                if (i !== j) {
-                    netBalance += creditMatrix[i][j]; // Positive = owes money, Negative = is owed money
-                }
-            }
-            console.log(`  ${userNames[i]}: ${netBalance.toFixed(2)} (${netBalance > 0 ? 'owes' : netBalance < 0 ? 'is owed' : 'balanced'})`);
-        }
+        // Pure computation — see @holons/core/expenses for the rules.
+        const { creditMatrix, userIds } = computeBalances(expenses, users, currency, allowedCurrencies);
+        const userNames = await Promise.all(userIds.map(id => this.getDisplayName(holonId, id)));
 
         return { creditMatrix, userNames };
     }
@@ -661,101 +476,8 @@ export default class Expenses {
     }
 
     async getUserCurrencyBalance(holonId, userID, currencyName) {
-        console.log(`\n=== GETTING CURRENCY BALANCE ===`);
-        console.log(`Holon ID: ${holonId}, User ID: ${userID}, Currency: ${currencyName}`);
-        
-        const expenses = await this.db.getAll(holonId.toString(), 'expenses');
-        let netBalance = 0;
-        const normalizedTargetCurrency = currencyName.toLowerCase().replace(/s$/, '').replace(/[^a-z]/g, '');
-
-        console.log(`Total expenses found: ${expenses?.length || 0}`);
-        console.log(`Normalized target currency: ${normalizedTargetCurrency}`);
-
-        if (!expenses || expenses.length === 0) {
-            console.log(`❌ No expenses found`);
-            return 0;
-        }
-
-        for (const expense of expenses) {
-            const expenseCurrencyNormalized = expense.currency ? expense.currency.toLowerCase().replace(/s$/, '').replace(/[^a-z]/g, '') : '';
-            
-            // FIX: Handle splitWith properly for display
-            let splitWithDisplay = 'none';
-            if (expense.splitWith) {
-                if (Array.isArray(expense.splitWith)) {
-                    splitWithDisplay = expense.splitWith.join(', ');
-                } else if (typeof expense.splitWith === 'string') {
-                    splitWithDisplay = expense.splitWith;
-                } else if (typeof expense.splitWith === 'number') {
-                    splitWithDisplay = expense.splitWith.toString();
-                } else {
-                    splitWithDisplay = JSON.stringify(expense.splitWith);
-                }
-            }
-            
-            console.log(`\nExpense ID: ${expense.id}`);
-            console.log(`  Amount: ${expense.amount} ${expense.currency}`);
-            console.log(`  Paid by: ${expense.paidBy}`);
-            console.log(`  Split with: [${splitWithDisplay}]`);
-            console.log(`  Currency match: ${expenseCurrencyNormalized} === ${normalizedTargetCurrency} ? ${expenseCurrencyNormalized === normalizedTargetCurrency}`);
-
-            if (expenseCurrencyNormalized === normalizedTargetCurrency) {
-                // FIX: Handle splitWith properly for calculation
-                let splitWithArray = [];
-                if (expense.splitWith) {
-                    if (Array.isArray(expense.splitWith)) {
-                        splitWithArray = expense.splitWith;
-                    } else if (typeof expense.splitWith === 'string') {
-                        // Try to parse as JSON or treat as single value
-                        try {
-                            const parsed = JSON.parse(expense.splitWith);
-                            splitWithArray = Array.isArray(parsed) ? parsed : [parsed];
-                        } catch {
-                            splitWithArray = [expense.splitWith];
-                        }
-                    } else if (typeof expense.splitWith === 'number') {
-                        splitWithArray = [expense.splitWith];
-                    } else {
-                        console.warn(`⚠️ Unknown splitWith type for expense ${expense.id}:`, typeof expense.splitWith, expense.splitWith);
-                        splitWithArray = [];
-                    }
-                }
-                
-                const numSplitters = splitWithArray.length > 0 ? splitWithArray.length : 1;
-                const share = expense.amount / numSplitters;
-                // FIX: Handle data type mismatch for includes check
-                let userInSplit = splitWithArray.some(id => id == userID); // Use == for type coercion
-
-                console.log(`  ✅ Processing expense:`);
-                console.log(`    Number of splitters: ${numSplitters}`);
-                console.log(`    Share per person: ${share.toFixed(2)}`);
-                console.log(`    User in split: ${userInSplit}`);
-                console.log(`    User is payer: ${expense.paidBy === userID}`);
-                console.log(`    Data types - expense.paidBy: ${typeof expense.paidBy} (${expense.paidBy}), userID: ${typeof userID} (${userID})`);
-
-                // FIX: Handle data type mismatch for comparison
-                const isPayer = expense.paidBy == userID; // Use == instead of === for type coercion
-                
-                if (isPayer) {
-                    netBalance += expense.amount; // User paid the full amount
-                    console.log(`    +${expense.amount} (paid full amount)`);
-                    if (userInSplit) {
-                        netBalance -= share; // Subtract their own share
-                        console.log(`    -${share.toFixed(2)} (own share)`);
-                    }
-                } else if (userInSplit) {
-                    netBalance -= share; // User is in split but didn't pay, so they owe their share
-                    console.log(`    -${share.toFixed(2)} (owe share)`);
-                }
-                
-                console.log(`    Current net balance: ${netBalance.toFixed(2)}`);
-            } else {
-                console.log(`  ⏭️ Skipping - currency mismatch`);
-            }
-        }
-        
-        console.log(`\nFinal net balance for user ${userID}: ${netBalance.toFixed(2)}`);
-        return netBalance;
+        const expenses = (await this.db.getAll(holonId.toString(), 'expenses')) || [];
+        return computeUserCurrencyBalance(expenses, userID, currencyName);
     }
 
     // Show participant selection interface with checklist-style user selection
@@ -810,37 +532,22 @@ export default class Expenses {
         }
     }
 
-    // Toggle individual participant in expense split
+    // Toggle individual participant in expense split (Telegraf wrapper around core).
     async toggleParticipant(ctx, holonId, messageId, expenseID, userID) {
         try {
             await ctx.answerCbQuery().catch(() => {});
-            
-            let expense = await this.db.get(holonId.toString(), 'expenses', expenseID);
+
+            const expense = await this.db.get(holonId.toString(), 'expenses', expenseID);
             if (!expense) {
                 await ctx.answerCbQuery('Expense not found');
                 return;
             }
 
-            // Toggle participant
-            if (expense.splitWith.includes(userID)) {
-                // Remove user from split
-                expense.splitWith = expense.splitWith.filter(id => id !== userID);
-                // Add holonId ("This Holon") if split becomes empty
-                if (expense.splitWith.length === 0) {
-                    expense.splitWith.push(holonId);
-                }
-            } else {
-                // Add user to split
-                expense.splitWith.push(userID);
-                // Remove holonId ("This Holon") if it exists in the array
-                expense.splitWith = expense.splitWith.filter(id => id !== holonId);
-            }
+            const updated = toggleParticipantSplit(expense, userID, holonId);
+            await this.db.put(holonId.toString(), 'expenses', updated);
 
-            await this.db.put(holonId.toString(), 'expenses', expense);
-            
             // Refresh the participant selection view
             await this.showParticipantSelection(ctx, holonId, messageId, expenseID);
-
         } catch (error) {
             console.error('Error toggling participant:', error);
             await ctx.answerCbQuery('Error updating participant');
@@ -873,27 +580,22 @@ export default class Expenses {
         }
     }
 
-    // Select all participants for expense split
+    // Select all participants for expense split (Telegraf wrapper around core).
     async selectAllParticipants(ctx, holonId, messageId, expenseID) {
         try {
             await ctx.answerCbQuery().catch(() => {});
-            
-            let expense = await this.db.get(holonId.toString(), 'expenses', expenseID);
+
+            const expense = await this.db.get(holonId.toString(), 'expenses', expenseID);
             if (!expense) {
                 await ctx.answerCbQuery('Expense not found');
                 return;
             }
 
-            const users = await this.db.getAll(holonId.toString(), 'users');
+            const users = (await this.db.getAll(holonId.toString(), 'users')) || [];
+            const updated = splitAmongAll(expense, users.map(u => u.id));
+            await this.db.put(holonId.toString(), 'expenses', updated);
 
-            // Add all users to the split (excluding holon ID to avoid duplication)
-            expense.splitWith = users.map(user => user.id);
-
-            await this.db.put(holonId.toString(), 'expenses', expense);
-            
-            // Refresh the participant selection view to show all users selected
             await this.showParticipantSelection(ctx, holonId, messageId, expenseID);
-
         } catch (error) {
             console.error('Error selecting all participants:', error);
             await ctx.answerCbQuery('Error selecting all participants');


### PR DESCRIPTION
## Summary
- Adds `@holons/core/expenses` with UI-agnostic types, pure split operations (`createExpense`, `toggleParticipant`, `addParticipant`, `removeParticipant`, `splitAmongAll`), and balance math (`computeCreditMatrix`, `computeBalances`, `computeUserCurrencyBalance`, `normalizeCurrency`, `coerceSplitWith`). `findIndex` lookups are replaced with a single id->index `Map` so credit-matrix computation is linear in the number of split entries instead of quadratic.
- Rewires `packages/telegram-ui/src/Expenses.js` as a thin Telegraf facade. Storage + balance computation now flow through core; i18n, REA event creation, photo uploads and chat UI stay in the bot.
- Adds a typed `./expenses` entry to `@holons/core`'s `exports` map so plain `node` consumers (e.g. the bot's `node src/HolonsBot.js` start path) can resolve the subpath to the compiled `dist/` output. Excludes `*.test.ts` files from `tsc` so vitest sources don't end up in `dist`.

## Test plan
- [x] `pnpm install`
- [x] `pnpm -r --if-present typecheck` (all packages green)
- [x] `pnpm -r --if-present build` (web build succeeds)
- [x] `pnpm -F @holons/core test` (17 / 17 vitest passes for balance + operations)
- [x] `pnpm -F @holons/telegram-ui test` (30 passed, 1 skipped — including the HolonsBot import integration test)
- [x] Smoke: `pnpm -F @holons/core build && node -e "import('./packages/core/dist/expenses/index.js').then(m => { if (!m.computeBalances && !m.calculateBalance) throw new Error('missing balance op'); console.log('OK exports', Object.keys(m)); })"`
- [x] `pnpm -F harvest-web exec svelte-kit sync` (exit 0)
- [x] Manual: `node -e "import('packages/telegram-ui/src/Expenses.js')"` resolves `@holons/core/expenses` against the dist build

🤖 Generated with [Claude Code](https://claude.com/claude-code)