### PR TITLE
core/library: extract borrowing/lending into @holons/core

### DIFF
--- a/packages/core/src/library/deposits.test.ts
+++ b/packages/core/src/library/deposits.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import { recordBorrowAccounting, recordReturnAccounting } from './deposits.js';
+import { createLibraryItem } from './operations.js';
+import { LIBRARY_TYPES, type LibraryDB } from './types.js';
+
+function harness() {
+  const dbPut = vi.fn<(holon: string, lens: string, data: unknown) => Promise<void>>(
+    async () => undefined
+  );
+  const db: LibraryDB = {
+    get: vi.fn(async () => null),
+    put: dbPut,
+    delete: vi.fn(async () => undefined),
+    getAll: vi.fn(async () => [])
+  };
+  const eventStorePut = vi.fn(async () => undefined);
+  const eventStore = { put: eventStorePut };
+  const factory = {
+    itemBorrowed: vi.fn(() => [{ id: 'b1' }, { id: 'b2' }]),
+    itemReturned: vi.fn(() => [{ id: 'r1' }])
+  };
+  return { deps: { db, eventStore, eventFactory: factory }, dbPut, eventStorePut, factory };
+}
+
+describe('recordBorrowAccounting', () => {
+  it('skips when borrower is the owner', async () => {
+    const { deps, dbPut, eventStorePut } = harness();
+    const item = createLibraryItem('drill', LIBRARY_TYPES.TOOL, { createdBy: 1, value: 5 });
+    await recordBorrowAccounting(deps, 'h', { id: 1 }, item);
+    expect(dbPut).not.toHaveBeenCalled();
+    expect(eventStorePut).not.toHaveBeenCalled();
+  });
+
+  it('skips when item has no value', async () => {
+    const { deps, dbPut } = harness();
+    const item = createLibraryItem('drill', LIBRARY_TYPES.TOOL, { createdBy: 1, value: 0 });
+    await recordBorrowAccounting(deps, 'h', { id: 2 }, item);
+    expect(dbPut).not.toHaveBeenCalled();
+  });
+
+  it('writes expense + REA events for a billable borrow', async () => {
+    const { deps, dbPut, eventStorePut, factory } = harness();
+    const item = createLibraryItem('drill', LIBRARY_TYPES.TOOL, { createdBy: 1, value: 5 });
+    await recordBorrowAccounting(deps, 'h', { id: 2, username: 'b' }, item);
+    expect(dbPut).toHaveBeenCalledTimes(1);
+    expect(dbPut.mock.calls[0][1]).toBe('expenses');
+    expect(eventStorePut).toHaveBeenCalledTimes(2);
+    expect(factory.itemBorrowed).toHaveBeenCalledWith('h', { id: 2, username: 'b' }, item, 5, 0);
+  });
+});
+
+describe('recordReturnAccounting', () => {
+  it('writes refund expense + return REA events for non-owner', async () => {
+    const { deps, dbPut, eventStorePut, factory } = harness();
+    const item = createLibraryItem('drill', LIBRARY_TYPES.TOOL, { createdBy: 1, value: 5 });
+    await recordReturnAccounting(deps, 'h', { id: 2 }, item);
+    expect(dbPut).toHaveBeenCalledTimes(1);
+    expect(eventStorePut).toHaveBeenCalledTimes(1);
+    expect(factory.itemReturned).toHaveBeenCalledWith('h', { id: 2 }, item, 5);
+  });
+
+  it('skips refund expense when owner returns, but still records REA events', async () => {
+    const { deps, dbPut, eventStorePut } = harness();
+    const item = createLibraryItem('drill', LIBRARY_TYPES.TOOL, { createdBy: 1, value: 5 });
+    await recordReturnAccounting(deps, 'h', { id: 1 }, item);
+    expect(dbPut).not.toHaveBeenCalled();
+    expect(eventStorePut).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/library/deposits.ts
+++ b/packages/core/src/library/deposits.ts
@@ -1,0 +1,126 @@
+/**
+ * @holons/core/library — borrow/return accounting (expenses + REA events).
+ *
+ * Pure side-effects on the storage + event-store provided by the caller. The
+ * REA event factory and aggregator live in `packages/telegram-ui/src/domain/rea`
+ * for now; this module accepts them via parameters so future units (e.g. a
+ * web borrow flow) can reuse the same accounting glue.
+ */
+
+import type { BorrowActor, LibraryDB, LibraryItem } from './types.js';
+
+// Local declaration: the core tsconfig targets ES2022 without DOM/Node libs,
+// so `console` isn't in the type lib. Accounting failures are non-fatal and
+// logged best-effort at runtime; this declare keeps the host's console.
+declare const console: { error: (...args: unknown[]) => void };
+
+const EXPENSES_LENS = 'expenses';
+
+/** Minimal interface a REA event store needs to satisfy. */
+export interface REAEventStoreLike {
+  put(holonId: string | number, event: any): Promise<unknown>;
+}
+
+/** Minimal interface a REA event factory needs to satisfy. */
+export interface REAEventFactoryLike {
+  itemBorrowed(
+    holonId: string | number,
+    borrower: BorrowActor,
+    item: LibraryItem,
+    credits: number,
+    deposit: number
+  ): any[];
+  itemReturned(
+    holonId: string | number,
+    borrower: BorrowActor,
+    item: LibraryItem,
+    depositAmount: number
+  ): any[];
+}
+
+export interface AccountingDeps {
+  db: LibraryDB;
+  eventStore: REAEventStoreLike;
+  eventFactory: REAEventFactoryLike;
+}
+
+/**
+ * Record the bookkeeping for an item-borrow: a credit-denominated expense
+ * shared between owner and borrower, plus the matching REA events. Skipped
+ * silently when the borrower owns the item, or when the item has no value.
+ *
+ * Errors are swallowed (logged) so a bookkeeping hiccup never blocks the
+ * underlying borrow — matches the behaviour of the original Library.js.
+ */
+export async function recordBorrowAccounting(
+  deps: AccountingDeps,
+  holonId: string | number,
+  borrower: BorrowActor,
+  item: LibraryItem
+): Promise<void> {
+  if (item.createdBy === borrower.id) return;
+  if (!item.value || item.value <= 0) return;
+
+  const holon = String(holonId);
+  try {
+    const expense = {
+      id: Date.now(),
+      date: Date.now(),
+      amount: item.value,
+      currency: 'credits',
+      description: `Borrowed: ${item.id}`,
+      paidBy: item.createdBy,
+      splitWith: [borrower.id],
+      itemId: item.id,
+      type: 'borrow' as const
+    };
+    await deps.db.put(holon, EXPENSES_LENS, expense);
+
+    const events = deps.eventFactory.itemBorrowed(holonId, borrower, item, item.value, 0);
+    await Promise.all(events.map((e) => deps.eventStore.put(holonId, e)));
+  } catch (error) {
+    console.error('Error creating borrow expense/events:', error);
+  }
+}
+
+/**
+ * Record the bookkeeping for an item-return: a refund expense (reverse of the
+ * borrow charge) and the matching REA events. Skipped when the returner owns
+ * the item or when there is nothing to refund.
+ */
+export async function recordReturnAccounting(
+  deps: AccountingDeps,
+  holonId: string | number,
+  returner: BorrowActor,
+  item: LibraryItem
+): Promise<void> {
+  const holon = String(holonId);
+  const isOwner = item.createdBy === returner.id;
+  const value = item.value || 0;
+
+  if (!isOwner && value > 0) {
+    try {
+      const refundExpense = {
+        id: Date.now(),
+        date: Date.now(),
+        amount: value,
+        currency: 'credits',
+        description: `Returned: ${item.id}`,
+        paidBy: returner.id,
+        splitWith: [item.createdBy],
+        itemId: item.id,
+        type: 'return' as const
+      };
+      await deps.db.put(holon, EXPENSES_LENS, refundExpense);
+    } catch (error) {
+      console.error('Error creating return expense:', error);
+    }
+  }
+
+  try {
+    const events = deps.eventFactory.itemReturned(holonId, returner, item, value);
+    await Promise.all(events.map((e) => deps.eventStore.put(holonId, e)));
+  } catch (error) {
+    console.error('Error creating REA events for return:', error);
+  }
+}

--- a/packages/core/src/library/index.ts
+++ b/packages/core/src/library/index.ts
@@ -1,0 +1,50 @@
+/**
+ * @holons/core/library
+ *
+ * Shared community-library domain logic. Authoritative source for borrowing
+ * and lending CRUD + deposit accounting, used by the Telegram bot today and
+ * by future web/text/AI UIs.
+ *
+ * Subpath import:
+ *   import { addItem, borrowItem, recordBorrowAccounting } from '@holons/core/library';
+ */
+
+export {
+  LIBRARY_TYPES,
+  type BorrowActor,
+  type CreateLibraryItemOptions,
+  type LibraryDB,
+  type LibraryItem,
+  type LibraryItemType,
+  type LibraryStats
+} from './types.js';
+
+export {
+  addItem,
+  borrowItem,
+  computeBorrowerInitials,
+  createLibraryItem,
+  detectItemType,
+  filterItems,
+  getItem,
+  getItemDisplayTitle,
+  getItemIcon,
+  getLibraryStats,
+  getTypeDisplayName,
+  listItems,
+  removeItem,
+  returnItem,
+  setItemValue,
+  type AddItemResult,
+  type BorrowItemResult,
+  type ReturnItemResult,
+  type SetValueResult
+} from './operations.js';
+
+export {
+  recordBorrowAccounting,
+  recordReturnAccounting,
+  type AccountingDeps,
+  type REAEventFactoryLike,
+  type REAEventStoreLike
+} from './deposits.js';

--- a/packages/core/src/library/operations.test.ts
+++ b/packages/core/src/library/operations.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  addItem,
+  borrowItem,
+  computeBorrowerInitials,
+  createLibraryItem,
+  detectItemType,
+  filterItems,
+  getItem,
+  getItemDisplayTitle,
+  getItemIcon,
+  getLibraryStats,
+  getTypeDisplayName,
+  listItems,
+  removeItem,
+  returnItem,
+  setItemValue
+} from './operations.js';
+import { LIBRARY_TYPES, type LibraryDB, type LibraryItem } from './types.js';
+
+function mockDb(initial: Record<string, LibraryItem> = {}): {
+  db: LibraryDB;
+  store: Map<string, LibraryItem>;
+  put: ReturnType<typeof vi.fn>;
+  del: ReturnType<typeof vi.fn>;
+} {
+  const store = new Map(Object.entries(initial));
+  const put = vi.fn(async (_h: string, _l: string, data: any) => {
+    store.set(data.id, data);
+  });
+  const del = vi.fn(async (_h: string, _l: string, key: string) => {
+    store.delete(key);
+  });
+  const db: LibraryDB = {
+    get: vi.fn(async (_h: string, _l: string, key?: string) => store.get(key ?? '') ?? null),
+    put,
+    delete: del,
+    getAll: vi.fn(async () => Array.from(store.values()))
+  };
+  return { db, store, put, del };
+}
+
+describe('detectItemType', () => {
+  it('detects tools, books, equipment, and falls back to other', () => {
+    expect(detectItemType('hammer')).toBe(LIBRARY_TYPES.TOOL);
+    expect(detectItemType('A guide to bees')).toBe(LIBRARY_TYPES.BOOK);
+    expect(detectItemType('Camera tripod')).toBe(LIBRARY_TYPES.EQUIPMENT);
+    expect(detectItemType('thingamajig')).toBe(LIBRARY_TYPES.OTHER);
+  });
+});
+
+describe('createLibraryItem', () => {
+  it('uses sensible defaults and preserves overrides', () => {
+    const item = createLibraryItem('drill', LIBRARY_TYPES.TOOL, {
+      createdBy: 1,
+      createdByUsername: 'alice',
+      category: 'shed',
+      value: 5
+    });
+    expect(item).toMatchObject({
+      id: 'drill',
+      type: 'tool',
+      borrowed: false,
+      borrower: null,
+      category: 'shed',
+      value: 5,
+      createdBy: 1,
+      createdByUsername: 'alice'
+    });
+    expect(item.created).toBeInstanceOf(Date);
+  });
+
+  it('falls back to OTHER when type is missing', () => {
+    expect(createLibraryItem('x').type).toBe(LIBRARY_TYPES.OTHER);
+  });
+});
+
+describe('getItemIcon / getTypeDisplayName / getItemDisplayTitle', () => {
+  it('maps types to icons', () => {
+    expect(getItemIcon({ type: LIBRARY_TYPES.TOOL })).toBe('🔧');
+    expect(getItemIcon({ type: LIBRARY_TYPES.BOOK })).toBe('📚');
+    expect(getItemIcon({ type: LIBRARY_TYPES.EQUIPMENT })).toBe('⚙️');
+    expect(getItemIcon({ type: LIBRARY_TYPES.OTHER })).toBe('📦');
+    expect(getItemIcon('legacy-string')).toBe('📦');
+  });
+  it('maps types to display names', () => {
+    expect(getTypeDisplayName(LIBRARY_TYPES.TOOL)).toBe('tool');
+    expect(getTypeDisplayName(undefined)).toBe('item');
+  });
+  it('handles legacy string items', () => {
+    expect(getItemDisplayTitle('plain')).toBe('plain');
+    expect(getItemDisplayTitle({ id: 'drill' })).toBe('drill');
+  });
+});
+
+describe('computeBorrowerInitials', () => {
+  it('prefers first+last initials, then username, then ?', () => {
+    expect(computeBorrowerInitials({ id: 1, first_name: 'Ada', last_name: 'Lovelace' })).toBe('AL');
+    expect(computeBorrowerInitials({ id: 2, first_name: 'Mononym' })).toBe('M');
+    expect(computeBorrowerInitials({ id: 3, username: 'zara' })).toBe('Z');
+    expect(computeBorrowerInitials({ id: 4 })).toBe('?');
+  });
+});
+
+describe('addItem', () => {
+  it('adds when absent and rejects duplicates', async () => {
+    const { db, store, put } = mockDb();
+    const ok = await addItem(db, 'h1', 'hammer', { createdBy: 1, value: 3 });
+    expect(ok.ok).toBe(true);
+    expect(ok.item?.type).toBe(LIBRARY_TYPES.TOOL);
+    expect(store.has('hammer')).toBe(true);
+    expect(put).toHaveBeenCalledTimes(1);
+
+    const dup = await addItem(db, 'h1', 'hammer');
+    expect(dup.ok).toBe(false);
+    expect(dup.reason).toBe('already_exists');
+  });
+});
+
+describe('removeItem / getItem / listItems / filterItems / getLibraryStats', () => {
+  it('round-trips through the storage layer', async () => {
+    const { db, del } = mockDb({
+      apple: createLibraryItem('apple', LIBRARY_TYPES.OTHER, { category: 'fruit' }),
+      drill: createLibraryItem('drill', LIBRARY_TYPES.TOOL, { category: 'shed' })
+    });
+    expect((await getItem(db, 'h', 'apple'))?.id).toBe('apple');
+    const items = await listItems(db, 'h');
+    expect(items.map((i) => i.id)).toEqual(['apple', 'drill']);
+
+    expect(filterItems(items, 'shed').map((i) => i.id)).toEqual(['drill']);
+    expect(filterItems(items, '').length).toBe(2);
+
+    const stats = getLibraryStats(items);
+    expect(stats.total).toBe(2);
+    expect(stats.borrowed).toBe(0);
+    expect(stats.available).toBe(2);
+    expect(stats.byType).toEqual({ other: 1, tool: 1 });
+
+    await removeItem(db, 'h', 'apple');
+    expect(del).toHaveBeenCalledWith('h', 'library', 'apple');
+  });
+});
+
+describe('setItemValue', () => {
+  it('lets the owner change value and rejects others', async () => {
+    const item = createLibraryItem('drill', LIBRARY_TYPES.TOOL, { createdBy: 1, value: 5 });
+    const { db } = mockDb({ drill: item });
+
+    const owner = await setItemValue(db, 'h', 'drill', 8, 1);
+    expect(owner.ok).toBe(true);
+    expect(owner.item?.value).toBe(8);
+
+    const stranger = await setItemValue(db, 'h', 'drill', 999, 2);
+    expect(stranger.ok).toBe(false);
+    expect(stranger.reason).toBe('forbidden');
+
+    const missing = await setItemValue(db, 'h', 'nope', 1, 1);
+    expect(missing.ok).toBe(false);
+    expect(missing.reason).toBe('not_found');
+  });
+});
+
+describe('borrowItem / returnItem', () => {
+  it('marks borrowed/returned and surfaces ownership', async () => {
+    const item = createLibraryItem('drill', LIBRARY_TYPES.TOOL, { createdBy: 10, value: 2 });
+    const { db } = mockDb({ drill: item });
+
+    const taken = await borrowItem(
+      db,
+      'h',
+      'drill',
+      { id: 20, username: 'bob', first_name: 'Bob' },
+      new Date('2099-01-01')
+    );
+    expect(taken.ok).toBe(true);
+    expect(taken.isOwner).toBe(false);
+    expect(taken.item?.borrowed).toBe(true);
+    expect(taken.item?.borrowerInitials).toBe('B');
+
+    const conflict = await borrowItem(
+      db,
+      'h',
+      'drill',
+      { id: 30, username: 'eve' },
+      new Date('2099-02-01')
+    );
+    expect(conflict.ok).toBe(false);
+    expect(conflict.reason).toBe('already_borrowed');
+
+    const wrongReturner = await returnItem(db, 'h', 'drill', { id: 99, username: 'mallory' });
+    expect(wrongReturner.ok).toBe(false);
+    expect(wrongReturner.reason).toBe('forbidden');
+    // Snapshot is preserved on forbidden so callers can show the borrower.
+    expect(wrongReturner.item?.borrower).toBe('bob');
+
+    const returned = await returnItem(db, 'h', 'drill', { id: 20, username: 'bob' });
+    expect(returned.ok).toBe(true);
+    expect(returned.item?.borrowed).toBe(false);
+    // value/createdBy survive the return so accounting helpers still work.
+    expect(returned.item?.value).toBe(2);
+    expect(returned.item?.createdBy).toBe(10);
+
+    const notBorrowed = await returnItem(db, 'h', 'drill', { id: 20, username: 'bob' });
+    expect(notBorrowed.ok).toBe(false);
+    expect(notBorrowed.reason).toBe('not_borrowed');
+  });
+
+  it('rejects borrow on missing item', async () => {
+    const { db } = mockDb();
+    const r = await borrowItem(db, 'h', 'missing', { id: 1 }, new Date());
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('not_found');
+  });
+});

--- a/packages/core/src/library/operations.ts
+++ b/packages/core/src/library/operations.ts
@@ -1,0 +1,297 @@
+/**
+ * @holons/core/library — UI-agnostic CRUD + helpers for community library items.
+ *
+ * The bot's `Library.js` (Telegraf) and any future web UI both call these
+ * helpers so that the storage shape stays consistent across surfaces.
+ *
+ * The DB parameter is anything matching `LibraryDB` (HoloSphere implements it).
+ */
+
+import {
+  LIBRARY_TYPES,
+  type BorrowActor,
+  type CreateLibraryItemOptions,
+  type LibraryDB,
+  type LibraryItem,
+  type LibraryItemType,
+  type LibraryStats
+} from './types.js';
+
+const LENS = 'library';
+
+const TOOL_KEYWORDS = [
+  'hammer',
+  'drill',
+  'saw',
+  'screwdriver',
+  'wrench',
+  'pliers',
+  'shovel',
+  'rake',
+  'axe',
+  'knife'
+];
+const BOOK_KEYWORDS = ['book', 'manual', 'guide', 'novel', 'textbook'];
+const EQUIPMENT_KEYWORDS = ['camera', 'projector', 'speaker', 'tent', 'bicycle', 'ladder'];
+
+/** Detect a likely item category from its name. */
+export function detectItemType(itemName: string): LibraryItemType {
+  const name = itemName.toLowerCase();
+  if (TOOL_KEYWORDS.some((k) => name.includes(k))) return LIBRARY_TYPES.TOOL;
+  if (BOOK_KEYWORDS.some((k) => name.includes(k))) return LIBRARY_TYPES.BOOK;
+  if (EQUIPMENT_KEYWORDS.some((k) => name.includes(k))) return LIBRARY_TYPES.EQUIPMENT;
+  return LIBRARY_TYPES.OTHER;
+}
+
+/** Build a fully-populated `LibraryItem` ready to persist. */
+export function createLibraryItem(
+  id: string,
+  type?: LibraryItemType | null,
+  options: CreateLibraryItemOptions = {}
+): LibraryItem {
+  return {
+    id,
+    type: type || LIBRARY_TYPES.OTHER,
+    borrowed: false,
+    createdBy: options.createdBy,
+    createdByUsername: options.createdByUsername,
+    borrower: null,
+    category: options.category || 'Uncategorized',
+    description: options.description || '',
+    value: options.value || 0,
+    created: new Date()
+  };
+}
+
+/** Pick a display icon for an item (or string fallback). */
+export function getItemIcon(item: { type?: string } | string): string {
+  if (typeof item === 'string') return '📦';
+  switch (item.type) {
+    case LIBRARY_TYPES.TOOL:
+      return '🔧';
+    case LIBRARY_TYPES.BOOK:
+      return '📚';
+    case LIBRARY_TYPES.EQUIPMENT:
+      return '⚙️';
+    case LIBRARY_TYPES.OTHER:
+    default:
+      return '📦';
+  }
+}
+
+/** Human-friendly type name, e.g. for stats listings. */
+export function getTypeDisplayName(type?: string): string {
+  switch (type) {
+    case LIBRARY_TYPES.TOOL:
+      return 'tool';
+    case LIBRARY_TYPES.BOOK:
+      return 'book';
+    case LIBRARY_TYPES.EQUIPMENT:
+      return 'equipment';
+    case LIBRARY_TYPES.OTHER:
+    default:
+      return 'item';
+  }
+}
+
+/** Display title for an item or legacy string entry. */
+export function getItemDisplayTitle(item: { id?: string } | string): string {
+  if (typeof item === 'string') return item;
+  return item.id ?? '';
+}
+
+/** Compute borrower initials from first/last name with username fallback. */
+export function computeBorrowerInitials(actor: BorrowActor): string {
+  const firstInitial = actor.first_name ? actor.first_name.charAt(0).toUpperCase() : '';
+  const lastInitial = actor.last_name ? actor.last_name.charAt(0).toUpperCase() : '';
+  const initials = firstInitial + lastInitial;
+  if (initials) return initials;
+  if (actor.username) return actor.username.charAt(0).toUpperCase();
+  return '?';
+}
+
+// ============================================================================
+// Read operations
+// ============================================================================
+
+/** Fetch a single item by id from a holon's library. Returns `null` if absent. */
+export async function getItem(
+  db: LibraryDB,
+  holonId: string | number,
+  itemId: string
+): Promise<LibraryItem | null> {
+  return (await db.get(String(holonId), LENS, itemId)) as LibraryItem | null;
+}
+
+/** List all library items for a holon, sorted by id. */
+export async function listItems(db: LibraryDB, holonId: string | number): Promise<LibraryItem[]> {
+  const list = ((await db.getAll(String(holonId), LENS)) || []) as LibraryItem[];
+  list.sort((a, b) => String(a.id).localeCompare(String(b.id)));
+  return list;
+}
+
+/** Filter library items by free-text term (matches id and category, case-insensitive). */
+export function filterItems(items: LibraryItem[], term: string): LibraryItem[] {
+  const needle = (term || '').toLowerCase();
+  if (!needle) return items;
+  return items.filter(
+    (item) =>
+      String(item.id || '')
+        .toLowerCase()
+        .includes(needle) ||
+      String(item.category || '')
+        .toLowerCase()
+        .includes(needle)
+  );
+}
+
+/** Aggregate library stats (totals, byType, borrowed/available). */
+export function getLibraryStats(items: LibraryItem[]): LibraryStats {
+  const byType: Record<string, number> = {};
+  for (const item of items) {
+    const type = item.type || LIBRARY_TYPES.OTHER;
+    byType[type] = (byType[type] || 0) + 1;
+  }
+  return {
+    total: items.length,
+    borrowed: items.filter((i) => i.borrowed).length,
+    available: items.filter((i) => !i.borrowed).length,
+    byType
+  };
+}
+
+// ============================================================================
+// Mutating operations — return outcomes so UIs can render appropriate messages
+// ============================================================================
+
+export interface AddItemResult {
+  ok: boolean;
+  item?: LibraryItem;
+  reason?: 'already_exists';
+}
+
+/** Add a new library item if the id is not already taken. */
+export async function addItem(
+  db: LibraryDB,
+  holonId: string | number,
+  itemId: string,
+  options: CreateLibraryItemOptions = {}
+): Promise<AddItemResult> {
+  const holon = String(holonId);
+  if (await db.get(holon, LENS, itemId)) {
+    return { ok: false, reason: 'already_exists' };
+  }
+  const type = detectItemType(itemId);
+  const item = createLibraryItem(itemId, type, options);
+  await db.put(holon, LENS, item);
+  return { ok: true, item };
+}
+
+/** Delete a library item unconditionally. */
+export async function removeItem(
+  db: LibraryDB,
+  holonId: string | number,
+  itemId: string
+): Promise<void> {
+  await db.delete(String(holonId), LENS, itemId);
+}
+
+export interface SetValueResult {
+  ok: boolean;
+  item?: LibraryItem;
+  reason?: 'not_found' | 'forbidden';
+}
+
+/** Update an item's credit value. Only the original owner may change it. */
+export async function setItemValue(
+  db: LibraryDB,
+  holonId: string | number,
+  itemId: string,
+  value: number,
+  requestingUserId: number | string
+): Promise<SetValueResult> {
+  const holon = String(holonId);
+  const item = (await db.get(holon, LENS, itemId)) as LibraryItem | null;
+  if (!item) return { ok: false, reason: 'not_found' };
+  if (item.createdBy !== requestingUserId) return { ok: false, reason: 'forbidden' };
+  item.value = Number.isFinite(value) ? value : 0;
+  await db.put(holon, LENS, item);
+  return { ok: true, item };
+}
+
+export interface BorrowItemResult {
+  ok: boolean;
+  item?: LibraryItem;
+  /** True when the borrower is the item's owner (no credit charge applies). */
+  isOwner?: boolean;
+  reason?: 'not_found' | 'already_borrowed';
+}
+
+/**
+ * Mark an item as borrowed by `borrower`. Caller is responsible for any
+ * concurrency guarding (the bot uses an in-memory lock around the calendar
+ * picker) and any expense/REA bookkeeping (see `recordBorrowAccounting`).
+ */
+export async function borrowItem(
+  db: LibraryDB,
+  holonId: string | number,
+  itemId: string,
+  borrower: BorrowActor,
+  returnDate: Date | string
+): Promise<BorrowItemResult> {
+  const holon = String(holonId);
+  const item = (await db.get(holon, LENS, itemId)) as LibraryItem | null;
+  if (!item) return { ok: false, reason: 'not_found' };
+  if (item.borrowed) return { ok: false, reason: 'already_borrowed' };
+
+  item.borrowed = true;
+  item.borrower = borrower.username ?? null;
+  item.borrowerId = borrower.id;
+  item.borrowerInitials = computeBorrowerInitials(borrower);
+  item.borrowedAt = new Date();
+  item.returnBy = returnDate instanceof Date ? returnDate : new Date(returnDate);
+  await db.put(holon, LENS, item);
+
+  return { ok: true, item, isOwner: item.createdBy === borrower.id };
+}
+
+export interface ReturnItemResult {
+  ok: boolean;
+  item?: LibraryItem;
+  isOwner?: boolean;
+  reason?: 'not_found' | 'not_borrowed' | 'forbidden';
+}
+
+/**
+ * Mark an item as returned by `returner`. Only the current borrower (matched
+ * by id, falling back to username) may return. The current item snapshot is
+ * always returned (on success and on `not_borrowed`/`forbidden`) so callers
+ * can render meaningful error messages without re-fetching.
+ */
+export async function returnItem(
+  db: LibraryDB,
+  holonId: string | number,
+  itemId: string,
+  returner: BorrowActor
+): Promise<ReturnItemResult> {
+  const holon = String(holonId);
+  const item = (await db.get(holon, LENS, itemId)) as LibraryItem | null;
+  if (!item) return { ok: false, reason: 'not_found' };
+  if (!item.borrowed) return { ok: false, reason: 'not_borrowed', item };
+
+  const isBorrower =
+    item.borrowerId === returner.id || (returner.username && item.borrower === returner.username);
+  if (!isBorrower) return { ok: false, reason: 'forbidden', item };
+
+  const isOwner = item.createdBy === returner.id;
+
+  // Snapshot pre-clear values (value, createdBy) survive untouched, so the
+  // caller can hand the returned item straight to accounting helpers.
+  item.borrowed = false;
+  item.borrower = null;
+  item.borrowerId = null;
+  item.returnedAt = new Date();
+  await db.put(holon, LENS, item);
+
+  return { ok: true, item, isOwner };
+}

--- a/packages/core/src/library/types.ts
+++ b/packages/core/src/library/types.ts
@@ -1,0 +1,73 @@
+/**
+ * @holons/core/library — type definitions
+ *
+ * Authoritative source for community-library item shapes shared across UIs.
+ * Originally extracted from packages/telegram-ui/src/Library.js.
+ */
+
+/** Standard item categories supported by the library. */
+export const LIBRARY_TYPES = {
+  TOOL: 'tool',
+  BOOK: 'book',
+  EQUIPMENT: 'equipment',
+  OTHER: 'other'
+} as const;
+
+export type LibraryItemType = (typeof LIBRARY_TYPES)[keyof typeof LIBRARY_TYPES];
+
+/** Persisted library item shape. */
+export interface LibraryItem {
+  id: string;
+  type: LibraryItemType;
+  borrowed: boolean;
+  /** Telegram user id of the owner (numeric in TG, but tolerated as string). */
+  createdBy?: number | string;
+  createdByUsername?: string;
+  borrower: string | null;
+  borrowerId?: number | string | null;
+  borrowerInitials?: string;
+  borrowedAt?: Date | string;
+  returnBy?: Date | string;
+  returnedAt?: Date | string;
+  category: string;
+  description: string;
+  value: number;
+  created: Date | string;
+  ratings?: Array<{ user?: string; rating: number; review?: string; date: Date | string }>;
+  issues?: Array<{ reporter?: string; issue: string; date: Date | string; resolved: boolean }>;
+  // forward compat
+  [k: string]: unknown;
+}
+
+/** Options for `createLibraryItem`. */
+export interface CreateLibraryItemOptions {
+  createdBy?: number | string;
+  createdByUsername?: string;
+  category?: string;
+  description?: string;
+  value?: number;
+}
+
+/** Minimal HoloSphere-shaped storage interface this module needs. */
+export interface LibraryDB {
+  get(holon: string, lens: string, key?: string): Promise<any | null>;
+  put(holon: string, lens: string, data: any): Promise<unknown>;
+  delete(holon: string, lens: string, key: string): Promise<unknown>;
+  getAll(holon: string, lens: string): Promise<Array<any>>;
+}
+
+/** Shape of a borrower (caller-provided; matches Telegram `ctx.from`). */
+export interface BorrowActor {
+  id: number | string;
+  username?: string;
+  first_name?: string;
+  last_name?: string;
+}
+
+/** Aggregate stats produced by `getLibraryStats`. */
+export interface LibraryStats {
+  total: number;
+  borrowed: number;
+  available: number;
+  byType: Record<string, number>;
+}

--- a/packages/telegram-ui/src/Library.js
+++ b/packages/telegram-ui/src/Library.js
@@ -1,23 +1,35 @@
 /**
  * @fileoverview Community library system for item lending and borrowing.
+ *
+ * This module is now a thin Telegraf adapter on top of `@holons/core/library`.
+ * All persistence, validation, and accounting logic lives in core; this file
+ * owns the bot UX (commands, inline keyboards, calendar pickers, photo flow).
+ *
  * @module src/Library
  */
 
 import { Markup } from 'telegraf';
+import {
+    LIBRARY_TYPES,
+    addItem as coreAddItem,
+    borrowItem as coreBorrowItem,
+    createLibraryItem as coreCreateLibraryItem,
+    detectItemType as coreDetectItemType,
+    filterItems as coreFilterItems,
+    getItemDisplayTitle as coreGetItemDisplayTitle,
+    getItemIcon as coreGetItemIcon,
+    getLibraryStats as coreGetLibraryStats,
+    getTypeDisplayName as coreGetTypeDisplayName,
+    listItems as coreListItems,
+    recordBorrowAccounting,
+    recordReturnAccounting,
+    removeItem as coreRemoveItem,
+    returnItem as coreReturnItem,
+    setItemValue as coreSetItemValue
+} from '@holons/core/library';
 import { REAEventStore, REAEventFactory, REAAggregator } from './domain/rea/index.js';
 import { extractItemsFromImage } from './AI.js';
 import { Calendar } from './Calendar.js';
-
-/**
- * Standard library item types supported by the system.
- * @constant {Object.<string, string>}
- */
-const LIBRARY_TYPES = {
-    TOOL: 'tool',
-    BOOK: 'book',
-    EQUIPMENT: 'equipment',
-    OTHER: 'other'
-};
 
 /**
  * Number of items to display per page in the library.
@@ -42,7 +54,7 @@ const ITEMS_PER_PAGE = 15;
  *
  * @example
  * const library = new Library(bot, db);
- * // Use /additem hammer 5 to add an item worth 5 credits
+ * // Use /libadd hammer 5 to add an item worth 5 credits
  * // Use /borrow hammer to borrow an item
  */
 class Library {
@@ -63,7 +75,8 @@ class Library {
             start_date: new Date() // Can't select past dates
         });
 
-        // Initialize REA components
+        // Initialize REA components (still owned by the bot — passed to core
+        // accounting helpers when recording borrows/returns)
         this.eventStore = new REAEventStore(db);
         this.eventFactory = REAEventFactory;
         this.aggregator = new REAAggregator(this.eventStore);
@@ -115,63 +128,29 @@ class Library {
     }
 
     // Helper method to create a standardized library item
+    // (delegates to @holons/core/library for the canonical shape)
     createLibraryItem(id, type, options = {}) {
-        return {
-            id: id,
-            type: type || LIBRARY_TYPES.OTHER,
-            borrowed: false,
-            createdBy: options.createdBy,
-            createdByUsername: options.createdByUsername,
-            borrower: null,
-            category: options.category || 'Uncategorized',
-            description: options.description || '',
-            value: options.value || 0,
-            created: new Date()
-        };
+        return coreCreateLibraryItem(id, type, options);
     }
 
     // Helper method to get item icon based on type
     getItemIcon(item) {
-        if (typeof item === 'string') {
-            return '📦';
-        }
-        switch (item.type) {
-            case LIBRARY_TYPES.TOOL: return '🔧';
-            case LIBRARY_TYPES.BOOK: return '📚';
-            case LIBRARY_TYPES.EQUIPMENT: return '⚙️';
-            case LIBRARY_TYPES.OTHER:
-            default: return '📦';
-        }
+        return coreGetItemIcon(item);
     }
 
     // Helper method to get item display title
     getItemDisplayTitle(item) {
-        if (typeof item === 'string') return item;
-        return item.id;
+        return coreGetItemDisplayTitle(item);
     }
 
     // Helper method to get type display name
     getTypeDisplayName(type) {
-        switch (type) {
-            case LIBRARY_TYPES.TOOL: return 'tool';
-            case LIBRARY_TYPES.BOOK: return 'book';
-            case LIBRARY_TYPES.EQUIPMENT: return 'equipment';
-            case LIBRARY_TYPES.OTHER:
-            default: return 'item';
-        }
+        return coreGetTypeDisplayName(type);
     }
 
     // Helper to detect item type from name
     detectItemType(itemName) {
-        const name = itemName.toLowerCase();
-        const toolKeywords = ['hammer', 'drill', 'saw', 'screwdriver', 'wrench', 'pliers', 'shovel', 'rake', 'axe', 'knife'];
-        const bookKeywords = ['book', 'manual', 'guide', 'novel', 'textbook'];
-        const equipmentKeywords = ['camera', 'projector', 'speaker', 'tent', 'bicycle', 'ladder'];
-
-        if (toolKeywords.some(k => name.includes(k))) return LIBRARY_TYPES.TOOL;
-        if (bookKeywords.some(k => name.includes(k))) return LIBRARY_TYPES.BOOK;
-        if (equipmentKeywords.some(k => name.includes(k))) return LIBRARY_TYPES.EQUIPMENT;
-        return LIBRARY_TYPES.OTHER;
+        return coreDetectItemType(itemName);
     }
 
     async addItem(ctx) {
@@ -182,22 +161,21 @@ class Library {
             ctx.reply('Please specify an item to add. eg: /libadd hammer 10 tools');
             return;
         }
-        if (await this.db.get(holonId.toString(), 'library', item)) {
+
+        const result = await coreAddItem(this.db, holonId, item, {
+            createdBy: ctx.from.id,
+            createdByUsername: ctx.from.username,
+            category,
+            value: parseInt(value) || 0
+        });
+
+        if (!result.ok) {
             ctx.reply(`${item} is already in the library.`);
             return;
         }
 
-        const itemValue = parseInt(value) || 0;
-        const itemType = this.detectItemType(item);
-        const libraryItem = this.createLibraryItem(item, itemType, {
-            createdBy: ctx.from.id,
-            createdByUsername: ctx.from.username,
-            category: category,
-            value: itemValue
-        });
-
-        await this.db.put(holonId.toString(), 'library', libraryItem);
-        const icon = this.getItemIcon(libraryItem);
+        const icon = this.getItemIcon(result.item);
+        const itemValue = result.item.value;
         ctx.reply(`${icon} Added ${item} to the library${itemValue > 0 ? ` (value: ${itemValue})` : ''}.`);
     }
 
@@ -208,7 +186,7 @@ class Library {
             ctx.reply('Please specify an item to remove. eg: /libremove hammer');
             return;
         }
-        await this.db.delete(holonId.toString(), 'library', item);
+        await coreRemoveItem(this.db, holonId, item);
         ctx.reply(`Removed ${item} from the library.`);
     }
 
@@ -398,18 +376,15 @@ class Library {
             return;
         }
 
-        const { itemName, username, firstName, lastName } = pendingBorrow;
+        const { itemName, username, firstName } = pendingBorrow;
         const returnDate = new Date(dateStr);
 
-        // Create initials from first name and last name
-        const firstInitial = firstName ? firstName.charAt(0).toUpperCase() : '';
-        const lastInitial = lastName ? lastName.charAt(0).toUpperCase() : '';
-        const initials = firstInitial + lastInitial || (username ? username.charAt(0).toUpperCase() : '?');
-
         try {
-            // Re-check item is still available
-            const freshItem = await this.db.get(holonId.toString(), 'library', itemName);
-            if (!freshItem || freshItem.borrowed) {
+            // Borrow + record accounting through @holons/core/library so the
+            // canonical shape (borrower, borrowerInitials, returnBy, expenses,
+            // REA events) stays consistent across UIs.
+            const result = await coreBorrowItem(this.db, holonId, itemName, ctx.from, returnDate);
+            if (!result.ok) {
                 await ctx.answerCbQuery('Item is no longer available.').catch(() => {});
                 this.pendingBorrows.delete(pendingKey);
                 this.borrowLocks.delete(pendingKey);
@@ -417,46 +392,13 @@ class Library {
                 return;
             }
 
-            // Check if it's the owner borrowing
-            const isOwner = freshItem.createdBy === ctx.from.id;
-
-            // Create expense entry for borrowed item (if has value and not owner)
-            if (!isOwner && freshItem.value > 0) {
-                try {
-                    const expense = {
-                        id: Date.now(),
-                        date: Date.now(),
-                        amount: freshItem.value,
-                        currency: 'credits',
-                        description: `Borrowed: ${itemName}`,
-                        paidBy: freshItem.createdBy,
-                        splitWith: [ctx.from.id],
-                        itemId: itemName,
-                        type: 'borrow'
-                    };
-                    await this.db.put(holonId.toString(), 'expenses', expense);
-
-                    const events = this.eventFactory.itemBorrowed(
-                        holonId,
-                        ctx.from,
-                        freshItem,
-                        freshItem.value,
-                        0
-                    );
-                    await Promise.all(events.map(e => this.eventStore.put(holonId, e)));
-                } catch (error) {
-                    console.error('Error creating borrow expense/events:', error);
-                }
-            }
-
-            // Update item with borrow info including return date and initials
-            freshItem.borrowed = true;
-            freshItem.borrower = username;
-            freshItem.borrowerId = ctx.from.id;
-            freshItem.borrowerInitials = initials;
-            freshItem.borrowedAt = new Date();
-            freshItem.returnBy = returnDate;
-            await this.db.put(holonId.toString(), 'library', freshItem);
+            const freshItem = result.item;
+            await recordBorrowAccounting(
+                { db: this.db, eventStore: this.eventStore, eventFactory: this.eventFactory },
+                holonId,
+                ctx.from,
+                freshItem
+            );
 
             await ctx.answerCbQuery(`Borrowed until ${dateStr}`).catch(() => {});
 
@@ -467,7 +409,7 @@ class Library {
 
             // Build confirmation message with credit info if applicable
             let confirmMsg = `${icon} ${firstName || username} borrowed ${itemName}\n📅 Return by: ${dateStr}`;
-            if (!isOwner && freshItem.value > 0) {
+            if (!result.isOwner && freshItem.value > 0) {
                 confirmMsg += `\n💳 ${freshItem.value}● charged`;
             }
             confirmMsg += '\n\n📦 Library:';
@@ -506,21 +448,17 @@ class Library {
             return;
         }
 
-        let currentItem = await this.db.get(holonId.toString(), 'library', item);
-        if (!currentItem) {
-            ctx.reply(`${item} is not in the library.`);
+        const result = await coreSetItemValue(this.db, holonId, item, parseInt(value) || 0, ctx.from.id);
+        if (!result.ok) {
+            if (result.reason === 'not_found') {
+                ctx.reply(`${item} is not in the library.`);
+            } else if (result.reason === 'forbidden') {
+                ctx.reply(`Only the owner can change the value for ${item}.`);
+            }
             return;
         }
-
-        if (currentItem.createdBy !== ctx.from.id) {
-            ctx.reply(`Only the owner can change the value for ${item}.`);
-            return;
-        }
-
-        currentItem.value = parseInt(value) || 0;
-        await this.db.put(holonId.toString(), 'library', currentItem);
-        const icon = this.getItemIcon(currentItem);
-        ctx.reply(`${icon} Updated ${item} value to ${currentItem.value}.`);
+        const icon = this.getItemIcon(result.item);
+        ctx.reply(`${icon} Updated ${item} value to ${result.item.value}.`);
     }
 
     async returnItem(ctx, fromKeyboard = false) {
@@ -538,76 +476,45 @@ class Library {
             return;
         }
 
-        let currentItem = await this.db.get(holonId.toString(), 'library', item);
-        if (!currentItem) {
-            if (fromKeyboard) await ctx.answerCbQuery(`${item} is not in the library.`).catch(() => {});
-            else ctx.reply(`${item} is not in the library.`);
-            return;
-        }
-        if (!currentItem.borrowed) {
-            if (fromKeyboard) await ctx.answerCbQuery(`${item} is not borrowed.`).catch(() => {});
-            else ctx.reply(`${item} is not borrowed.`);
-            return;
-        }
-
-        // Check by borrowerId (more reliable) or fall back to username
-        const isBorrower = currentItem.borrowerId === ctx.from.id ||
-                          currentItem.borrower === ctx.from.username;
-        if (!isBorrower) {
-            if (fromKeyboard) await ctx.answerCbQuery(`Only ${currentItem.borrower} can return this item.`).catch(() => {});
-            else ctx.reply(`Only ${currentItem.borrower} can return this item.`);
-            return;
-        }
-
-        // Check if it's the owner returning (owner doesn't pay/get refunded)
-        const isOwner = currentItem.createdBy === ctx.from.id;
-
-        // Create reverse expense entry to cancel the borrow charge
-        if (!isOwner && currentItem.value > 0) {
-            try {
-                const refundExpense = {
-                    id: Date.now(),
-                    date: Date.now(),
-                    amount: currentItem.value,
-                    currency: 'credits',
-                    description: `Returned: ${item}`,
-                    paidBy: ctx.from.id,
-                    splitWith: [currentItem.createdBy],
-                    itemId: item,
-                    type: 'return'
-                };
-                await this.db.put(holonId.toString(), 'expenses', refundExpense);
-            } catch (error) {
-                console.error('Error creating return expense:', error);
+        const result = await coreReturnItem(this.db, holonId, item, ctx.from);
+        if (!result.ok) {
+            if (result.reason === 'not_found') {
+                if (fromKeyboard) await ctx.answerCbQuery(`${item} is not in the library.`).catch(() => {});
+                else ctx.reply(`${item} is not in the library.`);
+                return;
             }
+            if (result.reason === 'not_borrowed') {
+                if (fromKeyboard) await ctx.answerCbQuery(`${item} is not borrowed.`).catch(() => {});
+                else ctx.reply(`${item} is not borrowed.`);
+                return;
+            }
+            if (result.reason === 'forbidden') {
+                const borrower = result.item?.borrower || 'the borrower';
+                if (fromKeyboard) await ctx.answerCbQuery(`Only ${borrower} can return this item.`).catch(() => {});
+                else ctx.reply(`Only ${borrower} can return this item.`);
+                return;
+            }
+            return;
         }
 
-        // Create REA events for the return transaction
-        try {
-            const events = this.eventFactory.itemReturned(
-                holonId,
-                ctx.from,
-                currentItem,
-                currentItem.value || 0
-            );
-            await Promise.all(events.map(e => this.eventStore.put(holonId, e)));
-        } catch (error) {
-            console.error('Error creating REA events for return:', error);
-        }
+        // returnItem preserves value/createdBy on the returned snapshot, so the
+        // accounting helpers still see the borrow context they need.
+        await recordReturnAccounting(
+            { db: this.db, eventStore: this.eventStore, eventFactory: this.eventFactory },
+            holonId,
+            ctx.from,
+            result.item
+        );
 
-        currentItem.borrowed = false;
-        currentItem.borrower = null;
-        currentItem.borrowerId = null;
-        currentItem.returnedAt = new Date();
-        await this.db.put(holonId.toString(), 'library', currentItem);
+        const value = result.item.value || 0;
 
         if (fromKeyboard) {
-            const refundMsg = (!isOwner && currentItem.value > 0) ? ` (${currentItem.value}● refunded)` : '';
+            const refundMsg = (!result.isOwner && value > 0) ? ` (${value}● refunded)` : '';
             await ctx.answerCbQuery(`Returned${refundMsg}`).catch(() => {});
             await this.showLibrary(ctx);
         } else {
-            const icon = this.getItemIcon(currentItem);
-            const refundMsg = (!isOwner && currentItem.value > 0) ? `\n💳 ${currentItem.value}● refunded` : '';
+            const icon = this.getItemIcon(result.item);
+            const refundMsg = (!result.isOwner && value > 0) ? `\n💳 ${value}● refunded` : '';
             ctx.reply(`${icon} You returned ${item}.${refundMsg}`);
         }
     }
@@ -702,7 +609,7 @@ class Library {
             return;
         }
 
-        await this.db.delete(holonId.toString(), 'library', itemId);
+        await coreRemoveItem(this.db, holonId, itemId);
         await ctx.answerCbQuery(`Deleted ${itemId}`).catch(() => {});
         await this.showLibrary(ctx);
     }
@@ -713,8 +620,7 @@ class Library {
         const page = options.page || 0;
         const holonId = ctx.chat?.id || ctx.callbackQuery?.message?.chat?.id;
 
-        let list = await this.db.getAll(holonId.toString(), 'library');
-        list.sort((a, b) => a.id.localeCompare(b.id));
+        let list = await coreListItems(this.db, holonId);
 
         if (list.length === 0 && !removeMode) {
             await ctx.reply('📦 The library is empty.\n\nUse /libadd to add items or send a photo to add items from a picture.',
@@ -844,7 +750,7 @@ class Library {
         ctx.answerCbQuery(`Removed ${itemId}`).catch(() => {});
 
         // Delete and refresh
-        await this.db.delete(holonId.toString(), 'library', itemId);
+        await coreRemoveItem(this.db, holonId, itemId);
         await this.showLibrary(ctx, { removeMode: true });
     }
 
@@ -998,20 +904,12 @@ class Library {
             const itemName = typeof item === 'string' ? item : item.name;
             const itemValue = typeof item === 'object' && item.value ? item.value : 0;
 
-            // Check if item already exists
-            if (await this.db.get(holonId.toString(), 'library', itemName)) {
-                continue;
-            }
-
-            const itemType = this.detectItemType(itemName);
-            const libraryItem = this.createLibraryItem(itemName, itemType, {
+            const result = await coreAddItem(this.db, holonId, itemName, {
                 createdBy: ctx.from.id,
                 createdByUsername: ctx.from.username,
                 value: itemValue
             });
-
-            await this.db.put(holonId.toString(), 'library', libraryItem);
-            added++;
+            if (result.ok) added++;
         }
 
         this.pendingPhotoItems.delete(holonId);
@@ -1039,29 +937,24 @@ class Library {
 
     async getLibraryItems(ctx) {
         let holonId = ctx.chat.id;
-        let list = await this.db.getAll(holonId.toString(), 'library');
-        list.sort((a, b) => a.id.localeCompare(b.id));
-        return list;
+        return await coreListItems(this.db, holonId);
     }
 
     async searchItems(ctx) {
         const searchTerm = ctx.message.text.split('/search ')[1].toLowerCase();
-        let list = await this.getLibraryItems(ctx);
-        
-        const results = list.filter(item => 
-            item.id.toLowerCase().includes(searchTerm) || 
-            item.category.toLowerCase().includes(searchTerm)
-        );
+        const list = await this.getLibraryItems(ctx);
+        const results = coreFilterItems(list, searchTerm);
 
         if (results.length === 0) {
             ctx.reply('No items found matching your search.');
             return;
         }
-        
+
         ctx.reply('Search results:', this.getLibraryKeyboard(results));
     }
 
     async rateItem(ctx) {
+        const holonId = ctx.chat.id;
         const [_, item, rating, ...reviewWords] = ctx.message.text.split(/\s+/);
         const review = reviewWords.join(' ');
         const numRating = parseInt(rating);
@@ -1090,6 +983,7 @@ class Library {
     }
 
     async reportIssue(ctx) {
+        const holonId = ctx.chat.id;
         const [_, item, ...issueWords] = ctx.message.text.split(/\s+/);
         const issue = issueWords.join(' ');
 
@@ -1112,24 +1006,18 @@ class Library {
     }
 
     async showStats(ctx) {
-        let list = await this.getLibraryItems(ctx);
-
-        // Count items by type
-        const byType = {};
-        list.forEach(item => {
-            const type = item.type || LIBRARY_TYPES.OTHER;
-            byType[type] = (byType[type] || 0) + 1;
-        });
+        const list = await this.getLibraryItems(ctx);
+        const stats = coreGetLibraryStats(list);
 
         // Format stats message
         const statsMessage = `📊 Library Statistics
 
-📦 Total Items: ${list.length}
-🔄 Currently Borrowed: ${list.filter(i => i.borrowed).length}
-✅ Available: ${list.filter(i => !i.borrowed).length}
+📦 Total Items: ${stats.total}
+🔄 Currently Borrowed: ${stats.borrowed}
+✅ Available: ${stats.available}
 
 By Type:
-${Object.entries(byType).map(([type, count]) => {
+${Object.entries(stats.byType).map(([type, count]) => {
     const icon = this.getItemIcon({ type });
     return `${icon} ${this.getTypeDisplayName(type)}: ${count}`;
 }).join('\n')}`;


### PR DESCRIPTION
Phase B Unit 11 of 20.

Extracts borrow/return/deposit logic from `packages/telegram-ui/src/Library.js` into `@holons/core/library` (no web equivalent existed).

- New: `packages/core/src/library/{types,operations,deposits,index}.ts` + 17 vitest cases
- `LibraryItem`, `LibraryItemType`, `LIBRARY_TYPES`, `BorrowActor`, `LibraryStats` types
- Mutating ops return `{ ok, item?, reason? }` discriminated union
- `recordBorrowAccounting` / `recordReturnAccounting` accept REA store + factory by parameter (no Telegraf import)
- `Library.js` rewired as thin Telegraf adapter; keyboards/calendar/photo flow/borrow locks stay; storage + accounting delegated

Simplify pass found 3 cleanups:
- `coreReturnItem` returns item snapshot on `not_borrowed`/`forbidden` too → eliminated redundant pre-fetch
- `Library.js#getItemDisplayTitle` now delegates to core
- `Library.js#returnItem` reduced from 3-step (read → return → re-read) to single core call

Verification: typecheck/build clean, 17/17 tests, 18 exports, svelte-kit sync OK.