### PR TITLE
mcp-ui: expenses domain (unit 3/15)

### DIFF
--- a/packages/mcp-ui/README.md
+++ b/packages/mcp-ui/README.md
@@ -1,0 +1,17 @@
+# @holons/mcp-ui
+
+MCP server exposing every `@holons/core` function as an independently-callable tool. Replaces the legacy `telegram-ui` HTTP bot API (port 3101) and the duplicate MCP wrappers in `telegram-ui/mcp`.
+
+## Usage
+
+```bash
+pnpm -F @holons/mcp-ui build
+node packages/mcp-ui/dist/index.js                 # stdio
+node packages/mcp-ui/dist/index.js --port 3200     # SSE
+```
+
+## Env
+
+- `HOLONS_PEER` — Gun peer URL (default `https://gun.holons.io/gun`)
+- `HOLONS_APP` — HoloSphere app name (default `Holons`)
+- `HOLONS_ACTOR_ID` / `HOLONS_ACTOR_NAME` / `HOLONS_ACTOR_USERNAME` — default acting user

--- a/packages/mcp-ui/package.json
+++ b/packages/mcp-ui/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@holons/mcp-ui",
+  "version": "0.1.0",
+  "private": true,
+  "description": "MCP server exposing every @holons/core function as an independently-callable tool. Replaces the telegram-ui HTTP bot API.",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": "./dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@holons/core": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "holosphere": "1.3.0-alpha4",
+    "zod": "^3.23.8",
+    "dotenv": "^17.2.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.17",
+    "tsx": "^4.21.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/mcp-ui/src/holosphere.ts
+++ b/packages/mcp-ui/src/holosphere.ts
@@ -1,0 +1,16 @@
+const PEER = process.env.HOLONS_PEER || 'https://gun.holons.io/gun';
+const APP = process.env.HOLONS_APP || 'Holons';
+
+let hs: any;
+export async function getHoloSphere(): Promise<any> {
+  if (hs) return hs;
+  const mod: any = await import('holosphere');
+  const HoloSphere = mod.HoloSphere || mod.default;
+  hs = new HoloSphere(APP, false, null, { peers: [PEER] });
+  await new Promise((r) => setTimeout(r, 1500));
+  return hs;
+}
+
+export function getApp(): string {
+  return APP;
+}

--- a/packages/mcp-ui/src/identity.ts
+++ b/packages/mcp-ui/src/identity.ts
@@ -1,0 +1,14 @@
+export interface Actor {
+  id: string | number;
+  first_name?: string;
+  username?: string;
+}
+
+export function resolveActor(override?: Partial<Actor>): Actor {
+  const id = override?.id ?? process.env.HOLONS_ACTOR_ID ?? 'mcp-ui';
+  return {
+    id,
+    first_name: override?.first_name ?? process.env.HOLONS_ACTOR_NAME ?? 'MCP-UI',
+    username: override?.username ?? process.env.HOLONS_ACTOR_USERNAME,
+  };
+}

--- a/packages/mcp-ui/src/index.ts
+++ b/packages/mcp-ui/src/index.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import http from 'http';
+import { createServer } from './server.js';
+
+async function main() {
+  const server = await createServer();
+  const portArg = process.argv.indexOf('--port');
+  if (portArg !== -1 && process.argv[portArg + 1]) {
+    const port = parseInt(process.argv[portArg + 1], 10);
+    let sseTransport: SSEServerTransport | undefined;
+    const httpServer = http.createServer(async (req, res) => {
+      if (req.method === 'GET' && req.url === '/sse') {
+        sseTransport = new SSEServerTransport('/messages', res);
+        await server.connect(sseTransport);
+      } else if (req.method === 'POST' && req.url === '/messages') {
+        if (sseTransport) {
+          let body = '';
+          req.on('data', (c) => (body += c));
+          req.on('end', async () => {
+            await sseTransport!.handlePostMessage(req, res, body);
+          });
+        } else {
+          res.writeHead(400);
+          res.end('No SSE connection');
+        }
+      } else {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ name: 'holons-mcp-ui', version: '0.1.0' }));
+      }
+    });
+    httpServer.listen(port, () => {
+      console.error(`holons-mcp-ui listening on port ${port} (SSE)`);
+    });
+  } else {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    console.error('holons-mcp-ui running on stdio');
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/packages/mcp-ui/src/server.ts
+++ b/packages/mcp-ui/src/server.ts
@@ -1,0 +1,16 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getHoloSphere } from './holosphere.js';
+import { resolveActor } from './identity.js';
+import { registerAllTools, type ToolDeps } from './tools/index.js';
+
+export async function createServer(): Promise<McpServer> {
+  const server = new McpServer({
+    name: 'holons-mcp-ui',
+    version: '0.1.0',
+    description:
+      'MCP server exposing every @holons/core function as an independently-callable tool.',
+  });
+  const deps: ToolDeps = { getHoloSphere, resolveActor };
+  await registerAllTools(server, deps);
+  return server;
+}

