### PR TITLE
core/calendar: extract RSVP + iCal into @holons/core

### DIFF
--- a/apps/web/src/lib/services/icalGenerator.ts
+++ b/apps/web/src/lib/services/icalGenerator.ts
@@ -1,148 +1,27 @@
-// iCal Feed Generator Service
-// Generates iCal feeds from holon events for export/subscription
+// iCal Feed Generator Service — re-export from @holons/core/calendar.
+// Generation lives in `@holons/core/calendar`; browser-only download
+// helpers stay here because they need DOM/Blob.
 
-import ICAL from 'ical.js';
+export {
+    generateICalFeed,
+    generateICal,
+    toICalendar,
+    mapStatusToICalStatus,
+    type HolonEvent,
+    type ICalFeedOptions,
+} from '@holons/core/calendar';
 
-export interface HolonEvent {
-    id: string;
-    title: string;
-    description?: string;
-    location?: string;
-    when: string; // ISO date string
-    ends?: string; // ISO date string
-    participants?: Array<{ id: string; username?: string; firstName?: string; lastName?: string }>;
-    status?: string;
-    category?: string;
-}
-
-/**
- * Generates an iCal feed from holon events
- * @param events - Array of holon events
- * @param holonName - Name of the holon (for calendar name)
- * @param holonId - ID of the holon
- * @returns iCal formatted string
- */
-export function generateICalFeed(
-    events: HolonEvent[],
-    holonName: string,
-    holonId: string
-): string {
-    // Create the calendar component
-    const cal = new ICAL.Component(['vcalendar', [], []]);
-
-    // Set calendar properties
-    cal.updatePropertyWithValue('prodid', '-//Harvest Holon Calendar//EN');
-    cal.updatePropertyWithValue('version', '2.0');
-    cal.updatePropertyWithValue('calscale', 'GREGORIAN');
-    cal.updatePropertyWithValue('method', 'PUBLISH');
-    cal.updatePropertyWithValue('x-wr-calname', `${holonName} Calendar`);
-    cal.updatePropertyWithValue('x-wr-caldesc', `Events from ${holonName} holon`);
-    cal.updatePropertyWithValue('x-wr-timezone', 'UTC');
-
-    // Add each event
-    events.forEach(event => {
-        try {
-            if (!event.when) return; // Skip events without dates
-
-            const vevent = new ICAL.Component('vevent');
-            const ievent = new ICAL.Event(vevent);
-
-            // Set UID - use event ID with holon ID for uniqueness
-            ievent.uid = `${event.id}@${holonId}.harvest.app`;
-
-            // Set summary (title)
-            ievent.summary = event.title || 'Untitled Event';
-
-            // Set description
-            if (event.description) {
-                ievent.description = event.description;
-            }
-
-            // Set location
-            if (event.location) {
-                ievent.location = event.location;
-            }
-
-            // Set start time
-            const startDate = new Date(event.when);
-            ievent.startDate = ICAL.Time.fromJSDate(startDate, true);
-
-            // Set end time
-            const endDate = event.ends ? new Date(event.ends) : new Date(startDate.getTime() + 60 * 60 * 1000); // Default 1 hour
-            ievent.endDate = ICAL.Time.fromJSDate(endDate, true);
-
-            // Add status
-            if (event.status) {
-                vevent.updatePropertyWithValue('status', mapStatusToICalStatus(event.status));
-            }
-
-            // Add categories
-            if (event.category) {
-                vevent.updatePropertyWithValue('categories', event.category);
-            }
-
-            // Add participants as attendees
-            if (event.participants && event.participants.length > 0) {
-                event.participants.forEach(participant => {
-                    const attendeeName = participant.firstName || participant.username || participant.id;
-                    const attendee = vevent.addPropertyWithValue(
-                        'attendee',
-                        `mailto:${participant.id}@harvest.app`
-                    );
-                    attendee.setParameter('cn', attendeeName);
-                    attendee.setParameter('role', 'REQ-PARTICIPANT');
-                    attendee.setParameter('partstat', 'ACCEPTED');
-                });
-            }
-
-            // Set created and last modified timestamps
-            const now = ICAL.Time.now();
-            vevent.updatePropertyWithValue('dtstamp', now);
-            vevent.updatePropertyWithValue('created', now);
-            vevent.updatePropertyWithValue('last-modified', now);
-
-            // Add the event to the calendar
-            cal.addSubcomponent(vevent);
-        } catch (error) {
-            console.error('Error generating iCal event:', error);
-            // Skip malformed events
-        }
-    });
-
-    return cal.toString();
-}
-
-/**
- * Maps holon event status to iCal status
- */
-function mapStatusToICalStatus(status: string): string {
-    const statusMap: Record<string, string> = {
-        'completed': 'CONFIRMED',
-        'ongoing': 'CONFIRMED',
-        'scheduled': 'CONFIRMED',
-        'cancelled': 'CANCELLED',
-        'tentative': 'TENTATIVE'
-    };
-
-    return statusMap[status.toLowerCase()] || 'CONFIRMED';
-}
-
-/**
- * Generates a download URL for the iCal feed
- * @param icalContent - iCal content string
- * @returns Blob URL for download
- */
+/** Create a Blob URL for an iCal payload (browser-only). */
 export function createICalDownloadUrl(icalContent: string): string {
     const blob = new Blob([icalContent], { type: 'text/calendar;charset=utf-8' });
     return URL.createObjectURL(blob);
 }
 
