### PR TITLE
mcp-ui: calendar domain (unit 5/15)

### DIFF
--- a/packages/mcp-ui/README.md
+++ b/packages/mcp-ui/README.md
@@ -1,0 +1,15 @@
+# @holons/mcp-ui
+
+MCP server exposing every `@holons/core` function as an independently-callable tool. Replaces the legacy `telegram-ui` HTTP bot API (port 3101) and the duplicate MCP wrappers in `telegram-ui/mcp`.
+
+## Usage
+
+```bash
+pnpm -F @holons/mcp-ui build
+node packages/mcp-ui/dist/index.js                 # stdio
+node packages/mcp-ui/dist/index.js --port 3200     # SSE
+```
+
+## Env
+
+- `HOLONS_PEER` / `HOLONS_APP` / `HOLONS_ACTOR_ID` / `HOLONS_ACTOR_NAME` / `HOLONS_ACTOR_USERNAME`

--- a/packages/mcp-ui/package.json
+++ b/packages/mcp-ui/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@holons/mcp-ui",
+  "version": "0.1.0",
+  "private": true,
+  "description": "MCP server exposing every @holons/core function as an independently-callable tool. Replaces the telegram-ui HTTP bot API.",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": "./dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@holons/core": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "holosphere": "1.3.0-alpha4",
+    "zod": "^3.23.8",
+    "dotenv": "^17.2.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.17",
+    "tsx": "^4.21.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/mcp-ui/src/holosphere.ts
+++ b/packages/mcp-ui/src/holosphere.ts
@@ -1,0 +1,16 @@
+const PEER = process.env.HOLONS_PEER || 'https://gun.holons.io/gun';
+const APP = process.env.HOLONS_APP || 'Holons';
+
+let hs: any;
+export async function getHoloSphere(): Promise<any> {
+  if (hs) return hs;
+  const mod: any = await import('holosphere');
+  const HoloSphere = mod.HoloSphere || mod.default;
+  hs = new HoloSphere(APP, false, null, { peers: [PEER] });
+  await new Promise((r) => setTimeout(r, 1500));
+  return hs;
+}
+
+export function getApp(): string {
+  return APP;
+}

--- a/packages/mcp-ui/src/identity.ts
+++ b/packages/mcp-ui/src/identity.ts
@@ -1,0 +1,14 @@
+export interface Actor {
+  id: string | number;
+  first_name?: string;
+  username?: string;
+}
+
+export function resolveActor(override?: Partial<Actor>): Actor {
+  const id = override?.id ?? process.env.HOLONS_ACTOR_ID ?? 'mcp-ui';
+  return {
+    id,
+    first_name: override?.first_name ?? process.env.HOLONS_ACTOR_NAME ?? 'MCP-UI',
+    username: override?.username ?? process.env.HOLONS_ACTOR_USERNAME,
+  };
+}

--- a/packages/mcp-ui/src/index.ts
+++ b/packages/mcp-ui/src/index.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import http from 'http';
+import { createServer } from './server.js';
+
+async function main() {
+  const server = await createServer();
+  const portArg = process.argv.indexOf('--port');
+  if (portArg !== -1 && process.argv[portArg + 1]) {
+    const port = parseInt(process.argv[portArg + 1], 10);
+    let sseTransport: SSEServerTransport | undefined;
+    const httpServer = http.createServer(async (req, res) => {
+      if (req.method === 'GET' && req.url === '/sse') {
+        sseTransport = new SSEServerTransport('/messages', res);
+        await server.connect(sseTransport);
+      } else if (req.method === 'POST' && req.url === '/messages') {
+        if (sseTransport) {
+          let body = '';
+          req.on('data', (c) => (body += c));
+          req.on('end', async () => {
+            await sseTransport!.handlePostMessage(req, res, body);
+          });
+        } else {
+          res.writeHead(400);
+          res.end('No SSE connection');
+        }
+      } else {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ name: 'holons-mcp-ui', version: '0.1.0' }));
+      }
+    });
+    httpServer.listen(port, () => {
+      console.error(`holons-mcp-ui listening on port ${port} (SSE)`);
+    });
+  } else {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    console.error('holons-mcp-ui running on stdio');
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/packages/mcp-ui/src/server.ts
+++ b/packages/mcp-ui/src/server.ts
@@ -1,0 +1,16 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getHoloSphere } from './holosphere.js';
+import { resolveActor } from './identity.js';
+import { registerAllTools, type ToolDeps } from './tools/index.js';
+
+export async function createServer(): Promise<McpServer> {
+  const server = new McpServer({
+    name: 'holons-mcp-ui',
+    version: '0.1.0',
+    description:
+      'MCP server exposing every @holons/core function as an independently-callable tool.',
+  });
+  const deps: ToolDeps = { getHoloSphere, resolveActor };
+  await registerAllTools(server, deps);
+  return server;
+}

