### PR TITLE
mcp-ui: users domain (unit 6/15)

### DIFF
--- a/packages/mcp-ui/README.md
+++ b/packages/mcp-ui/README.md
@@ -1,0 +1,15 @@
+# @holons/mcp-ui
+
+MCP server exposing every `@holons/core` function as an independently-callable tool. Replaces the legacy `telegram-ui` HTTP bot API (port 3101) and the duplicate MCP wrappers in `telegram-ui/mcp`.
+
+## Usage
+
+```bash
+pnpm -F @holons/mcp-ui build
+node packages/mcp-ui/dist/index.js                 # stdio
+node packages/mcp-ui/dist/index.js --port 3200     # SSE
+```
+
+## Env
+
+- `HOLONS_PEER` / `HOLONS_APP` / `HOLONS_ACTOR_ID` / `HOLONS_ACTOR_NAME` / `HOLONS_ACTOR_USERNAME`

--- a/packages/mcp-ui/package.json
+++ b/packages/mcp-ui/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@holons/mcp-ui",
+  "version": "0.1.0",
+  "private": true,
+  "description": "MCP server exposing every @holons/core function as an independently-callable tool. Replaces the telegram-ui HTTP bot API.",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": "./dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@holons/core": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "holosphere": "1.3.0-alpha4",
+    "zod": "^3.23.8",
+    "dotenv": "^17.2.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.17",
+    "tsx": "^4.21.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/mcp-ui/src/holosphere.ts
+++ b/packages/mcp-ui/src/holosphere.ts
@@ -1,0 +1,16 @@
+const PEER = process.env.HOLONS_PEER || 'https://gun.holons.io/gun';
+const APP = process.env.HOLONS_APP || 'Holons';
+
+let hs: any;
+export async function getHoloSphere(): Promise<any> {
+  if (hs) return hs;
+  const mod: any = await import('holosphere');
+  const HoloSphere = mod.HoloSphere || mod.default;
+  hs = new HoloSphere(APP, false, null, { peers: [PEER] });
+  await new Promise((r) => setTimeout(r, 1500));
+  return hs;
+}
+
+export function getApp(): string {
+  return APP;
+}

--- a/packages/mcp-ui/src/identity.ts
+++ b/packages/mcp-ui/src/identity.ts
@@ -1,0 +1,14 @@
+export interface Actor {
+  id: string | number;
+  first_name?: string;
+  username?: string;
+}
+
+export function resolveActor(override?: Partial<Actor>): Actor {
+  const id = override?.id ?? process.env.HOLONS_ACTOR_ID ?? 'mcp-ui';
+  return {
+    id,
+    first_name: override?.first_name ?? process.env.HOLONS_ACTOR_NAME ?? 'MCP-UI',
+    username: override?.username ?? process.env.HOLONS_ACTOR_USERNAME,
+  };
+}

--- a/packages/mcp-ui/src/index.ts
+++ b/packages/mcp-ui/src/index.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import http from 'http';
+import { createServer } from './server.js';
+
+async function main() {
+  const server = await createServer();
+  const portArg = process.argv.indexOf('--port');
+  if (portArg !== -1 && process.argv[portArg + 1]) {
+    const port = parseInt(process.argv[portArg + 1], 10);
+    let sseTransport: SSEServerTransport | undefined;
+    const httpServer = http.createServer(async (req, res) => {
+      if (req.method === 'GET' && req.url === '/sse') {
+        sseTransport = new SSEServerTransport('/messages', res);
+        await server.connect(sseTransport);
+      } else if (req.method === 'POST' && req.url === '/messages') {
+        if (sseTransport) {
+          let body = '';
+          req.on('data', (c) => (body += c));
+          req.on('end', async () => {
+            await sseTransport!.handlePostMessage(req, res, body);
+          });
+        } else {
+          res.writeHead(400);
+          res.end('No SSE connection');
+        }
+      } else {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ name: 'holons-mcp-ui', version: '0.1.0' }));
+      }
+    });
+    httpServer.listen(port, () => {
+      console.error(`holons-mcp-ui listening on port ${port} (SSE)`);
+    });
+  } else {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    console.error('holons-mcp-ui running on stdio');
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/packages/mcp-ui/src/server.ts
+++ b/packages/mcp-ui/src/server.ts
@@ -1,0 +1,16 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getHoloSphere } from './holosphere.js';
+import { resolveActor } from './identity.js';
+import { registerAllTools, type ToolDeps } from './tools/index.js';
+
+export async function createServer(): Promise<McpServer> {
+  const server = new McpServer({
+    name: 'holons-mcp-ui',
+    version: '0.1.0',
+    description:
+      'MCP server exposing every @holons/core function as an independently-callable tool.',
+  });
+  const deps: ToolDeps = { getHoloSphere, resolveActor };
+  await registerAllTools(server, deps);
+  return server;
+}

