### PR TITLE
core/holosphere: unify factory + identity-aware writes

### DIFF
--- a/apps/web/src/lib/holosphereWrite.ts
+++ b/apps/web/src/lib/holosphereWrite.ts
@@ -1,107 +1,67 @@
 /**
- * Holosphere Write Utilities
+ * Holosphere Write Utilities — web wrapper.
  *
- * Provides wrapped write operations that:
- * 1. Pass the activeHolonIdentity as the "actingAs" option
- * 2. Handle AuthorizationError and show notifications
+ * The actual write/identity logic lives in `@holons/core/holosphere` so
+ * the bot uses the same code path. This file just glues the core API to
+ * Svelte stores: `actingAs` is read from `activeHolonIdentity`, and
+ * denials are surfaced via `notifyWriteDenied`.
  */
 
 import { get } from 'svelte/store';
+import type { HoloSphere } from 'holosphere';
+import {
+  writeWithIdentity as coreWriteWithIdentity,
+  canWriteToHolon as coreCanWriteToHolon,
+  createHolonWriter as coreCreateHolonWriter,
+  type WriteDeniedInfo,
+} from '@holons/core/holosphere';
 import { activeHolonIdentity } from './stores/activeHolonIdentity';
 import { notifyWriteDenied } from './stores/writeNotifications';
-import type { HoloSphere } from 'holosphere';
+
+/** Resolve the current acting-as identity from the Svelte store. */
+const actingAsFromStore = () => get(activeHolonIdentity);
+
+/** Default denial handler — show a toast notification. */
+const defaultOnDenied = (info: WriteDeniedInfo): void => {
+  notifyWriteDenied(`Unable to save - no write permission for this holon's ${info.lensName}`);
+};
 
 /**
  * Write to holosphere with active identity context and error handling.
  *
- * @param holosphere - The HoloSphere instance
- * @param holonId - The target holon ID
- * @param lensName - The lens to write to
- * @param data - The data to write
- * @param options - Additional options
- * @returns Promise that resolves when write completes
- * @throws Re-throws non-authorization errors
+ * See `@holons/core/holosphere#writeWithIdentity` for the underlying logic.
  */