--- a/packages/mcp-ui/src/tools/calendar.ts
+++ b/packages/mcp-ui/src/tools/calendar.ts
@@ -1,0 +1,183 @@
+// @holons/mcp-ui — calendar domain tools.
+// Wraps `@holons/core/calendar` (iCal feed, RSVP toggle) plus a thin
+// event-create helper that persists to HoloSphere directly.
+
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  generateICalFeed,
+  toggleRSVP,
+  type HolonEvent,
+  type RSVPUser,
+} from '@holons/core/calendar';
+import type { ToolDeps } from './index.js';
+
+type TextContent = { type: 'text'; text: string };
+type ToolResult = { content: TextContent[]; isError?: boolean };
+
+function ok(payload: unknown): ToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }],
+  };
+}
+
+function fail(message: string, extra?: Record<string, unknown>): ToolResult {
+  return {
+    isError: true,
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify({ success: false, error: message, ...extra }, null, 2),
+      },
+    ],
+  };
+}
+
+/** Coerce whatever HoloSphere returns into an array of records. */
+function asArray<T = any>(v: unknown): T[] {
+  if (Array.isArray(v)) return v as T[];
+  if (v && typeof v === 'object') return Object.values(v as Record<string, T>);
+  return [];
+}
+
+/** Quests/events with a `when` field are the iCal-eligible entries. */
+function toHolonEvents(items: any[]): HolonEvent[] {
+  return items
+    .filter((it) => it && typeof it === 'object' && it.when)
+    .map((it) => ({
+      id: String(it.id ?? it.key ?? `e_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`),
+      title: String(it.title ?? 'Untitled Event'),
+      description: it.description,
+      location: it.location,
+      when: String(it.when),
+      ends: it.ends || it.until || undefined,
+      participants: Array.isArray(it.participants) ? it.participants : undefined,
+      status: it.status,
+      category: it.category,
+    }));
+}
+
+export function registerCalendarTools(server: McpServer, deps: ToolDeps): void {
+  server.tool(
+    'calendar_ical_feed',
+    'Generate an iCal feed (RFC 5545 .ics text) for a holon. Pulls scheduled quests and events from HoloSphere and runs them through @holons/core/calendar.generateICalFeed.',
+    { holon: z.string().describe('Holon ID (chat ID / DAO ID)') },
+    async ({ holon }): Promise<ToolResult> => {
+      try {
+        const h = await deps.getHoloSphere();
+        const [profile, quests, events] = await Promise.all([
+          h.get(holon, 'profile', holon).catch(() => null),
+          h.getAll(holon, 'quests').catch(() => []),
+          h.getAll(holon, 'events').catch(() => []),
+        ]);
+        const holonName =
+          profile?.name || profile?.title || 'Holon Calendar';
+        const items = [...asArray(quests), ...asArray(events)];
+        const calendarEvents = toHolonEvents(items);
+        const ical = generateICalFeed(calendarEvents, holonName, holon);
+        return ok({
+          success: true,
+          holon,
+          holonName,
+          eventCount: calendarEvents.length,
+          ical,
+        });
+      } catch (err) {
+        return fail(err instanceof Error ? err.message : String(err));
+      }
+    }
+  );
+
+  server.tool(
+    'calendar_rsvp_toggle',
+    'Toggle a user\'s RSVP state for a holon event. With `status` ("yes"/"no"/"maybe") the state is set explicitly; otherwise it flips. Persists the user record back to HoloSphere.',
+    {
+      holon: z.string().describe('Holon ID'),
+      eventId: z.string().describe('Event / message key to RSVP against'),
+      userId: z.union([z.string(), z.number()]).describe('User ID'),
+      status: z
+        .enum(['yes', 'no', 'maybe'])
+        .optional()
+        .describe('Force a specific status. Omit to toggle.'),
+    },
+    async ({ holon, eventId, userId, status }): Promise<ToolResult> => {
+      try {
+        const h = await deps.getHoloSphere();
+        const userKey = String(userId);
+        const existing = (await h
+          .get(holon, 'users', userKey)
+          .catch(() => null)) as RSVPUser | null;
+        const user: RSVPUser =
+          existing && typeof existing === 'object'
+            ? existing
+            : { id: userId };
+
+        let updated: RSVPUser;
+        if (status) {
+          // Explicit set — bypass toggle so callers can be idempotent.
+          // `maybe` clears the flag (no boolean state exists for it).
+          if (typeof user.participated !== 'object' || !user.participated) {
+            user.participated = {};
+          }
+          const key = String(eventId);
+          if (status === 'maybe') delete user.participated[key];
+          else user.participated[key] = status === 'yes';
+          updated = user;
+        } else {
+          updated = toggleRSVP(user, eventId);
+        }
+        await h.put(holon, 'users', updated);
+        const attending = Boolean(updated.participated?.[String(eventId)]);
+        return ok({
+          success: true,
+          holon,
+          eventId,
+          userId,
+          attending,
+          status: status ?? (attending ? 'yes' : 'no'),
+        });
+      } catch (err) {
+        return fail(err instanceof Error ? err.message : String(err));
+      }
+    }
+  );
+
+  // No `createEvent` helper in @holons/core/calendar yet — build inline.
+  server.tool(
+    'calendar_event_create',
+    'Create a calendar event in a holon. Persists to the `events` lens via HoloSphere. No Telegram or browser side-effects.',
+    {
+      holon: z.string().describe('Holon ID'),
+      title: z.string().describe('Event title'),
+      when: z.string().describe('Start time (ISO date string)'),
+      until: z.string().optional().describe('End time (ISO date string)'),
+      description: z.string().optional(),
+      category: z.string().optional(),
+    },
+    async ({ holon, title, when, until, description, category }): Promise<ToolResult> => {
+      try {
+        const h = await deps.getHoloSphere();
+        const actor = deps.resolveActor();
+        const event = {
+          id: `e_${Date.now()}`,
+          version: '0.1',
+          holon,
+          title,
+          description: description || '',
+          type: 'event',
+          status: 'upcoming',
+          date: Date.now(),
+          when,
+          until: until || '',
+          category: category || undefined,
+          participants: [] as unknown[],
+          initiator: actor,
+        };
+        await h.put(holon, 'events', event);
+        return ok({ success: true, holon, event });
+      } catch (err) {
+        return fail(err instanceof Error ? err.message : String(err));
+      }
+    }
+  );
+}