-/**
- * Downloads an iCal file
- * @param icalContent - iCal content string
- * @param fileName - Name for the downloaded file
- */
-export function downloadICalFile(icalContent: string, fileName: string = 'calendar.ics'): void {
+/** Trigger a browser download of an iCal payload (browser-only). */
+export function downloadICalFile(
+    icalContent: string,
+    fileName: string = 'calendar.ics'
+): void {
     const url = createICalDownloadUrl(icalContent);
     const link = document.createElement('a');
     link.href = url;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,7 +6,11 @@
   "description": "Shared domain logic for Holons UIs (web, telegram, text, ai). UI-agnostic.",
   "exports": {
     ".": "./src/index.ts",
-    "./*": "./src/*/index.ts"
+    "./*": {
+      "types": "./src/*/index.ts",
+      "import": "./dist/*/index.js",
+      "default": "./src/*/index.ts"
+    }
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
@@ -14,7 +18,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "holosphere": "1.3.0-alpha4"
+    "holosphere": "1.3.0-alpha4",
+    "ical.js": "^2.2.1"
   },
   "devDependencies": {
     "typescript": "^5.7.3",

--- a/packages/core/src/calendar/calendar.test.ts
+++ b/packages/core/src/calendar/calendar.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import {
+    generateICalFeed,
+    generateICal,
+    toICalendar,
+    mapStatusToICalStatus,
+    toggleRSVP,
+    isAttending,
+    buildRSVPList,
+    countAttendees,
+    rsvpDisplayName,
+} from './index.js';
+
+describe('iCal generation', () => {
+    it('emits a VCALENDAR with a VEVENT for a basic event', () => {
+        const ical = generateICalFeed(
+            [
+                {
+                    id: 'evt1',
+                    title: 'Standup',
+                    when: '2026-05-07T09:00:00Z',
+                    ends: '2026-05-07T09:30:00Z',
+                },
+            ],
+            'My Holon',
+            'holon-123'
+        );
+        expect(ical).toContain('BEGIN:VCALENDAR');
+        expect(ical).toContain('END:VCALENDAR');
+        expect(ical).toContain('BEGIN:VEVENT');
+        expect(ical).toContain('SUMMARY:Standup');
+        expect(ical).toContain('UID:evt1@holon-123.harvest.app');
+    });
+
+    it('skips events without `when`', () => {
+        const ical = generateICalFeed(
+            [{ id: 'no-date', title: 'Floating', when: '' }],
+            'H',
+            'h1'
+        );
+        expect(ical).not.toContain('BEGIN:VEVENT');
+    });
+
+    it('exposes generateICal and toICalendar aliases', () => {
+        expect(generateICal).toBe(generateICalFeed);
+        expect(toICalendar).toBe(generateICalFeed);
+    });
+
+    it('maps statuses to iCal STATUS values', () => {
+        expect(mapStatusToICalStatus('cancelled')).toBe('CANCELLED');
+        expect(mapStatusToICalStatus('TENTATIVE')).toBe('TENTATIVE');
+        expect(mapStatusToICalStatus('completed')).toBe('CONFIRMED');
+        expect(mapStatusToICalStatus('whatever')).toBe('CONFIRMED');
+    });
+});
+
+describe('RSVP', () => {
+    it('toggles attendance per event/message key', () => {
+        const user = { id: 'u1', first_name: 'Ada' };
+        toggleRSVP(user, 'msg-42');
+        expect(isAttending(user, 'msg-42')).toBe(true);
+        toggleRSVP(user, 'msg-42');
+        expect(isAttending(user, 'msg-42')).toBe(false);
+    });
+
+    it('builds a participant list with display names', () => {
+        const users = [
+            { id: 'u1', first_name: 'Ada', participated: { 'm1': true } },
+            { id: 'u2', username: 'bob', participated: {} },
+        ];
+        const list = buildRSVPList(users, 'm1');
+        expect(list).toEqual([
+            { userId: 'u1', name: 'Ada', attending: true },
+            { userId: 'u2', name: 'bob', attending: false },
+        ]);
+        expect(countAttendees(users, 'm1')).toBe(1);
+    });
+
+    it('falls back through display name fields', () => {
+        expect(rsvpDisplayName({ id: 'x', first_name: 'A', second_name: 'B' })).toBe('A B');
+        expect(rsvpDisplayName({ id: 'x', username: 'bob' })).toBe('bob');
+        expect(rsvpDisplayName({ id: '42' })).toBe('42');
+    });
+});

--- a/packages/core/src/calendar/ical.ts
+++ b/packages/core/src/calendar/ical.ts
@@ -1,0 +1,146 @@
+// @holons/core/calendar — iCal generation
+// UI-agnostic iCalendar feed generator. Used by web (SvelteKit endpoint)
+// and bot (export commands). Browser-only download helpers stay in the
+// web wrapper that re-exports this module.
+
+import ICAL from 'ical.js';
+
+// `console` is universally present (browser, Node, workers); declare it
+// here so we don't pull in `dom`/`node` lib types from the base tsconfig.
+declare const console: { error?: (...args: unknown[]) => void };
+
+/** A holon event (quest with `when`) shaped for iCal export. */
+export interface HolonEvent {
+    id: string;
+    title: string;
+    description?: string;
+    location?: string;
+    /** ISO date string for event start. */
+    when: string;
+    /** ISO date string for event end. Defaults to start + 1h when omitted. */
+    ends?: string;
+    participants?: Array<{
+        id: string;
+        username?: string;
+        firstName?: string;
+        lastName?: string;
+    }>;
+    status?: string;
+    category?: string;
+}
+
+/** Options for iCal feed generation. */
+export interface ICalFeedOptions {
+    /** Calendar product identifier. Defaults to Harvest. */
+    prodId?: string;
+    /** Domain used to scope event UIDs. Defaults to `harvest.app`. */
+    uidDomain?: string;
+}
+
+const DEFAULT_PRODID = '-//Harvest Holon Calendar//EN';
+const DEFAULT_UID_DOMAIN = 'harvest.app';
+
+/**
+ * Generate an iCal feed string from holon events.
+ *
+ * @param events     Events to include (entries lacking `when` are skipped).
+ * @param holonName  Display name for the calendar.
+ * @param holonId    Holon identifier, embedded in event UIDs.
+ * @param options    Optional product id / UID domain overrides.
+ */
+export function generateICalFeed(
+    events: HolonEvent[],
+    holonName: string,
+    holonId: string,
+    options: ICalFeedOptions = {}
+): string {
+    const prodId = options.prodId ?? DEFAULT_PRODID;
+    const uidDomain = options.uidDomain ?? DEFAULT_UID_DOMAIN;
+
+    const cal = new ICAL.Component(['vcalendar', [], []]);
+    cal.updatePropertyWithValue('prodid', prodId);
+    cal.updatePropertyWithValue('version', '2.0');
+    cal.updatePropertyWithValue('calscale', 'GREGORIAN');
+    cal.updatePropertyWithValue('method', 'PUBLISH');
+    cal.updatePropertyWithValue('x-wr-calname', `${holonName} Calendar`);
+    cal.updatePropertyWithValue('x-wr-caldesc', `Events from ${holonName} holon`);
+    cal.updatePropertyWithValue('x-wr-timezone', 'UTC');
+
+    for (const event of events) {
+        if (!event?.when) continue;
+        try {
+            cal.addSubcomponent(buildVEvent(event, holonId, uidDomain));
+        } catch (err) {
+            // Skip malformed events but keep the feed valid.
+            console.error?.('Error generating iCal event:', err);
+        }
+    }
+
+    return cal.toString();
+}
+
+/** Alias kept for spec compatibility (`generateICal` / `toICalendar`). */
+export const generateICal = generateICalFeed;
+export const toICalendar = generateICalFeed;
+
+function buildVEvent(
+    event: HolonEvent,
+    holonId: string,
+    uidDomain: string
+): InstanceType<typeof ICAL.Component> {
+    const vevent = new ICAL.Component('vevent');
+    const ievent = new ICAL.Event(vevent);
+
+    ievent.uid = `${event.id}@${holonId}.${uidDomain}`;
+    ievent.summary = event.title || 'Untitled Event';
+    if (event.description) ievent.description = event.description;
+    if (event.location) ievent.location = event.location;
+
+    const startDate = new Date(event.when);
+    ievent.startDate = ICAL.Time.fromJSDate(startDate, true);
+    const endDate = event.ends
+        ? new Date(event.ends)
+        : new Date(startDate.getTime() + 60 * 60 * 1000);
+    ievent.endDate = ICAL.Time.fromJSDate(endDate, true);
+
+    if (event.status) {
+        vevent.updatePropertyWithValue('status', mapStatusToICalStatus(event.status));
+    }
+    if (event.category) {
+        vevent.updatePropertyWithValue('categories', event.category);
+    }
+
+    if (event.participants?.length) {
+        for (const participant of event.participants) {
+            const attendeeName =
+                participant.firstName || participant.username || participant.id;
+            const attendee = vevent.addPropertyWithValue(
+                'attendee',
+                `mailto:${participant.id}@${uidDomain}`
+            );
+            attendee.setParameter('cn', attendeeName);
+            attendee.setParameter('role', 'REQ-PARTICIPANT');
+            attendee.setParameter('partstat', 'ACCEPTED');
+        }
+    }
+
+    const now = ICAL.Time.now();
+    vevent.updatePropertyWithValue('dtstamp', now);
+    vevent.updatePropertyWithValue('created', now);
+    vevent.updatePropertyWithValue('last-modified', now);
+
+    return vevent;
+}
+
+const STATUS_MAP: Record<string, string> = {
+    cancelled: 'CANCELLED',
+    tentative: 'TENTATIVE',
+    completed: 'CONFIRMED',
+    ongoing: 'CONFIRMED',
+    scheduled: 'CONFIRMED',
+};
+
+/** Map an internal event status to an iCal STATUS value. */
+export function mapStatusToICalStatus(status: string): string {
+    return STATUS_MAP[(status || '').toLowerCase()] ?? 'CONFIRMED';
+}

--- a/packages/core/src/calendar/index.ts
+++ b/packages/core/src/calendar/index.ts
@@ -1,0 +1,7 @@
+// @holons/core/calendar — calendar / RSVP / iCal layer.
+// Subpath import: `import { generateICalFeed, toggleRSVP } from '@holons/core/calendar'`.
+// `.js` extensions match TS ESM emit output; the package `exports` map points
+// at compiled `dist/` for runtime consumers and at `src/` for typecheck.
+
+export * from './ical.js';
+export * from './rsvp.js';

--- a/packages/core/src/calendar/rsvp.ts
+++ b/packages/core/src/calendar/rsvp.ts
@@ -1,0 +1,80 @@
+// @holons/core/calendar — RSVP / participation tracking
+// Pure data helpers shared by web and bot. UI-agnostic — no Telegraf,
+// no DOM. Bots own the keyboard rendering, the web app owns its UI.
+
+/** Display fields used to build a participant label. */
+export interface RSVPUser {
+    id: string | number;
+    username?: string;
+    first_name?: string;
+    second_name?: string;
+    /**
+     * Map of `messageId -> attending?` for legacy bot storage. The bot
+     * stores per-message RSVP state on the user record.
+     */
+    participated?: Record<string, boolean | undefined> | null;
+}
+
+/** A single rendered participant entry. */
+export interface RSVPEntry {
+    userId: string | number;
+    name: string;
+    attending: boolean;
+}
+
+/** Display name for a user, falling back through the available fields. */
+export function rsvpDisplayName(user: RSVPUser): string {
+    const first = user.first_name || user.username || String(user.id);
+    return user.second_name ? `${first} ${user.second_name}` : first;
+}
+
+/** Whether the user is currently marked attending for the given event/message. */
+export function isAttending(
+    user: RSVPUser,
+    eventKey: string | number
+): boolean {
+    if (!user || typeof user.participated !== 'object' || !user.participated) {
+        return false;
+    }
+    return Boolean(user.participated[String(eventKey)]);
+}
+
+/**
+ * Toggle the user's RSVP state for the given event/message key.
+ * Mutates and returns the user (ensuring `participated` is an object).
+ */
+export function toggleRSVP<T extends RSVPUser>(
+    user: T,
+    eventKey: string | number
+): T {
+    if (typeof user.participated !== 'object' || !user.participated) {
+        user.participated = {};
+    }
+    const key = String(eventKey);
+    user.participated[key] = !user.participated[key];
+    return user;
+}
+
+/**
+ * Build a participant list (for rendering an RSVP keyboard or web list).
+ * The check-mark glyph is left to the UI layer; only the boolean state
+ * and display name are produced here.
+ */
+export function buildRSVPList(
+    users: RSVPUser[],
+    eventKey: string | number
+): RSVPEntry[] {
+    return (users ?? []).map((user) => ({
+        userId: user.id,
+        name: rsvpDisplayName(user),
+        attending: isAttending(user, eventKey),
+    }));
+}
+
+/** Count attendees for the given event/message key. */
+export function countAttendees(
+    users: RSVPUser[],
+    eventKey: string | number
+): number {
+    return (users ?? []).filter((u) => isAttending(u, eventKey)).length;
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
 }

--- a/packages/telegram-ui/src/Calendar.js
+++ b/packages/telegram-ui/src/Calendar.js
@@ -1,6 +1,10 @@
 /**
  * @fileoverview Calendar and time selection for HolonsBot.
  * @module src/Calendar
+ *
+ * RSVP storage and iCal generation are routed through `@holons/core/calendar`
+ * so the web and bot share one calendar/RSVP/iCal layer. Telegraf-specific
+ * scheduling UI (date/time inline keyboards) stays here.
  */
 import { readFile } from 'fs/promises';
 import { createRequire } from "module";
@@ -10,6 +14,28 @@ const lang = JSON.parse(
     )
 );
 import dayjs from 'dayjs';
+import {
+    generateICalFeed,
+    toggleRSVP,
+    isAttending,
+    buildRSVPList,
+    countAttendees,
+    rsvpDisplayName,
+} from '@holons/core/calendar';
+
+/**
+ * Shared calendar helpers exposed for other bot modules (e.g. RSVP.js,
+ * Events.js). Routes RSVP toggling, participant listing, and iCal
+ * export through `@holons/core/calendar` so the bot and web stay in sync.
+ */
+export const CalendarCore = {
+    generateICalFeed,
+    toggleRSVP,
+    isAttending,
+    buildRSVPList,
+    countAttendees,
+    rsvpDisplayName,
+};
 
 /**
  * Calendar class for date and time selection in Telegram inline keyboards.


### PR DESCRIPTION
Phase B Unit 10 of 20.

Extracts iCal feed generator (from `apps/web/src/lib/services/icalGenerator.ts`) and RSVP helpers (from `packages/telegram-ui/src/RSVP.js`) into `@holons/core/calendar`.

- New: `packages/core/src/calendar/{ical,rsvp,index}.ts` — `generateICalFeed`, `toICalendar`, `mapStatusToICalStatus`, `toggleRSVP`, `isAttending`, `buildRSVPList`, `countAttendees`, `rsvpDisplayName` + 7 vitest cases
- Replaced: `apps/web/src/lib/services/icalGenerator.ts` is a re-export; browser-only `createICalDownloadUrl`/`downloadICalFile` stay (need DOM/Blob)
- Wired: `packages/telegram-ui/src/Calendar.js` exposes a `CalendarCore` facade so RSVP.js/Events.js can route through core; Telegraf scheduling UI untouched
- Added: `ical.js@^2.2.1` dep to `@holons/core`
- **Important** core/package.json exports tweak: added conditional `import → dist/*/index.js` so plain Node (no --experimental-strip-types) resolves `@holons/core/<domain>` after build. Resolves the runtime concern flagged by Unit 8.
- core/tsconfig.json excludes `*.test.ts` from emit

Verification: typecheck/build clean, 7/7 calendar tests, smoke OK, bot resolves `@holons/core/calendar` from compiled dist.