### PR TITLE
mcp-ui: scoring domain (unit 4/15)

### DIFF
--- a/packages/mcp-ui/.gitignore
+++ b/packages/mcp-ui/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/packages/mcp-ui/README.md
+++ b/packages/mcp-ui/README.md
@@ -1,0 +1,15 @@
+# @holons/mcp-ui
+
+MCP server exposing every `@holons/core` function as an independently-callable tool. Replaces the legacy `telegram-ui` HTTP bot API (port 3101) and the duplicate MCP wrappers in `telegram-ui/mcp`.
+
+## Usage
+
+```bash
+pnpm -F @holons/mcp-ui build
+node packages/mcp-ui/dist/index.js                 # stdio
+node packages/mcp-ui/dist/index.js --port 3200     # SSE
+```
+
+## Env
+
+- `HOLONS_PEER` / `HOLONS_APP` / `HOLONS_ACTOR_ID` / `HOLONS_ACTOR_NAME` / `HOLONS_ACTOR_USERNAME`

--- a/packages/mcp-ui/package.json
+++ b/packages/mcp-ui/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@holons/mcp-ui",
+  "version": "0.1.0",
+  "private": true,
+  "description": "MCP server exposing every @holons/core function as an independently-callable tool. Replaces the telegram-ui HTTP bot API.",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": "./dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@holons/core": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "holosphere": "1.3.0-alpha4",
+    "zod": "^3.23.8",
+    "dotenv": "^17.2.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.17",
+    "tsx": "^4.21.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/mcp-ui/src/holosphere.ts
+++ b/packages/mcp-ui/src/holosphere.ts
@@ -1,0 +1,16 @@
+const PEER = process.env.HOLONS_PEER || 'https://gun.holons.io/gun';
+const APP = process.env.HOLONS_APP || 'Holons';
+
+let hs: any;
+export async function getHoloSphere(): Promise<any> {
+  if (hs) return hs;
+  const mod: any = await import('holosphere');
+  const HoloSphere = mod.HoloSphere || mod.default;
+  hs = new HoloSphere(APP, false, null, { peers: [PEER] });
+  await new Promise((r) => setTimeout(r, 1500));
+  return hs;
+}
+
+export function getApp(): string {
+  return APP;
+}

--- a/packages/mcp-ui/src/identity.ts
+++ b/packages/mcp-ui/src/identity.ts
@@ -1,0 +1,14 @@
+export interface Actor {
+  id: string | number;
+  first_name?: string;
+  username?: string;
+}
+
+export function resolveActor(override?: Partial<Actor>): Actor {
+  const id = override?.id ?? process.env.HOLONS_ACTOR_ID ?? 'mcp-ui';
+  return {
+    id,
+    first_name: override?.first_name ?? process.env.HOLONS_ACTOR_NAME ?? 'MCP-UI',
+    username: override?.username ?? process.env.HOLONS_ACTOR_USERNAME,
+  };
+}

--- a/packages/mcp-ui/src/index.ts
+++ b/packages/mcp-ui/src/index.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import http from 'http';
+import { createServer } from './server.js';
+
+async function main() {
+  const server = await createServer();
+  const portArg = process.argv.indexOf('--port');
+  if (portArg !== -1 && process.argv[portArg + 1]) {
+    const port = parseInt(process.argv[portArg + 1], 10);
+    let sseTransport: SSEServerTransport | undefined;
+    const httpServer = http.createServer(async (req, res) => {
+      if (req.method === 'GET' && req.url === '/sse') {
+        sseTransport = new SSEServerTransport('/messages', res);
+        await server.connect(sseTransport);
+      } else if (req.method === 'POST' && req.url === '/messages') {
+        if (sseTransport) {
+          let body = '';
+          req.on('data', (c) => (body += c));
+          req.on('end', async () => {
+            await sseTransport!.handlePostMessage(req, res, body);
+          });
+        } else {
+          res.writeHead(400);
+          res.end('No SSE connection');
+        }
+      } else {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ name: 'holons-mcp-ui', version: '0.1.0' }));
+      }
+    });
+    httpServer.listen(port, () => {
+      console.error(`holons-mcp-ui listening on port ${port} (SSE)`);
+    });
+  } else {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    console.error('holons-mcp-ui running on stdio');
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/packages/mcp-ui/src/server.ts
+++ b/packages/mcp-ui/src/server.ts
@@ -1,0 +1,16 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getHoloSphere } from './holosphere.js';
+import { resolveActor } from './identity.js';
+import { registerAllTools, type ToolDeps } from './tools/index.js';
+
+export async function createServer(): Promise<McpServer> {
+  const server = new McpServer({
+    name: 'holons-mcp-ui',
+    version: '0.1.0',
+    description:
+      'MCP server exposing every @holons/core function as an independently-callable tool.',
+  });
+  const deps: ToolDeps = { getHoloSphere, resolveActor };
+  await registerAllTools(server, deps);
+  return server;
+}