--- a/packages/mcp-ui/src/tools/index.ts
+++ b/packages/mcp-ui/src/tools/index.ts
@@ -1,0 +1,38 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Actor } from '../identity.js';
+
+export interface ToolDeps {
+  getHoloSphere: () => Promise<any>;
+  resolveActor: (override?: Partial<Actor>) => Actor;
+}
+
+const DOMAINS = [
+  'holosphere',
+  'tasks',
+  'expenses',
+  'scoring',
+  'calendar',
+  'users',
+  'council',
+  'checklists',
+  'dna',
+  'library',
+  'shopping',
+  'federation',
+  'commands',
+  'settings',
+];
+
+export async function registerAllTools(server: McpServer, deps: ToolDeps): Promise<void> {
+  for (const domain of DOMAINS) {
+    try {
+      const mod: any = await import(`./${domain}.js`);
+      const registerName = `register${domain[0].toUpperCase()}${domain.slice(1)}Tools`;
+      if (typeof mod[registerName] === 'function') {
+        mod[registerName](server, deps);
+      }
+    } catch {
+      // Domain file not yet present in this worktree — skip silently.
+    }
+  }
+}

--- a/packages/mcp-ui/tsconfig.json
+++ b/packages/mcp-ui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary

Unit 5 of the 15-unit parallel migration. Adds `packages/mcp-ui` — an MCP server that exposes every public function in `@holons/core` as an independently-callable MCP tool. Replaces the legacy `telegram-ui` HTTP bot API (port 3101) and the duplicate MCP wrappers in `telegram-ui/mcp`.

This PR carries:

- The shared scaffold (byte-identical across all 15 unit PRs): `package.json`, `tsconfig.json`, `src/holosphere.ts`, `src/identity.ts`, `src/server.ts`, `src/index.ts`, `src/tools/index.ts`, `README.md`. The tool loader uses dynamic imports per domain so sibling PRs land independently — missing files are skipped silently.
- The **calendar** domain (`src/tools/calendar.ts`) registering three tools:
  - `calendar_ical_feed` — wraps `generateICalFeed(...)` from `@holons/core/calendar`. Fetches the holon profile + quests + events lenses in parallel, filters to entries with `when`, and returns the .ics text plus `eventCount`.
  - `calendar_rsvp_toggle` — wraps `toggleRSVP(...)`. Loads the user record from the `users` lens, toggles (or sets explicitly when `status` is provided), and persists back. `status: "maybe"` clears the flag since the legacy `participated` map is boolean-only.
  - `calendar_event_create` — no `createEvent` helper exists in `@holons/core/calendar` yet, so the event shape (`id, version, holon, title, when, until, status, type, ...`) is built inline matching the legacy `telegram-ui` POST /event payload, then persisted via `h.put(holon, 'events', event)`. Pure HoloSphere, no Telegram side-effects.

All tools return `{ content: [{ type: 'text', text: JSON.stringify({ success, ... }) }] }` and flip `isError: true` on failure.

## Test plan

- [x] `pnpm install` and `pnpm run build` in `packages/mcp-ui` (tsc clean)
- [x] Smoke test (initialize -> notifications/initialized -> tools/list over stdio) lists all three `calendar_*` tools — `grep -qE '"calendar_'` returns PASS
- [ ] Live `calendar_ical_feed` call against a real holon (gun.holons.io)
- [ ] Live `calendar_rsvp_toggle` round-trip
- [ ] Live `calendar_event_create` writing to a test holon

Generated with [Claude Code](https://claude.com/claude-code)