--- a/packages/mcp-ui/src/tools/expenses.ts
+++ b/packages/mcp-ui/src/tools/expenses.ts
@@ -1,0 +1,219 @@
+// MCP tools wrapping @holons/core/expenses.
+//
+// Each tool is a thin shim: it parses JSON-encoded args (since core operates
+// on plain objects, but MCP tool arguments must be JSON-Schema-typed scalars
+// or simple shapes), calls the pure core function, and returns the result.
+import { z } from 'zod';
+import {
+  addParticipant,
+  calculateBalance,
+  computeCreditMatrix,
+  createExpense,
+  splitAmongAll,
+  toggleParticipant,
+  type AgentId,
+  type CreateExpenseInput,
+  type Expense,
+  type User,
+} from '@holons/core/expenses';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolDeps } from './index.js';
+
+type ToolResult = {
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: boolean;
+};
+
+function ok(payload: Record<string, unknown>): ToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify({ success: true, ...payload }, null, 2) }],
+  };
+}
+
+function fail(error: unknown): ToolResult {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    content: [{ type: 'text', text: JSON.stringify({ success: false, error: message }, null, 2) }],
+    isError: true,
+  };
+}
+
+function parseJson<T>(raw: string, label: string): T {
+  try {
+    return JSON.parse(raw) as T;
+  } catch (err) {
+    throw new Error(
+      `Invalid JSON for "${label}": ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}
+
+async function loadExpenses(
+  deps: ToolDeps,
+  args: { expenses?: string; holon?: string }
+): Promise<Expense[]> {
+  if (typeof args.expenses === 'string' && args.expenses.length > 0) {
+    const parsed = parseJson<unknown>(args.expenses, 'expenses');
+    if (!Array.isArray(parsed)) throw new Error('"expenses" must be a JSON array');
+    return parsed as Expense[];
+  }
+  if (typeof args.holon === 'string' && args.holon.length > 0) {
+    const h = await deps.getHoloSphere();
+    const raw = await h.getAll(args.holon, 'expenses');
+    if (Array.isArray(raw)) return raw as Expense[];
+    if (raw && typeof raw === 'object') return Object.values(raw) as Expense[];
+    return [];
+  }
+  throw new Error('Provide either "expenses" (JSON array) or "holon"');
+}
+
+export function registerExpensesTools(server: McpServer, deps: ToolDeps): void {
+  server.tool(
+    'expense_create',
+    'Create a normalized expense via @holons/core. Optionally persists via HoloSphere when persist=true.',
+    {
+      holon: z.string().describe('HoloSphere holon id (used as fallback splitWith and for persistence).'),
+      expense: z
+        .string()
+        .describe('JSON-encoded CreateExpenseInput: { id, amount, currency, description, paidBy, splitWith?, picture?, date? }. holonId is taken from the "holon" arg unless overridden here.'),
+      persist: z.boolean().optional().describe('When true, h.put(holon, "expenses", created).'),
+    },
+    async ({ holon, expense, persist }) => {
+      try {
+        const input = parseJson<Partial<CreateExpenseInput>>(expense, 'expense');
+        const fullInput: CreateExpenseInput = {
+          holonId: input.holonId ?? holon,
+          id: input.id ?? Date.now(),
+          amount: Number(input.amount),
+          currency: String(input.currency ?? ''),
+          description: String(input.description ?? ''),
+          paidBy: input.paidBy as AgentId,
+          splitWith: input.splitWith,
+          picture: input.picture ?? null,
+          date: input.date,
+        };
+        const created = createExpense(fullInput);
+        if (!created) return fail('createExpense rejected input (non-positive or invalid amount)');
+        if (persist) {
+          const h = await deps.getHoloSphere();
+          await h.put(holon, 'expenses', created);
+        }
+        return ok({ expense: created, persisted: Boolean(persist) });
+      } catch (err) {
+        return fail(err);
+      }
+    }
+  );
+
+  server.tool(
+    'expense_balance',
+    'Compute the net balance for one user in one currency. Provide either "expenses" (JSON) or "holon" (fetch via HoloSphere).',
+    {
+      expenses: z.string().optional().describe('JSON array of Expense objects.'),
+      holon: z.string().optional().describe('Holon id to fetch expenses from when "expenses" is omitted.'),
+      userId: z.union([z.string(), z.number()]).describe('User whose net balance to compute.'),
+      currency: z.string().describe('Currency code (will be normalized by core).'),
+    },
+    async ({ expenses, holon, userId, currency }) => {
+      try {
+        const list = await loadExpenses(deps, { expenses, holon });
+        const net = calculateBalance(list, userId as AgentId, currency);
+        return ok({ userId, currency, net, expenseCount: list.length });
+      } catch (err) {
+        return fail(err);
+      }
+    }
+  );
+
+  server.tool(
+    'expense_credit_matrix',
+    'Build the NxN credit matrix for a given currency over a set of expenses and users.',
+    {
+      expenses: z.string().optional().describe('JSON array of Expense objects.'),
+      holon: z.string().optional().describe('Holon id to fetch expenses from when "expenses" is omitted.'),
+      users: z.string().describe('JSON array of User objects ({ id, username?, first_name?, last_name? }).'),
+      currency: z.string().describe('Currency code (normalized internally).'),
+      allowedCurrencies: z
+        .string()
+        .optional()
+        .describe('Optional JSON array of currency codes to gate the computation.'),
+    },
+    async ({ expenses, holon, users, currency, allowedCurrencies }) => {
+      try {
+        const list = await loadExpenses(deps, { expenses, holon });
+        const userArr = parseJson<User[]>(users, 'users');
+        const allowed = allowedCurrencies
+          ? parseJson<string[]>(allowedCurrencies, 'allowedCurrencies')
+          : [];
+        const result = computeCreditMatrix(list, userArr, currency, allowed);
+        return ok({ ...result, currency, expenseCount: list.length });
+      } catch (err) {
+        return fail(err);
+      }
+    }
+  );
+
+  server.tool(
+    'expense_split_among_all',
+    'Return a new Expense whose splitWith is replaced with the provided member ids.',
+    {
+      expense: z.string().describe('JSON-encoded Expense.'),
+      members: z.string().describe('JSON-encoded array of member ids (string|number).'),
+    },
+    async ({ expense, members }) => {
+      try {
+        const exp = parseJson<Expense>(expense, 'expense');
+        const memberIds = parseJson<AgentId[]>(members, 'members');
+        const next = splitAmongAll(exp, memberIds);
+        return ok({ expense: next });
+      } catch (err) {
+        return fail(err);
+      }
+    }
+  );
+
+  // `amount` is accepted for forward-compat but ignored: core splits evenly.
+  server.tool(
+    'expense_add_participant',
+    'Add a user to an expense splitWith (no-op if already present).',
+    {
+      expense: z.string().describe('JSON-encoded Expense.'),
+      userId: z.union([z.string(), z.number()]).describe('User id to add.'),
+      amount: z
+        .number()
+        .optional()
+        .describe('Ignored by core (even split); accepted for forward compatibility.'),
+    },
+    async ({ expense, userId }) => {
+      try {
+        const exp = parseJson<Expense>(expense, 'expense');
+        const next = addParticipant(exp, userId as AgentId);
+        return ok({ expense: next });
+      } catch (err) {
+        return fail(err);
+      }
+    }
+  );
+
+  // holonId is the sentinel used when the split would otherwise become empty.
+  server.tool(
+    'expense_toggle_participant',
+    'Toggle a user in/out of an expense splitWith. Falls back to [holonId] when removing the last participant.',
+    {
+      expense: z.string().describe('JSON-encoded Expense.'),
+      userId: z.union([z.string(), z.number()]).describe('User id to toggle.'),
+      holonId: z
+        .union([z.string(), z.number()])
+        .describe('Holon id used as the sentinel when the split becomes empty.'),
+    },
+    async ({ expense, userId, holonId }) => {
+      try {
+        const exp = parseJson<Expense>(expense, 'expense');
+        const next = toggleParticipant(exp, userId as AgentId, holonId as AgentId);
+        return ok({ expense: next });
+      } catch (err) {
+        return fail(err);
+      }
+    }
+  );
+}

--- a/packages/mcp-ui/src/tools/index.ts
+++ b/packages/mcp-ui/src/tools/index.ts
@@ -1,0 +1,38 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Actor } from '../identity.js';
+
+export interface ToolDeps {
+  getHoloSphere: () => Promise<any>;
+  resolveActor: (override?: Partial<Actor>) => Actor;
+}
+
+const DOMAINS = [
+  'holosphere',
+  'tasks',
+  'expenses',
+  'scoring',
+  'calendar',
+  'users',
+  'council',
+  'checklists',
+  'dna',
+  'library',
+  'shopping',
+  'federation',
+  'commands',
+  'settings',
+];
+
+export async function registerAllTools(server: McpServer, deps: ToolDeps): Promise<void> {
+  for (const domain of DOMAINS) {
+    try {
+      const mod: any = await import(`./${domain}.js`);
+      const registerName = `register${domain[0].toUpperCase()}${domain.slice(1)}Tools`;
+      if (typeof mod[registerName] === 'function') {
+        mod[registerName](server, deps);
+      }
+    } catch {
+      // Domain file not yet present in this worktree — skip silently.
+    }
+  }
+}

--- a/packages/mcp-ui/tsconfig.json
+++ b/packages/mcp-ui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- Scaffolds `packages/mcp-ui` — an MCP server exposing `@holons/core` functions as independently-callable tools, replacing the legacy `telegram-ui` HTTP bot API (port 3101).
- Adds the **expenses** domain: 6 tools (`expense_create`, `expense_balance`, `expense_credit_matrix`, `expense_split_among_all`, `expense_add_participant`, `expense_toggle_participant`) wrapping the pure functions in `@holons/core/expenses`.
- Scaffold files (`package.json`, `tsconfig.json`, `src/{index,server,holosphere,identity}.ts`, `src/tools/index.ts`, `README.md`) are byte-identical to siblings; only `src/tools/expenses.ts` is this unit's responsibility.

## Spec deviations (real signatures over simplified spec)
- `expense_balance` takes `userId` + `currency` — core's `calculateBalance` is per-user-per-currency (alias of `computeUserCurrencyBalance`), not a single-arg call.
- `expense_credit_matrix` takes `users` (JSON array) + `currency` (+ optional `allowedCurrencies`) — matches `computeCreditMatrix(expenses, users, currency, allowed?)`.
- `expense_toggle_participant` requires `holonId` — the sentinel used when the split would otherwise empty.
- `expense_add_participant` accepts `amount` for forward-compat but ignores it (core splits evenly).

## Test plan
- [x] pnpm install at repo root (workspace install)
- [x] cd packages/mcp-ui && pnpm run build (tsc) — clean
- [x] Smoke test: stdio initialize + tools/list lists all 6 expense_* tools (PASS)
- [ ] Cross-unit integration: verified dynamically-imported domain files don't conflict (tools/index.ts swallows missing-domain errors)

Generated with [Claude Code](https://claude.com/claude-code)