--- a/packages/mcp-ui/src/tools/index.ts
+++ b/packages/mcp-ui/src/tools/index.ts
@@ -1,0 +1,38 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Actor } from '../identity.js';
+
+export interface ToolDeps {
+  getHoloSphere: () => Promise<any>;
+  resolveActor: (override?: Partial<Actor>) => Actor;
+}
+
+const DOMAINS = [
+  'holosphere',
+  'tasks',
+  'expenses',
+  'scoring',
+  'calendar',
+  'users',
+  'council',
+  'checklists',
+  'dna',
+  'library',
+  'shopping',
+  'federation',
+  'commands',
+  'settings',
+];
+
+export async function registerAllTools(server: McpServer, deps: ToolDeps): Promise<void> {
+  for (const domain of DOMAINS) {
+    try {
+      const mod: any = await import(`./${domain}.js`);
+      const registerName = `register${domain[0].toUpperCase()}${domain.slice(1)}Tools`;
+      if (typeof mod[registerName] === 'function') {
+        mod[registerName](server, deps);
+      }
+    } catch {
+      // Domain file not yet present in this worktree — skip silently.
+    }
+  }
+}

--- a/packages/mcp-ui/src/tools/scoring.ts
+++ b/packages/mcp-ui/src/tools/scoring.ts
@@ -1,0 +1,186 @@
+/**
+ * MCP tools for the `@holons/core/scoring` domain.
+ *
+ * Each tool wraps a single public function from core so it can be invoked
+ * independently. No Telegram side-effects; pure scoring math + holosphere
+ * reads for equation/users.
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import {
+  DEFAULT_EQUATION,
+  calculatePercentageShare,
+  getScoreBreakdown,
+  loadEquation,
+  toAggregates,
+  type ScoreEquation,
+  type UserAggregates,
+} from '@holons/core/scoring';
+import type { ToolDeps } from './index.js';
+
+function ok(payload: unknown) {
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify({ success: true, ...(payload as object) }, null, 2),
+      },
+    ],
+  };
+}
+
+function err(message: string) {
+  return {
+    isError: true,
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify({ success: false, error: message }, null, 2),
+      },
+    ],
+  };
+}
+
+function parseJson<T>(raw: string | undefined, fallback: T, field: string): T {
+  if (!raw) return fallback;
+  try {
+    return JSON.parse(raw) as T;
+  } catch (e: any) {
+    throw new Error(`Invalid JSON for ${field}: ${e?.message ?? e}`);
+  }
+}
+
+function scoreUserBreakdown(
+  userId: string | number,
+  aggregatesJson: string,
+  equationJson: string | undefined,
+) {
+  const aggregates = parseJson<UserAggregates>(
+    aggregatesJson,
+    {} as UserAggregates,
+    'aggregates',
+  );
+  const equation = parseJson<ScoreEquation>(equationJson, DEFAULT_EQUATION, 'equation');
+  const breakdown = getScoreBreakdown(aggregates, equation);
+  return { userId, breakdown };
+}
+
+export function registerScoringTools(server: McpServer, deps: ToolDeps): void {
+  server.tool(
+    'score_user',
+    "Compute a single user's score breakdown from their aggregates using the supplied (or default) value equation. Wraps @holons/core/scoring: getScoreBreakdown.",
+    {
+      userId: z.union([z.string(), z.number()]).describe('User id (string or number).'),
+      aggregates: z
+        .string()
+        .describe(
+          'JSON-encoded UserAggregates ({ initiated, completed, sent, received, hours, collaboration, wants, offers }).',
+        ),
+      equation: z
+        .string()
+        .optional()
+        .describe('JSON-encoded ScoreEquation. Defaults to DEFAULT_EQUATION when omitted.'),
+    },
+    async ({ userId, aggregates, equation }) => {
+      try {
+        return ok(scoreUserBreakdown(userId, aggregates, equation));
+      } catch (e: any) {
+        return err(e?.message ?? String(e));
+      }
+    },
+  );
+
+  server.tool(
+    'score_all_users',
+    'Compute score breakdowns for many users in a holon. Loads each user from holosphere by id, then runs @holons/core/scoring: getScoreBreakdown per user with shared total → percentage.',
+    {
+      userIds: z.array(z.string()).describe('User ids to score.'),
+      holon: z.string().describe('Holon id to fetch user data from.'),
+      equation: z
+        .string()
+        .optional()
+        .describe('JSON-encoded ScoreEquation. Defaults to DEFAULT_EQUATION when omitted.'),
+    },
+    async ({ userIds, holon, equation }) => {
+      try {
+        const eq = parseJson<ScoreEquation>(equation, DEFAULT_EQUATION, 'equation');
+        const hs = await deps.getHoloSphere();
+
+        const users = await Promise.all(
+          userIds.map(async (id) => {
+            try {
+              const data = await hs.get(holon, 'users', id);
+              return { ...(data ?? {}), id };
+            } catch {
+              return { id };
+            }
+          }),
+        );
+
+        const scored = users.map((user) => {
+          const aggregates = toAggregates(user);
+          const breakdown = getScoreBreakdown(aggregates, eq);
+          return {
+            userId: String(user.id),
+            username: user.username || String(user.id),
+            aggregates,
+            breakdown,
+          };
+        });
+
+        const totalScore = scored.reduce((sum, u) => sum + u.breakdown.total, 0);
+        const out: Record<string, unknown> = {};
+        for (const u of scored) {
+          out[u.userId] = {
+            username: u.username,
+            score: u.breakdown.total,
+            percentage: calculatePercentageShare(u.breakdown.total, totalScore),
+            aggregates: u.aggregates,
+            breakdown: u.breakdown,
+          };
+        }
+        return ok({ holon, scores: out });
+      } catch (e: any) {
+        return err(e?.message ?? String(e));
+      }
+    },
+  );
+
+  server.tool(
+    'score_breakdown',
+    'Get a detailed score breakdown by category for a user. Wraps @holons/core/scoring: getScoreBreakdown.',
+    {
+      userId: z.union([z.string(), z.number()]).describe('User id (string or number).'),
+      aggregates: z.string().describe('JSON-encoded UserAggregates.'),
+      equation: z
+        .string()
+        .optional()
+        .describe('JSON-encoded ScoreEquation. Defaults to DEFAULT_EQUATION when omitted.'),
+    },
+    async ({ userId, aggregates, equation }) => {
+      try {
+        return ok(scoreUserBreakdown(userId, aggregates, equation));
+      } catch (e: any) {
+        return err(e?.message ?? String(e));
+      }
+    },
+  );
+
+  server.tool(
+    'score_equation_load',
+    'Load (and cache) the value equation for a holon from holosphere settings. Wraps @holons/core/scoring: loadEquation.',
+    {
+      holon: z.string().describe('Holon id whose equation to load.'),
+    },
+    async ({ holon }) => {
+      try {
+        const hs = await deps.getHoloSphere();
+        const equation = await loadEquation(hs, holon);
+        return ok({ holon, equation });
+      } catch (e: any) {
+        return err(e?.message ?? String(e));
+      }
+    },
+  );
+}

--- a/packages/mcp-ui/tsconfig.json
+++ b/packages/mcp-ui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- Scaffold the new `packages/mcp-ui` package (MCP server replacing the legacy `telegram-ui` HTTP bot API on port 3101).
- Add the scoring domain: `score_user`, `score_all_users`, `score_breakdown`, `score_equation_load` wrap `@holons/core/scoring` (`getScoreBreakdown`, `calculateAllUserScores`/`calculatePercentageShare`, `loadEquation`).
- Pure `@holons/core` — no Telegram side-effects.

## Notes for reviewers
- This is unit 4 of a 15-unit parallel migration. The scaffold (`package.json`, `tsconfig.json`, `src/holosphere.ts`, `src/identity.ts`, `src/index.ts`, `src/server.ts`, `src/tools/index.ts`, `README.md`) is byte-identical across all 15 PRs — merge conflicts on those files are expected and trivial to resolve (take either side).
- Only `src/tools/scoring.ts` is unique to this PR.
- `src/tools/index.ts` lazy-imports each domain file in a `try/catch`, so this PR is independently runnable: missing sibling domain files are skipped silently.
- The prompt's described signatures for `calculateAllUserScores` (`(userIds, holonStore, equation)`) didn't match the actual `@holons/core/scoring` export (`(users[], equation?, currencyBalances?)`). The tool's argument surface still matches the prompt (`{ userIds, holon, equation? }`); internally it fetches each user from holosphere by id and runs `getScoreBreakdown` per user, then computes percentages with `calculatePercentageShare`.

## Test plan
- [x] `pnpm install` and `pnpm run build` in `packages/mcp-ui` succeed.
- [x] Smoke test: `tools/list` over stdio returns all four `score_*` tools (PASS).
- [ ] Reviewer: verify `getScoreBreakdown` semantics for an actual holon (`score_user` with a sample aggregates JSON).
- [ ] Reviewer: confirm scaffold matches the unit-1/unit-2 PRs byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)