--- a/packages/mcp-ui/src/tools/index.ts
+++ b/packages/mcp-ui/src/tools/index.ts
@@ -1,0 +1,38 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Actor } from '../identity.js';
+
+export interface ToolDeps {
+  getHoloSphere: () => Promise<any>;
+  resolveActor: (override?: Partial<Actor>) => Actor;
+}
+
+const DOMAINS = [
+  'holosphere',
+  'tasks',
+  'expenses',
+  'scoring',
+  'calendar',
+  'users',
+  'council',
+  'checklists',
+  'dna',
+  'library',
+  'shopping',
+  'federation',
+  'commands',
+  'settings',
+];
+
+export async function registerAllTools(server: McpServer, deps: ToolDeps): Promise<void> {
+  for (const domain of DOMAINS) {
+    try {
+      const mod: any = await import(`./${domain}.js`);
+      const registerName = `register${domain[0].toUpperCase()}${domain.slice(1)}Tools`;
+      if (typeof mod[registerName] === 'function') {
+        mod[registerName](server, deps);
+      }
+    } catch {
+      // Domain file not yet present in this worktree — skip silently.
+    }
+  }
+}

--- a/packages/mcp-ui/src/tools/users.ts
+++ b/packages/mcp-ui/src/tools/users.ts
@@ -1,0 +1,208 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  getUserProfile,
+  ensureUserProfile,
+  saveUserProfile,
+  addUserValues,
+  addUserNeeds,
+  joinHolon,
+  leaveHolon,
+  type TelegramUserLike,
+  type UserDB,
+  type UserProfile,
+} from '@holons/core/users';
+import type { ToolDeps } from './index.js';
+
+const userIdSchema = z.union([z.string(), z.number()]);
+
+function ok(payload: Record<string, unknown>) {
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify({ success: true, ...payload }, null, 2),
+      },
+    ],
+  };
+}
+
+function fail(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify({ success: false, error: message }, null, 2),
+      },
+    ],
+    isError: true,
+  };
+}
+
+function parseJson<T>(label: string, raw: string): T {
+  try {
+    return JSON.parse(raw) as T;
+  } catch (e) {
+    const detail = e instanceof Error ? e.message : String(e);
+    throw new Error(`Invalid JSON for "${label}": ${detail}`);
+  }
+}
+
+/**
+ * Resolve a TelegramUserLike for tools that take `{ userId, user? }`.
+ * If `userJson` is provided, parse it; otherwise build a minimal stub from `userId`.
+ * `userId` always wins the id field so parsed and stub paths stay consistent.
+ */
+function resolveTargetUser(userId: string | number, userJson?: string): TelegramUserLike {
+  const base = userJson ? parseJson<TelegramUserLike>('user', userJson) : {};
+  return { ...base, id: userId };
+}
+
+export function registerUsersTools(server: McpServer, deps: ToolDeps): void {
+  server.tool(
+    'user_profile_get',
+    'Load a user profile for a holon. Creates a default profile if absent.',
+    {
+      holon: z.string().describe('Holon id'),
+      userId: userIdSchema.describe('Telegram-like user id'),
+      user: z
+        .string()
+        .optional()
+        .describe('Optional JSON-encoded TelegramUserLike for richer defaults'),
+    },
+    async ({ holon, userId, user }) => {
+      try {
+        const db = (await deps.getHoloSphere()) as UserDB;
+        const u = resolveTargetUser(userId, user);
+        const profile = await getUserProfile(db, u, holon);
+        return ok({ profile });
+      } catch (e) {
+        return fail(e);
+      }
+    },
+  );
+
+  server.tool(
+    'user_profile_ensure',
+    'Ensure a user profile exists for a holon (no-op if already present).',
+    {
+      holon: z.string().describe('Holon id'),
+      user: z.string().describe('JSON-encoded TelegramUserLike'),
+    },
+    async ({ holon, user }) => {
+      try {
+        const db = (await deps.getHoloSphere()) as UserDB;
+        const u = parseJson<TelegramUserLike>('user', user);
+        await ensureUserProfile(db, u, holon);
+        return ok({ ensured: true, userId: u.id, holon });
+      } catch (e) {
+        return fail(e);
+      }
+    },
+  );
+
+  server.tool(
+    'user_profile_save',
+    'Persist an updated user profile against a holon.',
+    {
+      holon: z.string().describe('Holon id'),
+      profile: z.string().describe('JSON-encoded UserProfile'),
+    },
+    async ({ holon, profile }) => {
+      try {
+        const db = (await deps.getHoloSphere()) as UserDB;
+        const p = parseJson<UserProfile>('profile', profile);
+        await saveUserProfile(db, holon, p);
+        return ok({ saved: true, holon, userId: p.id });
+      } catch (e) {
+        return fail(e);
+      }
+    },
+  );
+
+  server.tool(
+    'user_values_add',
+    'Append (deduplicated) values to a user profile in a holon.',
+    {
+      holon: z.string().describe('Holon id'),
+      userId: userIdSchema.describe('Telegram-like user id'),
+      values: z.array(z.string()).describe('Values to append'),
+      user: z
+        .string()
+        .optional()
+        .describe('Optional JSON-encoded TelegramUserLike (for first-time profile creation)'),
+    },
+    async ({ holon, userId, values, user }) => {
+      try {
+        const db = (await deps.getHoloSphere()) as UserDB;
+        const u = resolveTargetUser(userId, user);
+        const profile = await addUserValues(db, u, holon, values);
+        return ok({ profile });
+      } catch (e) {
+        return fail(e);
+      }
+    },
+  );
+
+  server.tool(
+    'user_needs_add',
+    'Append (deduplicated) needs to a user profile in a holon.',
+    {
+      holon: z.string().describe('Holon id'),
+      userId: userIdSchema.describe('Telegram-like user id'),
+      needs: z.array(z.string()).describe('Needs to append'),
+      user: z
+        .string()
+        .optional()
+        .describe('Optional JSON-encoded TelegramUserLike (for first-time profile creation)'),
+    },
+    async ({ holon, userId, needs, user }) => {
+      try {
+        const db = (await deps.getHoloSphere()) as UserDB;
+        const u = resolveTargetUser(userId, user);
+        const profile = await addUserNeeds(db, u, holon, needs);
+        return ok({ profile });
+      } catch (e) {
+        return fail(e);
+      }
+    },
+  );
+
+  server.tool(
+    'holon_join',
+    'Join a holon by ensuring the user profile exists.',
+    {
+      holon: z.string().describe('Holon id'),
+      user: z.string().describe('JSON-encoded TelegramUserLike'),
+    },
+    async ({ holon, user }) => {
+      try {
+        const db = (await deps.getHoloSphere()) as UserDB;
+        const u = parseJson<TelegramUserLike>('user', user);
+        const result = await joinHolon(db, u, holon);
+        return ok({ joined: Boolean(result.profile), ...result });
+      } catch (e) {
+        return fail(e);
+      }
+    },
+  );
+
+  server.tool(
+    'holon_leave',
+    'Leave a holon by deleting the user profile entry.',
+    {
+      holon: z.string().describe('Holon id'),
+      userId: userIdSchema.describe('Telegram-like user id'),
+    },
+    async ({ holon, userId }) => {
+      try {
+        const db = (await deps.getHoloSphere()) as UserDB;
+        const deleted = await leaveHolon(db, userId, holon);
+        return ok({ deleted, holon, userId });
+      } catch (e) {
+        return fail(e);
+      }
+    },
+  );
+}

