### PR TITLE
core/council: extract proposals + voting into @holons/core

### DIFF
--- a/apps/web/src/components/Proposals.svelte
+++ b/apps/web/src/components/Proposals.svelte
@@ -13,19 +13,13 @@
     import SourceBadge from './shared/SourceBadge.svelte';
     import TitleBar from './shared/TitleBar.svelte';
     import { CheckSquare } from 'svelte-feathers';
-
-    interface Proposal {
-        id: string;
-        type: string;
-        title: string;
-        description: string;
-        participants: string[];
-        stoppers: string[];
-        date: number;
-        creator: string;
-        _hologram?: { isHologram?: boolean; sourceHolon?: string; soul?: string };
-        _federation?: { origin?: string; sourceLens?: string };
-    }
+    import {
+        PROPOSAL_LENS,
+        createAndSaveProposal,
+        agree as coreAgree,
+        block as coreBlock,
+        type Proposal,
+    } from '@holons/core/council';
 
     const holosphere = getContext("holosphere") as HoloSphere;
 
@@ -92,7 +86,7 @@
 
         holosphere.subscribe(
             holonIdToSubscribe,
-            "quests",
+            PROPOSAL_LENS,
             (newItem: Proposal | null, key?: string) => {
                 if (!key) return;
 
@@ -113,7 +107,7 @@
 
     async function fetchFederatedProposals(holonIdToFetch: string): Promise<void> {
         try {
-            const federatedData = await holosphere.getFederated(holonIdToFetch, "quests", {
+            const federatedData = await holosphere.getFederated(holonIdToFetch, PROPOSAL_LENS, {
                 includeLocal: true,
                 includeFederated: true,
                 resolveReferences: true,
@@ -144,60 +138,25 @@
         subscribeToProposals(currentHolonID);
     }
 
+    // Thin facades over @holons/core/council. The holosphere instance
+    // satisfies the ProposalStore shape (put / get / subscribe / delete).
     function addProposal(title: string, description: string): void {
         if (!currentHolonID) return;
-        const newProposal: Proposal = {
-            id: crypto.randomUUID(),
-            type: "proposal",
+        void createAndSaveProposal(holosphere as any, currentHolonID, {
             title,
             description,
-            participants: [],
-            stoppers: [],
-            date: Math.floor(Date.now() / 1000),
-            creator: "Dashboard User",
-        };
-        holosphere.put(currentHolonID, "quests", newProposal);
+            creator: 'Dashboard User',
+        });
     }
 
     function toggleBlock(proposalId: string): void {
         if (!currentHolonID) return;
-        const proposal = proposals[proposalId];
-        if (!proposal) return;
-
-        const userId = "current-user";
-        const updatedProposal = { ...proposal };
-
-        if (!updatedProposal.stoppers) updatedProposal.stoppers = [];
-
-        if (updatedProposal.stoppers.includes(userId)) {
-            updatedProposal.stoppers = updatedProposal.stoppers.filter(id => id !== userId);
-        } else {
-            updatedProposal.stoppers = [...updatedProposal.stoppers, userId];
-            updatedProposal.participants = updatedProposal.participants?.filter(id => id !== userId) || [];
-        }
-
-        holosphere.put(currentHolonID, "quests", updatedProposal);
+        void coreBlock(holosphere as any, currentHolonID, proposalId, 'current-user');
     }
 
     function toggleAgree(proposalId: string): void {
         if (!currentHolonID) return;
-        const proposal = proposals[proposalId];
-        if (!proposal) return;
-
-        const userId = "current-user";
-        const updatedProposal = { ...proposal };
-        const participants = updatedProposal.participants || [];
-
-        if (participants.includes(userId)) {
-            updatedProposal.participants = participants.filter(id => id !== userId);
-        } else {
-            updatedProposal.participants = [...participants, userId];
-            if (updatedProposal.stoppers) {
-                updatedProposal.stoppers = updatedProposal.stoppers.filter(id => id !== userId);
-            }
-        }
-
-        holosphere.put(currentHolonID, "quests", updatedProposal);
+        void coreAgree(holosphere as any, currentHolonID, proposalId, 'current-user');
     }
 
     let showAddDialog = false;

--- a/packages/core/src/council/index.ts
+++ b/packages/core/src/council/index.ts
@@ -1,0 +1,35 @@
+// @holons/core/council — proposal lifecycle + voting tally.
+// UI-agnostic. LLM advisor prompts and Svelte stores stay in their UIs.
+
+export type {
+  Proposal,
+  ProposalStatus,
+  ProposalStore,
+  VoteDirection,
+  VoteEntry,
+  VoteTally,
+  Voter,
+  VoterId,
+} from './types.js';
+export { PROPOSAL_LENS } from './types.js';
+
+export {
+  DEFAULT_QUORUM,
+  applyVote,
+  deriveStatus,
+  hasAgreed,
+  hasBlocked,
+  tallyVotes,
+} from './voting.js';
+
+export {
+  agree,
+  block,
+  castVote,
+  createAndSaveProposal,
+  createProposal,
+  deleteProposal,
+  saveProposal,
+  subscribeToProposals,
+} from './proposals.js';
+export type { CreateProposalInput } from './proposals.js';

--- a/packages/core/src/council/proposals.test.ts
+++ b/packages/core/src/council/proposals.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import type { Proposal, ProposalStore } from './types.js';
+import {
+  agree,
+  block,
+  castVote,
+  createAndSaveProposal,
+  createProposal,
+  saveProposal,
+  subscribeToProposals,
+} from './proposals.js';
+
+function makeStore(): ProposalStore & {
+  records: Map<string, Proposal>;
+  subs: Array<(data: Proposal | null, key?: string) => void>;
+} {
+  const records = new Map<string, Proposal>();
+  const subs: Array<(data: Proposal | null, key?: string) => void> = [];
+  return {
+    records,
+    subs,
+    async put(_holon, _lens, data) {
+      records.set(data.id, JSON.parse(JSON.stringify(data)));
+      for (const cb of subs) cb(JSON.parse(JSON.stringify(data)), data.id);
+    },
+    async get(_holon, _lens, key) {
+      const r = records.get(key);
+      return r ? JSON.parse(JSON.stringify(r)) : null;
+    },
+    async delete(_holon, _lens, key) {
+      const had = records.delete(key);
+      if (had) for (const cb of subs) cb(null, key);
+      return had;
+    },
+    async subscribe(_holon, _lens, cb) {
+      subs.push(cb);
+      return { unsubscribe: () => subs.splice(subs.indexOf(cb), 1) };
+    },
+  };
+}
+
+describe('createProposal', () => {
+  it('builds a well-formed proposal', () => {
+    const p = createProposal({ title: 'Test', description: 'desc', creator: 'alice' });
+    expect(p.type).toBe('proposal');
+    expect(p.title).toBe('Test');
+    expect(p.participants).toEqual([]);
+    expect(p.stoppers).toEqual([]);
+    expect(p.status).toBe('ongoing');
+    expect(typeof p.id).toBe('string');
+  });
+
+  it('rejects empty titles', () => {
+    expect(() => createProposal({ title: '   ' })).toThrow();
+  });
+});
+
+describe('persistence', () => {
+  it('createAndSaveProposal writes to the store', async () => {
+    const store = makeStore();
+    const p = await createAndSaveProposal(store, 'holon-1', { title: 'Hi', creator: 'alice' });
+    expect(store.records.get(p.id)?.title).toBe('Hi');
+  });
+
+  it('saveProposal puts under the quests lens', async () => {
+    const store = makeStore();
+    const p = createProposal({ title: 'Lens test' });
+    await saveProposal(store, 'holon-1', p);
+    expect(store.records.get(p.id)).toBeDefined();
+  });
+
+  it('castVote reads, applies, writes', async () => {
+    const store = makeStore();
+    const p = await createAndSaveProposal(store, 'h', { title: 'Quorum?' });
+    const updated = await castVote(store, 'h', p.id, 'voter-1', 'agree');
+    expect(updated?.participants.length).toBe(1);
+    expect(store.records.get(p.id)?.participants.length).toBe(1);
+  });
+
+  it('agree / block helpers route correctly', async () => {
+    const store = makeStore();
+    const p = await createAndSaveProposal(store, 'h', { title: 'X' });
+    await agree(store, 'h', p.id, 'a');
+    await block(store, 'h', p.id, 'b');
+    const stored = store.records.get(p.id)!;
+    expect(stored.participants.length).toBe(1);
+    expect(stored.stoppers.length).toBe(1);
+    expect(stored.status).toBe('stopped');
+  });
+
+  it('castVote returns null for missing proposals', async () => {
+    const store = makeStore();
+    const result = await castVote(store, 'h', 'nope', 'a', 'agree');
+    expect(result).toBeNull();
+  });
+
+  it('subscribeToProposals filters non-proposal records', async () => {
+    const store = makeStore();
+    const seen: Array<{ data: Proposal | null; key?: string }> = [];
+    const off = await subscribeToProposals(store, 'h', (data, key) => seen.push({ data, key }));
+
+    await createAndSaveProposal(store, 'h', { title: 'Yes' });
+    // Simulate a quest (not a proposal) being written to the same lens.
+    await store.put('h', 'quests', { id: 'q1', type: 'quest', title: 'Q' } as unknown as Proposal);
+
+    expect(seen.length).toBe(1);
+    expect(seen[0].data?.type).toBe('proposal');
+
+    off();
+  });
+});

--- a/packages/core/src/council/proposals.ts
+++ b/packages/core/src/council/proposals.ts
@@ -1,0 +1,148 @@
+// Proposal lifecycle + persistence helpers.
+// Wraps a {@link ProposalStore} (holosphere or HolonDB-shaped adapter) so
+// both UIs can route reads and writes through the same code path.
+
+import type {
+  Proposal,
+  ProposalStore,
+  VoteEntry,
+  VoteDirection,
+} from './types.js';
+import { PROPOSAL_LENS } from './types.js';
+import { applyVote } from './voting.js';
+
+/** Options for {@link createProposal}. */
+export interface CreateProposalInput {
+  title: string;
+  description?: string;
+  creator?: VoteEntry;
+  /** Override the timestamp (unix seconds). Defaults to now. */
+  date?: number;
+  /** Override the id. Defaults to `crypto.randomUUID()` (or a fallback). */
+  id?: string;
+}
+
+function makeId(): string {
+  // Prefer crypto.randomUUID where available (browsers, Node ≥ 19).
+  const c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+  if (c?.randomUUID) return c.randomUUID();
+  // Fallback — good enough for local proposal ids.
+  return `proposal-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Build a fresh, well-formed proposal record. Does NOT persist — see
+ * {@link saveProposal} or {@link createAndSaveProposal}.
+ */
+export function createProposal(input: CreateProposalInput): Proposal {
+  const title = input.title?.trim();
+  if (!title) throw new Error('createProposal: title is required');
+
+  return {
+    id: input.id ?? makeId(),
+    type: 'proposal',
+    title,
+    description: input.description?.trim() ?? '',
+    participants: [],
+    stoppers: [],
+    date: input.date ?? Math.floor(Date.now() / 1000),
+    creator: input.creator,
+    status: 'ongoing',
+  };
+}
+
+/** Persist a proposal under the shared `quests` lens. */
+export function saveProposal(
+  store: ProposalStore,
+  holonId: string,
+  proposal: Proposal
+): Promise<unknown> | unknown {
+  return store.put(holonId, PROPOSAL_LENS, proposal);
+}
+
+/** Create and persist in one call. Returns the new proposal. */
+export async function createAndSaveProposal(
+  store: ProposalStore,
+  holonId: string,
+  input: CreateProposalInput
+): Promise<Proposal> {
+  const proposal = createProposal(input);
+  await saveProposal(store, holonId, proposal);
+  return proposal;
+}
+
+/**
+ * Apply a vote and persist. Reads the latest record from the store first
+ * to avoid clobbering concurrent updates.
+ *
+ * @returns The updated proposal, or `null` if it no longer exists.
+ */
+export async function castVote(
+  store: ProposalStore,
+  holonId: string,
+  proposalId: string,
+  voter: VoteEntry,
+  direction: VoteDirection
+): Promise<Proposal | null> {
+  const current = await store.get(holonId, PROPOSAL_LENS, proposalId);
+  if (!current) return null;
+  const next = applyVote(current as Proposal, voter, direction);
+  await saveProposal(store, holonId, next);
+  return next;
+}
+
+/** Convenience: cast an agree vote. */
+export function agree(
+  store: ProposalStore,
+  holonId: string,
+  proposalId: string,
+  voter: VoteEntry
+): Promise<Proposal | null> {
+  return castVote(store, holonId, proposalId, voter, 'agree');
+}
+
+/** Convenience: cast a block vote. */
+export function block(
+  store: ProposalStore,
+  holonId: string,
+  proposalId: string,
+  voter: VoteEntry
+): Promise<Proposal | null> {
+  return castVote(store, holonId, proposalId, voter, 'block');
+}
+
+/** Delete a proposal. No-op if the store does not implement `delete`. */
+export function deleteProposal(
+  store: ProposalStore,
+  holonId: string,
+  proposalId: string
+): Promise<unknown> | unknown {
+  if (!store.delete) return undefined;
+  return store.delete(holonId, PROPOSAL_LENS, proposalId);
+}
+
+/**
+ * Subscribe to proposal updates under a holon. The callback only fires for
+ * records with `type === 'proposal'` — quests stored under the same lens
+ * are filtered out.
+ *
+ * Returns a teardown function. If the store does not support subscriptions,
+ * returns a no-op teardown.
+ */
+export async function subscribeToProposals(
+  store: ProposalStore,
+  holonId: string,
+  cb: (proposal: Proposal | null, key?: string) => void
+): Promise<() => void> {
+  if (!store.subscribe) return () => {};
+  const sub = await store.subscribe(holonId, PROPOSAL_LENS, (data, key) => {
+    if (data == null) {
+      cb(null, key);
+      return;
+    }
+    if ((data as Proposal).type === 'proposal') {
+      cb(data as Proposal, key);
+    }
+  });
+  return sub.unsubscribe;
+}

--- a/packages/core/src/council/types.ts
+++ b/packages/core/src/council/types.ts
@@ -1,0 +1,92 @@
+// @holons/core/council — proposal + voting types.
+// UI-agnostic. No LLM coupling. No Svelte stores. Both harvest-web and
+// telegram-ui share these shapes via holosphere's `quests` lens.
+
+/**
+ * A user that has cast a vote on a proposal. The shape mirrors the loose
+ * subset both UIs already persist:
+ *  - harvest-web stores plain string IDs (e.g. "current-user")
+ *  - telegram-ui stores Telegram user objects (`{ id, first_name, ... }`)
+ *
+ * Core treats voters as identifiable by `id`. Anything else is opaque
+ * metadata the UI may use for display.
+ */
+export type VoterId = string | number;
+
+export interface Voter {
+  id: VoterId;
+  // Optional display fields preserved for telegram-ui compatibility.
+  first_name?: string;
+  last_name?: string;
+  username?: string;
+  [extra: string]: unknown;
+}
+
+/** Anything a UI persists as a "who voted" entry. */
+export type VoteEntry = Voter | string | number;
+
+export type ProposalStatus = 'ongoing' | 'stopped' | 'completed';
+
+/**
+ * Canonical proposal record. Both UIs persist this shape under the
+ * `quests` lens with `type === 'proposal'` (proposals share storage with
+ * quests; status fields like `participants`/`stoppers` are reused).
+ */
+export interface Proposal {
+  id: string;
+  type: 'proposal';
+  title: string;
+  description?: string;
+  /** Yea-votes / agreements. */
+  participants: VoteEntry[];
+  /** Veto / block votes. */
+  stoppers: VoteEntry[];
+  /** Unix seconds (web) or ms (bot). Stored as-is. */
+  date: number;
+  /** Free-form creator label or user object. */
+  creator?: VoteEntry;
+  status?: ProposalStatus;
+
+  // Federation/hologram bookkeeping kept opaque so federated views still
+  // round-trip cleanly through core helpers.
+  _hologram?: { isHologram?: boolean; sourceHolon?: string; soul?: string };
+  _federation?: { origin?: string; sourceLens?: string };
+
+  // Allow UIs to carry extra fields without losing them on round-trip.
+  [extra: string]: unknown;
+}
+
+/** Result of `tallyVotes` — a UI-agnostic snapshot of a proposal's state. */
+export interface VoteTally {
+  agreements: number;
+  blocks: number;
+  status: ProposalStatus;
+  /** True iff `agreements >= quorum` AND no active blockers. */
+  hasReachedQuorum: boolean;
+  /** Net support (agreements - blocks). Useful for sorting. */
+  netSupport: number;
+}
+
+/** Direction of a single vote action. */
+export type VoteDirection = 'agree' | 'block';
+
+/**
+ * Minimal persistence interface a UI provides so core can read/write
+ * proposals without taking a hard dep on holosphere's full surface.
+ *
+ * Both harvest-web (`HoloSphere`) and telegram-ui (`HolonDB`) satisfy
+ * this shape — see `proposals.ts` for adapter helpers.
+ */
+export interface ProposalStore {
+  put(holonId: string, lens: string, data: Proposal): Promise<unknown> | unknown;
+  get(holonId: string, lens: string, key: string): Promise<Proposal | null | undefined>;
+  delete?(holonId: string, lens: string, key: string): Promise<unknown> | unknown;
+  subscribe?(
+    holonId: string,
+    lens: string,
+    cb: (data: Proposal | null, key?: string) => void
+  ): Promise<{ unsubscribe: () => void }> | { unsubscribe: () => void };
+}
+
+/** Lens name proposals are stored under (shared with quests). */
+export const PROPOSAL_LENS = 'quests';

--- a/packages/core/src/council/voting.test.ts
+++ b/packages/core/src/council/voting.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import type { Proposal } from './types.js';
+import { applyVote, deriveStatus, hasAgreed, hasBlocked, tallyVotes } from './voting.js';
+
+const baseProposal: Proposal = {
+  id: 'p1',
+  type: 'proposal',
+  title: 'Adopt new meeting cadence',
+  description: 'Switch from weekly to bi-weekly all-hands.',
+  participants: [],
+  stoppers: [],
+  date: 1700000000,
+  creator: 'alice',
+  status: 'ongoing',
+};
+
+describe('tallyVotes', () => {
+  it('counts agreements and blocks', () => {
+    const p: Proposal = { ...baseProposal, participants: ['a', 'b', 'c'], stoppers: ['x'] };
+    const t = tallyVotes(p, 5);
+    expect(t.agreements).toBe(3);
+    expect(t.blocks).toBe(1);
+    expect(t.netSupport).toBe(2);
+    expect(t.status).toBe('stopped');
+    expect(t.hasReachedQuorum).toBe(false);
+  });
+
+  it('reaches quorum only with no blocks', () => {
+    const ok: Proposal = { ...baseProposal, participants: ['a', 'b', 'c', 'd', 'e'] };
+    expect(tallyVotes(ok, 5).hasReachedQuorum).toBe(true);
+
+    const blocked: Proposal = { ...ok, stoppers: ['x'] };
+    expect(tallyVotes(blocked, 5).hasReachedQuorum).toBe(false);
+  });
+
+  it('preserves completed status', () => {
+    const done: Proposal = { ...baseProposal, status: 'completed', participants: ['a'] };
+    expect(tallyVotes(done).status).toBe('completed');
+  });
+});
+
+describe('applyVote', () => {
+  it('toggles agree votes', () => {
+    const v1 = applyVote(baseProposal, 'alice', 'agree');
+    expect(hasAgreed(v1, 'alice')).toBe(true);
+
+    const v2 = applyVote(v1, 'alice', 'agree');
+    expect(hasAgreed(v2, 'alice')).toBe(false);
+  });
+
+  it('switching from agree to block clears the agree', () => {
+    const v1 = applyVote(baseProposal, 'alice', 'agree');
+    const v2 = applyVote(v1, 'alice', 'block');
+    expect(hasAgreed(v2, 'alice')).toBe(false);
+    expect(hasBlocked(v2, 'alice')).toBe(true);
+    expect(deriveStatus(v2)).toBe('stopped');
+  });
+
+  it('switching from block to agree clears the block', () => {
+    const v1 = applyVote(baseProposal, 'alice', 'block');
+    const v2 = applyVote(v1, 'alice', 'agree');
+    expect(hasBlocked(v2, 'alice')).toBe(false);
+    expect(hasAgreed(v2, 'alice')).toBe(true);
+    expect(deriveStatus(v2)).toBe('ongoing');
+  });
+
+  it('matches voters by id across string/object/number forms', () => {
+    const tgUser = { id: 42, first_name: 'Bob' };
+    const v1 = applyVote(baseProposal, tgUser, 'agree');
+    expect(hasAgreed(v1, { id: 42 })).toBe(true);
+    expect(hasAgreed(v1, '42')).toBe(true); // loose match
+    expect(hasAgreed(v1, 42)).toBe(true);
+  });
+
+  it('does not mutate the input proposal', () => {
+    const v1 = applyVote(baseProposal, 'alice', 'agree');
+    expect(baseProposal.participants).toEqual([]);
+    expect(v1).not.toBe(baseProposal);
+  });
+
+  it('rejects voters without an id', () => {
+    expect(() => applyVote(baseProposal, { first_name: 'noid' } as never, 'agree')).toThrow();
+  });
+});

--- a/packages/core/src/council/voting.ts
+++ b/packages/core/src/council/voting.ts
@@ -1,0 +1,126 @@
+// Pure voting tally + vote-mutation helpers. No I/O, no LLM, no UI.
+
+import type {
+  Proposal,
+  ProposalStatus,
+  Voter,
+  VoteEntry,
+  VoteDirection,
+  VoteTally,
+  VoterId,
+} from './types.js';
+
+/** Default quorum used by the web proposals view. */
+export const DEFAULT_QUORUM = 5;
+
+function entryId(entry: VoteEntry): VoterId | undefined {
+  if (entry == null) return undefined;
+  if (typeof entry === 'string' || typeof entry === 'number') return entry;
+  if (typeof entry === 'object' && 'id' in entry) return (entry as Voter).id;
+  return undefined;
+}
+
+function sameVoter(entry: VoteEntry, voter: VoteEntry): boolean {
+  const a = entryId(entry);
+  const b = entryId(voter);
+  if (a === undefined || b === undefined) return false;
+  // Loose equality so "42" (string) matches 42 (number) — telegram-ui mixes
+  // both depending on how the user record was loaded.
+  // eslint-disable-next-line eqeqeq
+  return a == b;
+}
+
+function withoutVoter(list: VoteEntry[] | undefined, voter: VoteEntry): VoteEntry[] {
+  if (!list?.length) return [];
+  return list.filter((e) => !sameVoter(e, voter));
+}
+
+function toggleVoter(list: VoteEntry[] | undefined, voter: VoteEntry): VoteEntry[] {
+  const without = withoutVoter(list, voter);
+  // If the voter was present, length shrinks → return the filtered list.
+  // Otherwise, append.
+  if (without.length !== (list?.length ?? 0)) return without;
+  return [...without, voter];
+}
+
+/**
+ * Compute the derived status for a proposal given its current vote arrays.
+ * Mirrors the rule used by both UIs:
+ *   any block      → 'stopped'
+ *   already done   → 'completed'   (preserved from input)
+ *   otherwise      → 'ongoing'
+ */
+export function deriveStatus(proposal: Pick<Proposal, 'participants' | 'stoppers' | 'status'>): ProposalStatus {
+  if (proposal.status === 'completed') return 'completed';
+  if ((proposal.stoppers?.length ?? 0) > 0) return 'stopped';
+  return 'ongoing';
+}
+
+/**
+ * Snapshot the tally for a proposal. Pure — does not mutate.
+ *
+ * @param proposal The proposal to inspect.
+ * @param quorum   Threshold for `hasReachedQuorum`. Defaults to `DEFAULT_QUORUM`.
+ */
+export function tallyVotes(proposal: Proposal, quorum: number = DEFAULT_QUORUM): VoteTally {
+  const agreements = proposal.participants?.length ?? 0;
+  const blocks = proposal.stoppers?.length ?? 0;
+  const status = deriveStatus(proposal);
+  return {
+    agreements,
+    blocks,
+    status,
+    hasReachedQuorum: blocks === 0 && agreements >= quorum,
+    netSupport: agreements - blocks,
+  };
+}
+
+/**
+ * Apply a vote. Returns a NEW proposal object — never mutates input.
+ *
+ * Rules (matching the existing UIs):
+ *  - 'agree' toggles membership in `participants`. Casting an agree-vote
+ *    also clears any prior block from the same voter.
+ *  - 'block' toggles membership in `stoppers`. Casting a block-vote also
+ *    clears any prior agree from the same voter.
+ *  - `status` is recomputed via {@link deriveStatus}.
+ */
+export function applyVote(
+  proposal: Proposal,
+  voter: VoteEntry,
+  direction: VoteDirection
+): Proposal {
+  if (entryId(voter) === undefined) {
+    throw new Error('applyVote: voter must have an id');
+  }
+
+  const participants = proposal.participants ?? [];
+  const stoppers = proposal.stoppers ?? [];
+
+  // Casting a vote toggles membership on its side and clears any vote on the
+  // opposing side from the same voter.
+  const next: Proposal =
+    direction === 'agree'
+      ? {
+          ...proposal,
+          participants: toggleVoter(participants, voter),
+          stoppers: withoutVoter(stoppers, voter),
+        }
+      : {
+          ...proposal,
+          participants: withoutVoter(participants, voter),
+          stoppers: toggleVoter(stoppers, voter),
+        };
+  next.status = deriveStatus(next);
+  return next;
+}
+
+/** Has this voter agreed to the proposal? */
+export function hasAgreed(proposal: Proposal, voter: VoteEntry): boolean {
+  return (proposal.participants ?? []).some((e) => sameVoter(e, voter));
+}
+
+/** Has this voter blocked the proposal? */
+export function hasBlocked(proposal: Proposal, voter: VoteEntry): boolean {
+  return (proposal.stoppers ?? []).some((e) => sameVoter(e, voter));
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
 }

--- a/packages/telegram-ui/src/council/index.js
+++ b/packages/telegram-ui/src/council/index.js
@@ -1,0 +1,11 @@
+/**
+ * @fileoverview Bot-side council facade re-exports.
+ *
+ * Existing entry points:
+ *  - `Council.js` (top-level): AI wisdom-generation — unrelated to proposal voting.
+ *  - This module: thin facade over `@holons/core/council` for proposal/vote ops.
+ *
+ * @module src/council
+ */
+
+export * from './proposals.js';

--- a/packages/telegram-ui/src/council/proposals.js
+++ b/packages/telegram-ui/src/council/proposals.js
@@ -1,0 +1,32 @@
+/**
+ * @fileoverview Bot-side facade over @holons/core/council.
+ *
+ * Quests.js stores proposals under the `quests` lens (`type === 'proposal'`)
+ * using its own holonDB instance. This facade re-exports the shared core
+ * helpers so all proposal lifecycle + voting tally logic lives in
+ * @holons/core. New bot code (and gradual refactors of Quests.js) should
+ * route writes through here instead of hand-rolling vote toggles.
+ *
+ * The HolonDB shape (`put` / `get` / `delete` / `subscribe`) satisfies the
+ * core `ProposalStore` interface as-is — no adapter required.
+ *
+ * @module src/council/proposals
+ */
+
+export {
+  PROPOSAL_LENS,
+  agree,
+  applyVote,
+  block,
+  castVote,
+  createAndSaveProposal,
+  createProposal,
+  deleteProposal,
+  saveProposal,
+  subscribeToProposals,
+  tallyVotes,
+  hasAgreed,
+  hasBlocked,
+  deriveStatus,
+  DEFAULT_QUORUM,
+} from '@holons/core/council';

--- a/packages/telegram-ui/tests/council-proposals.test.js
+++ b/packages/telegram-ui/tests/council-proposals.test.js
@@ -1,0 +1,93 @@
+// Smoke test for the bot-side council facade.
+// Verifies the @holons/core/council facade exports + HolonDB-shaped store
+// adapter contract.
+
+import { describe, expect, it } from 'vitest';
+import {
+  PROPOSAL_LENS,
+  agree,
+  applyVote,
+  block,
+  castVote,
+  createAndSaveProposal,
+  createProposal,
+  hasAgreed,
+  hasBlocked,
+  saveProposal,
+  subscribeToProposals,
+  tallyVotes,
+} from '../src/council/index.js';
+
+function makeHolonDBLike() {
+  const records = new Map();
+  const subs = [];
+  return {
+    records,
+    async put(_holon, _lens, data) {
+      records.set(data.id, JSON.parse(JSON.stringify(data)));
+      for (const cb of subs) cb(JSON.parse(JSON.stringify(data)), data.id);
+    },
+    async get(_holon, _lens, key) {
+      const r = records.get(key);
+      return r ? JSON.parse(JSON.stringify(r)) : null;
+    },
+    async delete(_holon, _lens, key) {
+      records.delete(key);
+    },
+    async subscribe(_holon, _lens, cb) {
+      subs.push(cb);
+      return { unsubscribe: () => subs.splice(subs.indexOf(cb), 1) };
+    },
+  };
+}
+
+describe('telegram-ui council facade', () => {
+  it('re-exports the canonical lens name', () => {
+    expect(PROPOSAL_LENS).toBe('quests');
+  });
+
+  it('createProposal + saveProposal round-trip through the store', async () => {
+    const db = makeHolonDBLike();
+    const p = createProposal({ title: 'Test', creator: { id: 1, first_name: 'Bot' } });
+    await saveProposal(db, '-1001', p);
+    const back = db.records.get(p.id);
+    expect(back?.title).toBe('Test');
+    expect(back?.type).toBe('proposal');
+  });
+
+  it('agree / block toggle votes via castVote', async () => {
+    const db = makeHolonDBLike();
+    const p = await createAndSaveProposal(db, '-1001', { title: 'Vote me' });
+    await agree(db, '-1001', p.id, { id: 42, first_name: 'Alice' });
+    await block(db, '-1001', p.id, { id: 99, first_name: 'Bob' });
+    const stored = db.records.get(p.id);
+    expect(stored.participants.length).toBe(1);
+    expect(stored.stoppers.length).toBe(1);
+    expect(tallyVotes(stored).status).toBe('stopped');
+  });
+
+  it('castVote is a no-op for missing proposals', async () => {
+    const db = makeHolonDBLike();
+    const result = await castVote(db, 'h', 'missing', { id: 1 }, 'agree');
+    expect(result).toBeNull();
+  });
+
+  it('applyVote is pure (no I/O) and reuses canonical rules', () => {
+    const p = createProposal({ title: 'X' });
+    const v = applyVote(p, { id: 7 }, 'agree');
+    expect(hasAgreed(v, { id: 7 })).toBe(true);
+    expect(hasBlocked(v, { id: 7 })).toBe(false);
+  });
+
+  it('subscribeToProposals filters non-proposal records', async () => {
+    const db = makeHolonDBLike();
+    const seen = [];
+    const off = await subscribeToProposals(db, 'h', (data, key) => seen.push({ data, key }));
+    await createAndSaveProposal(db, 'h', { title: 'P1' });
+    // Quest (not a proposal) under same lens — should be filtered.
+    await db.put('h', 'quests', { id: 'q1', type: 'quest', title: 'Q' });
+    expect(seen.length).toBe(1);
+    expect(seen[0].data.type).toBe('proposal');
+    off();
+  });
+});


### PR DESCRIPTION
Phase B Unit 13 of 20.

Extracts proposal lifecycle + voting tally into `@holons/core/council` (LLM prompts and Svelte-store-coupled visionClarification stay UI-side).

- New: `packages/core/src/council/{types,voting,proposals,index}.ts` + 17 vitest cases
- Web: `apps/web/src/components/Proposals.svelte` routes vote/agree/block through `@holons/core/council`
- Bot: new `packages/telegram-ui/src/council/{index,proposals}.js` facade for new callers; `Quests.js stop()` deliberately NOT swapped — its `stoppers`-only semantics differ from web `clear-the-other-side` rule (changing would alter bot behavior). New rewire surface available.
- `tallyVotes` returns `{agreements, blocks, status, hasReachedQuorum, netSupport}` so both UIs can drop inline `.length` math
- Voter id matching uses loose `==` so `"42"`, `42`, `{id:42}` all match (telegram-ui mixes forms)

`visionClarificationService.ts` deliberately untouched — it has LLM prompts and parsers, no proposal/vote schemas (data shape lives in Proposals.svelte / Quests.js).

Verification: typecheck/build clean, smoke 15 exports, svelte-kit sync, core 17/17 tests, telegram-ui 36/36+1skip.