-export async function writeWithIdentity(
+export function writeWithIdentity(
   holosphere: HoloSphere,
   holonId: string,
   lensName: string,
   data: any,
   options: { silent?: boolean } = {}
 ): Promise<boolean> {
-  const actingAs = get(activeHolonIdentity);
-
-  try {
-    await holosphere.put(holonId, lensName, data, { actingAs });
-    return true;
-  } catch (error: any) {
-    if (error?.name === 'AuthorizationError' || error?.message?.includes('Write access denied')) {
-      if (!options.silent) {
-        notifyWriteDenied(`Unable to save - no write permission for this holon's ${lensName}`);
-      }
-      console.warn('[writeWithIdentity] Write denied:', {
-        holonId: holonId?.slice(0, 12) + '...',
-        lensName,
-        actingAs: actingAs?.slice(0, 12) + '...',
-        error: error.message
-      });
-      return false;
-    }
-    // Re-throw other errors
-    throw error;
-  }
+  return coreWriteWithIdentity(holosphere, holonId, lensName, data, {
+    actingAs: actingAsFromStore,
+    onDenied: defaultOnDenied,
+    silent: options.silent,
+  });
 }
 
 /**
  * Check if we can write to a holon's lens before attempting the write.
- *
- * @param holosphere - The HoloSphere instance
- * @param holonId - The target holon ID
- * @param lensName - The lens to check
- * @returns Promise<boolean> - true if write is allowed
  */
-export async function canWriteToHolon(
+export function canWriteToHolon(
   holosphere: HoloSphere,
   holonId: string,
   lensName: string
 ): Promise<boolean> {
-  const actingAs = get(activeHolonIdentity);
-
-  try {
-    // Use the canWrite method if available (added by federation-methods mixin)
-    const hs = holosphere as any;
-    if (typeof hs.canWrite === 'function') {
-      const result = await hs.canWrite(holonId, lensName, actingAs, { actingAsHolon: actingAs });
-      return result?.canWrite === true;
-    }
-
-    // Fallback: check if we're the owner
-    const client = hs.client;
-    if (client?.publicKey === holonId) {
-      return true;
-    }
-
-    return false;
-  } catch (error) {
-    console.warn('[canWriteToHolon] Error checking write access:', error);
-    return false;
-  }
+  return coreCanWriteToHolon(holosphere, holonId, lensName, actingAsFromStore);
 }
 
 /**
  * Create a pre-bound write function for a specific holon context.
- * Useful for components that write frequently to the same holon.
- *
- * @param holosphere - The HoloSphere instance
- * @param holonId - The target holon ID
- * @returns Object with put and canWrite methods
  */
 export function createHolonWriter(holosphere: HoloSphere, holonId: string) {
-  return {
-    put: (lensName: string, data: any, options?: { silent?: boolean }) =>
-      writeWithIdentity(holosphere, holonId, lensName, data, options),
-
-    canWrite: (lensName: string) =>
-      canWriteToHolon(holosphere, holonId, lensName)
-  };
+  return coreCreateHolonWriter(holosphere, holonId, {
+    actingAs: actingAsFromStore,
+    onDenied: defaultOnDenied,
+  });
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,7 +6,12 @@
   "description": "Shared domain logic for Holons UIs (web, telegram, text, ai). UI-agnostic.",
   "exports": {
     ".": "./src/index.ts",
-    "./*": "./src/*/index.ts"
+    "./*": {
+      "types": "./src/*/index.ts",
+      "svelte": "./src/*/index.ts",
+      "node": "./dist/*/index.js",
+      "default": "./src/*/index.ts"
+    }
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/core/src/holosphere/factory.ts
+++ b/packages/core/src/holosphere/factory.ts
@@ -1,0 +1,67 @@
+/**
+ * UI-agnostic factory for `HoloSphere` instances.
+ *
+ * Both UIs (web + telegram bot) used to build `HoloSphere` independently with
+ * subtly different code paths. This module is the single place where the
+ * constructor is invoked; UI wrappers add only environment-specific concerns
+ * (svelte stores, Node key files, etc.).
+ *
+ * The factory deliberately does NOT touch `process.env`, `localStorage`, or
+ * filesystem — callers must resolve their own private key. That keeps the
+ * core importable from any runtime (browser, Node, edge).
+ */
+
+import { HoloSphere } from 'holosphere';
+
+/**
+ * Configuration for {@link createHoloSphere}. Mirrors the subset of
+ * `HoloSphereConfig` both UIs care about, plus an `awaitReady` flag.
+ *
+ * Anything not modelled here can be passed through `extra` — useful for
+ * Nostr-specific keys like `nostr: { relays, peers, persistence }`.
+ */
+export interface CreateHoloSphereOptions {
+  /** Application namespace (e.g. `"Holons"`, `"HolonsDebug"`). */
+  appName: string;
+  /** Private key as hex string or raw bytes. Resolved by the caller. */
+  privateKey?: Uint8Array | string | null;
+  /** Backend selector — defaults to whatever holosphere picks (Gun in 1.3). */
+  backend?: string;
+  /** Holosphere log level (`'INFO'`, `'DEBUG'`, ...). */
+  logLevel?: string;
+  /** Strict-mode toggle for holosphere. */
+  strict?: boolean;
+  /** When true, await `holosphere.ready()` before returning. */
+  awaitReady?: boolean;
+  /** Forward arbitrary extra keys to `HoloSphereConfig`. */
+  extra?: Record<string, unknown>;
+}
+
+/**
+ * Build (and optionally `ready()`) a `HoloSphere` instance.
+ *
+ * Returns the instance synchronously when `awaitReady` is omitted/false, and
+ * a `Promise<HoloSphere>` when it's true — matching the natural usage in each
+ * UI (web awaits, bot uses sync).
+ */
+export function createHoloSphere(options: CreateHoloSphereOptions): HoloSphere;
+export function createHoloSphere(
+  options: CreateHoloSphereOptions & { awaitReady: true }
+): Promise<HoloSphere>;
+export function createHoloSphere(
+  options: CreateHoloSphereOptions
+): HoloSphere | Promise<HoloSphere> {
+  const { appName, privateKey, backend, logLevel, strict, awaitReady, extra } = options;
+
+  const config: Record<string, unknown> = {
+    appName,
+    ...(privateKey !== undefined ? { privateKey } : {}),
+    ...(backend ? { backend } : {}),
+    ...(logLevel ? { logLevel } : {}),
+    ...(strict !== undefined ? { strict } : {}),
+    ...(extra ?? {}),
+  };
+
+  const instance = new HoloSphere(config as any);
+  return awaitReady ? instance.ready().then(() => instance) : instance;
+}

--- a/packages/core/src/holosphere/identity.ts
+++ b/packages/core/src/holosphere/identity.ts
@@ -1,0 +1,56 @@
+/**
+ * Identity helpers shared by all UIs.
+ *
+ * These functions encapsulate the "can I write here as <actingAs>?" check so
+ * web and telegram-ui both ask the same question the same way. The web app
+ * pulls `actingAs` from a Svelte store; the bot pulls it from its key
+ * manager — but the check itself lives here.
+ */
+
+import type { HoloSphere } from 'holosphere';
+
+/** Resolver for the current acting holon identity. May be sync or async. */
+export type ActingAsResolver = string | null | (() => string | null | Promise<string | null>);
+
+/** Resolve an `ActingAsResolver` to its underlying value. */
+export async function resolveActingAs(resolver: ActingAsResolver): Promise<string | null> {
+  if (typeof resolver === 'function') {
+    return await resolver();
+  }
+  return resolver;
+}
+
+/**
+ * Check whether `actingAs` may write to `holonId`/`lensName`.
+ *
+ * Tries the holosphere `canWrite` mixin first (federation-methods); falls
+ * back to a simple "are we the owner?" check using the client public key.
+ * Errors are swallowed and reported as `false` — call sites use this for UI
+ * gating, not security enforcement.
+ */
+export async function canWriteToHolon(
+  holosphere: HoloSphere,
+  holonId: string,
+  lensName: string,
+  actingAs: ActingAsResolver
+): Promise<boolean> {
+  const acting = await resolveActingAs(actingAs);
+
+  try {
+    const hs = holosphere as any;
+    if (typeof hs.canWrite === 'function') {
+      const result = await hs.canWrite(holonId, lensName, acting, { actingAsHolon: acting });
+      return result?.canWrite === true;
+    }
+
+    // Fallback: owner check — the bound private key owns the holon.
+    if (hs.client?.publicKey === holonId) {
+      return true;
+    }
+
+    return false;
+  } catch (error) {
+    console.warn('[canWriteToHolon] Error checking write access:', error);
+    return false;
+  }
+}

--- a/packages/core/src/holosphere/index.ts
+++ b/packages/core/src/holosphere/index.ts
@@ -1,0 +1,17 @@
+/**
+ * `@holons/core/holosphere` — unified entry point for HoloSphere I/O.
+ *
+ * Both `apps/web` and `packages/telegram-ui` build their HoloSphere instances
+ * and identity-aware writes through this module so all UIs run the same
+ * factory + permission logic.
+ */
+
+export { createHoloSphere, type CreateHoloSphereOptions } from './factory.js';
+export {
+  writeWithIdentity,
+  createHolonWriter,
+  type WriteWithIdentityOptions,
+  type WriteDeniedInfo,
+  type HolonWriter,
+} from './write.js';
+export { canWriteToHolon, resolveActingAs, type ActingAsResolver } from './identity.js';

--- a/packages/core/src/holosphere/write.ts
+++ b/packages/core/src/holosphere/write.ts
@@ -1,0 +1,110 @@
+/**
+ * Identity-aware writes.
+ *
+ * `writeWithIdentity` wraps `holosphere.put` so every call:
+ *   1. attaches the current `actingAs` identity (so federated permission
+ *      checks see who is doing the write), and
+ *   2. catches `AuthorizationError` / "Write access denied" and turns it
+ *      into a `false` return + optional UI notification — non-auth errors
+ *      still bubble up.
+ *
+ * Both UIs depend on this single implementation so behaviour stays identical.
+ */
+
+import type { HoloSphere } from 'holosphere';
+import { canWriteToHolon, resolveActingAs, type ActingAsResolver } from './identity.js';
+
+/** Options for {@link writeWithIdentity}. */
+export interface WriteWithIdentityOptions {
+  /** Resolver for the acting-as identity. */
+  actingAs?: ActingAsResolver;
+  /** Optional callback invoked when the write is denied. */
+  onDenied?: (info: WriteDeniedInfo) => void;
+  /** Suppress the `onDenied` callback for this call (errors still logged). */
+  silent?: boolean;
+}
+
+/** Information passed to {@link WriteWithIdentityOptions.onDenied}. */
+export interface WriteDeniedInfo {
+  holonId: string;
+  lensName: string;
+  actingAs: string | null;
+  message: string;
+}
+
+function isAuthError(error: any): boolean {
+  return (
+    error?.name === 'AuthorizationError' ||
+    typeof error?.message === 'string' && error.message.includes('Write access denied')
+  );
+}
+
+/**
+ * Write `data` to `holonId`/`lensName`, attaching `actingAs` and gracefully
+ * handling authorization failures.
+ *
+ * Returns `true` on success, `false` when the write was denied. Re-throws
+ * any other error.
+ */
+export async function writeWithIdentity(
+  holosphere: HoloSphere,
+  holonId: string,
+  lensName: string,
+  data: unknown,
+  options: WriteWithIdentityOptions = {}
+): Promise<boolean> {
+  const actingAs = await resolveActingAs(options.actingAs ?? null);
+
+  try {
+    await holosphere.put(holonId, lensName, data as object, { actingAs } as any);
+    return true;
+  } catch (error: any) {
+    if (isAuthError(error)) {
+      const info: WriteDeniedInfo = {
+        holonId,
+        lensName,
+        actingAs,
+        message: error?.message || 'Write access denied',
+      };
+      if (!options.silent && options.onDenied) {
+        options.onDenied(info);
+      }
+      console.warn('[writeWithIdentity] Write denied:', {
+        holonId: holonId?.slice(0, 12) + '...',
+        lensName,
+        actingAs: actingAs?.slice(0, 12) + '...',
+        error: error.message,
+      });
+      return false;
+    }
+    throw error;
+  }
+}
+
+/** A pre-bound writer for repeated writes against a single holon. */
+export interface HolonWriter {
+  put(lensName: string, data: unknown, options?: { silent?: boolean }): Promise<boolean>;
+  canWrite(lensName: string): Promise<boolean>;
+}
+
+/**
+ * Create a `HolonWriter` bound to a holon — useful for components or services
+ * that issue many writes against the same target. Identity + denial handling
+ * are captured once here.
+ */
+export function createHolonWriter(
+  holosphere: HoloSphere,
+  holonId: string,
+  options: { actingAs?: ActingAsResolver; onDenied?: (info: WriteDeniedInfo) => void } = {}
+): HolonWriter {
+  return {
+    put: (lensName, data, callOpts) =>
+      writeWithIdentity(holosphere, holonId, lensName, data, {
+        actingAs: options.actingAs,
+        onDenied: options.onDenied,
+        silent: callOpts?.silent,
+      }),
+
+    canWrite: (lensName) => canWriteToHolon(holosphere, holonId, lensName, options.actingAs ?? null),
+  };
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "lib": ["ES2022", "DOM"]
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules"]

--- a/packages/telegram-ui/src/createHoloSphere.js
+++ b/packages/telegram-ui/src/createHoloSphere.js
@@ -1,8 +1,13 @@
 /**
  * @fileoverview Factory functions for HoloSphere and KeyManager instances.
+ *
+ * The HoloSphere instance is now built by `@holons/core/holosphere`; this
+ * file is a thin Node wrapper that resolves a private key (env / file /
+ * generate) and wires the bot-only KeyManager.
+ *
  * @module src/createHoloSphere
  */
-import { HoloSphere } from 'holosphere';
+import { createHoloSphere as coreCreateHoloSphere } from '@holons/core/holosphere';
 import { getOrCreateKey } from '../utils/key-storage.js';
 import { generateSecretKey } from 'nostr-tools';
 import KeyManager from './KeyManager.js';
@@ -42,20 +47,22 @@ function generatePrivateKey() {
  */
 export default function createHoloSphere(appName, options = {}) {
     const resolvedAppName = appName || process.env.APPNAME || 'Holons';
-    const privateKey = options.privateKey
+    const { privateKey: pkOverride, backend, logLevel, relays: _ignoredRelays, ...extra } = options;
+    const privateKey = pkOverride
         || process.env.HOLOSPHERE_PRIVATE_KEY
         || getOrCreateKey(resolvedAppName, generatePrivateKey);
 
-    const holosphere = new HoloSphere({
-        backend: 'nostr',
+    // NOTE: `relays` here is intentionally NOT forwarded — holosphere 1.3
+    // ignores top-level `relays` and only consumes `nostr.relays`. The bot
+    // historically passed it as a hint and ran on Gun's default peer; pass
+    // `extra: { nostr: { relays: [...] } }` if/when migrating to nostr.
+    return coreCreateHoloSphere({
         appName: resolvedAppName,
-        privateKey: privateKey,
-        logLevel: options.logLevel || 'INFO',
-        relays: options.relays || ['wss://relay.holons.io/'],
-        ...options
+        privateKey,
+        backend: backend || 'nostr',
+        logLevel: logLevel || 'INFO',
+        extra,
     });
-
-    return holosphere;
 }
 
 /**


### PR DESCRIPTION
Phase B Unit 4 of 20.

Unifies HoloSphere I/O across web + telegram. One `createHoloSphere` factory and one `writeWithIdentity` / `createHolonWriter` / `canWriteToHolon` implementation.

- New: `packages/core/src/holosphere/{factory,identity,write,index}.ts`
- Web: `apps/web/src/lib/holosphereWrite.ts` is thin Svelte glue that pipes its store + toast into the core API
- Bot: `packages/telegram-ui/src/createHoloSphere.js` is thin Node wrapper that resolves persistent Nostr key (env / file / generate) and delegates construction
- Both UIs now run identical permission-check logic
- `core/package.json` adds `node` condition to `./*` exports map (resolves to dist/ for bot, src/ for Vite/SvelteKit)
- `core/tsconfig.json` adds `DOM` to lib so `console` resolves during core build

**Behavior preservation note**: Original bot passed `relays: ["wss://relay.holons.io/"]` at the top level of `HoloSphereConfig`, but holosphere 1.3 only consumes `nostr.relays` — so the parameter was silently ignored and Gun used its default peer. **Deliberately not auto-promoted** to avoid changing runtime endpoint. To activate Nostr relays, callers pass `extra: { nostr: { relays: [...] } }` (documented in bot wrapper).

Verification: typecheck/build clean, smoke OK exports `[canWriteToHolon, createHoloSphere, createHolonWriter, resolveActingAs, writeWithIdentity]`, web build OK, web vitest writeWithIdentity tests pass.