--- a/packages/mcp-ui/tsconfig.json
+++ b/packages/mcp-ui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary

Bootstraps `packages/mcp-ui`, a new MCP server that exposes every public `@holons/core` function as an independently-callable tool, with the **users** domain registered (unit 6 of 15).

- Scaffold (`package.json`, `tsconfig.json`, `src/{server,index,holosphere,identity,tools/index}.ts`, README) is byte-identical across all 15 parallel units so they merge cleanly.
- New domain file: `src/tools/users.ts` registers 7 snake_case tools — `user_profile_get`, `user_profile_ensure`, `user_profile_save`, `user_values_add`, `user_needs_add`, `holon_join`, `holon_leave` — backed by `@holons/core/users` (`getUserProfile`, `ensureUserProfile`, `saveUserProfile`, `addUserValues`, `addUserNeeds`, `joinHolon`, `leaveHolon`).
- Pure `@holons/core` — no Telegram side-effects. Replaces the legacy `telegram-ui` HTTP bot API + duplicate MCP wrappers for users.
- Uses `zod` input schemas. JSON-encoded `TelegramUserLike` / `UserProfile` payloads keep MCP arg surface flat.

## Test plan

- [x] `pnpm install` (workspace)
- [x] `pnpm -F @holons/core build` (transitively required at runtime — mcp-ui imports the dist of core)
- [x] `pnpm -F @holons/mcp-ui build` — clean tsc
- [x] `pnpm -F @holons/mcp-ui typecheck` — clean
- [x] MCP stdio smoke test (initialize + tools/list) returns all 7 users-domain tools; grep recipe from the unit spec returns `PASS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)