### PR TITLE
mcp-ui: council domain (unit 7/15)

### DIFF
--- a/packages/mcp-ui/README.md
+++ b/packages/mcp-ui/README.md
@@ -1,0 +1,15 @@
+# @holons/mcp-ui
+
+MCP server exposing every `@holons/core` function as an independently-callable tool. Replaces the legacy `telegram-ui` HTTP bot API (port 3101) and the duplicate MCP wrappers in `telegram-ui/mcp`.
+
+## Usage
+
+```bash
+pnpm -F @holons/mcp-ui build
+node packages/mcp-ui/dist/index.js                 # stdio
+node packages/mcp-ui/dist/index.js --port 3200     # SSE
+```
+
+## Env
+
+- `HOLONS_PEER` / `HOLONS_APP` / `HOLONS_ACTOR_ID` / `HOLONS_ACTOR_NAME` / `HOLONS_ACTOR_USERNAME`

--- a/packages/mcp-ui/package.json
+++ b/packages/mcp-ui/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@holons/mcp-ui",
+  "version": "0.1.0",
+  "private": true,
+  "description": "MCP server exposing every @holons/core function as an independently-callable tool. Replaces the telegram-ui HTTP bot API.",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": "./dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@holons/core": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "holosphere": "1.3.0-alpha4",
+    "zod": "^3.23.8",
+    "dotenv": "^17.2.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.17",
+    "tsx": "^4.21.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/mcp-ui/src/holosphere.ts
+++ b/packages/mcp-ui/src/holosphere.ts
@@ -1,0 +1,16 @@
+const PEER = process.env.HOLONS_PEER || 'https://gun.holons.io/gun';
+const APP = process.env.HOLONS_APP || 'Holons';
+
+let hs: any;
+export async function getHoloSphere(): Promise<any> {
+  if (hs) return hs;
+  const mod: any = await import('holosphere');
+  const HoloSphere = mod.HoloSphere || mod.default;
+  hs = new HoloSphere(APP, false, null, { peers: [PEER] });
+  await new Promise((r) => setTimeout(r, 1500));
+  return hs;
+}
+
+export function getApp(): string {
+  return APP;
+}

--- a/packages/mcp-ui/src/identity.ts
+++ b/packages/mcp-ui/src/identity.ts
@@ -1,0 +1,14 @@
+export interface Actor {
+  id: string | number;
+  first_name?: string;
+  username?: string;
+}
+
+export function resolveActor(override?: Partial<Actor>): Actor {
+  const id = override?.id ?? process.env.HOLONS_ACTOR_ID ?? 'mcp-ui';
+  return {
+    id,
+    first_name: override?.first_name ?? process.env.HOLONS_ACTOR_NAME ?? 'MCP-UI',
+    username: override?.username ?? process.env.HOLONS_ACTOR_USERNAME,
+  };
+}

--- a/packages/mcp-ui/src/index.ts
+++ b/packages/mcp-ui/src/index.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import http from 'http';
+import { createServer } from './server.js';
+
+async function main() {
+  const server = await createServer();
+  const portArg = process.argv.indexOf('--port');
+  if (portArg !== -1 && process.argv[portArg + 1]) {
+    const port = parseInt(process.argv[portArg + 1], 10);
+    let sseTransport: SSEServerTransport | undefined;
+    const httpServer = http.createServer(async (req, res) => {
+      if (req.method === 'GET' && req.url === '/sse') {
+        sseTransport = new SSEServerTransport('/messages', res);
+        await server.connect(sseTransport);
+      } else if (req.method === 'POST' && req.url === '/messages') {
+        if (sseTransport) {
+          let body = '';
+          req.on('data', (c) => (body += c));
+          req.on('end', async () => {
+            await sseTransport!.handlePostMessage(req, res, body);
+          });
+        } else {
+          res.writeHead(400);
+          res.end('No SSE connection');
+        }
+      } else {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ name: 'holons-mcp-ui', version: '0.1.0' }));
+      }
+    });
+    httpServer.listen(port, () => {
+      console.error(`holons-mcp-ui listening on port ${port} (SSE)`);
+    });
+  } else {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    console.error('holons-mcp-ui running on stdio');
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/packages/mcp-ui/src/server.ts
+++ b/packages/mcp-ui/src/server.ts
@@ -1,0 +1,16 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getHoloSphere } from './holosphere.js';
+import { resolveActor } from './identity.js';
+import { registerAllTools, type ToolDeps } from './tools/index.js';
+
+export async function createServer(): Promise<McpServer> {
+  const server = new McpServer({
+    name: 'holons-mcp-ui',
+    version: '0.1.0',
+    description:
+      'MCP server exposing every @holons/core function as an independently-callable tool.',
+  });
+  const deps: ToolDeps = { getHoloSphere, resolveActor };
+  await registerAllTools(server, deps);
+  return server;
+}

--- a/packages/mcp-ui/src/tools/council.ts
+++ b/packages/mcp-ui/src/tools/council.ts
@@ -1,0 +1,257 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import {
+  agree,
+  block,
+  castVote,
+  createProposal,
+  deleteProposal,
+  saveProposal,
+  tallyVotes,
+  PROPOSAL_LENS,
+  type Proposal,
+  type ProposalStore,
+  type VoteEntry,
+} from '@holons/core/council';
+import type { ToolDeps } from './index.js';
+
+function ok(payload: Record<string, unknown>) {
+  return {
+    content: [
+      { type: 'text' as const, text: JSON.stringify({ success: true, ...payload }, null, 2) },
+    ],
+  };
+}
+
+function fail(error: string, extra: Record<string, unknown> = {}) {
+  return {
+    content: [
+      { type: 'text' as const, text: JSON.stringify({ success: false, error, ...extra }, null, 2) },
+    ],
+    isError: true,
+  };
+}
+
+function parseJSON<T = unknown>(raw: string, label: string): T {
+  try {
+    return JSON.parse(raw) as T;
+  } catch (e) {
+    throw new Error(`${label}: invalid JSON — ${(e as Error).message}`);
+  }
+}
+
+function coerceVoter(raw: string): VoteEntry {
+  const trimmed = raw.trim();
+  if (trimmed.startsWith('{') || trimmed.startsWith('[') || trimmed.startsWith('"')) {
+    return parseJSON<VoteEntry>(trimmed, 'voter');
+  }
+  const asNum = Number(trimmed);
+  return Number.isFinite(asNum) && trimmed !== '' ? asNum : trimmed;
+}
+
+function entryIdOf(entry: VoteEntry): string | number | undefined {
+  if (entry == null) return undefined;
+  if (typeof entry === 'string' || typeof entry === 'number') return entry;
+  if (typeof entry === 'object' && 'id' in entry) return (entry as { id: string | number }).id;
+  return undefined;
+}
+
+/** Adapt a HoloSphere instance to the ProposalStore interface @holons/core expects. */
+function holoSphereAsStore(hs: any): ProposalStore {
+  return {
+    put: (holonId, lens, data) => hs.put(holonId, lens, data),
+    async get(holonId, lens, key) {
+      const all = await hs.getAll(holonId, lens);
+      if (all && typeof all === 'object' && key in all) return all[key] as Proposal;
+      if (typeof hs.get === 'function') {
+        try {
+          const one = await hs.get(holonId, lens, key);
+          return (one ?? null) as Proposal | null;
+        } catch {
+          return null;
+        }
+      }
+      return null;
+    },
+    delete: (holonId, lens, key) =>
+      typeof hs.delete === 'function'
+        ? hs.delete(holonId, lens, key)
+        : hs.put(holonId, lens, { id: key, _deleted: true }),
+  };
+}
+
+async function withStore(deps: ToolDeps): Promise<ProposalStore> {
+  return holoSphereAsStore(await deps.getHoloSphere());
+}
+
+export function registerCouncilTools(server: McpServer, deps: ToolDeps): void {
+  server.tool(
+    'proposal_create',
+    'Create a council proposal. If `persist` is true, also saves to holosphere under the shared `quests` lens.',
+    {
+      holon: z.string().describe('Holon id (chat id or holon address).'),
+      title: z.string().describe('Proposal title.'),
+      description: z.string().optional().describe('Optional proposal body.'),
+      initiator: z
+        .string()
+        .describe('Voter JSON — either an object {id, first_name?, ...} or a bare id.'),
+      proposalType: z
+        .string()
+        .optional()
+        .describe('Optional proposal sub-type label (stored as `proposalType`).'),
+      persist: z
+        .boolean()
+        .optional()
+        .describe('If true, also save to holosphere. Defaults to false.'),
+    },
+    async ({ holon, title, description, initiator, proposalType, persist }) => {
+      try {
+        const base = createProposal({
+          title,
+          description,
+          creator: coerceVoter(initiator),
+        });
+        const proposal: Proposal = proposalType ? { ...base, proposalType } : base;
+        if (persist) {
+          const store = await withStore(deps);
+          await saveProposal(store, holon, proposal);
+        }
+        return ok({ proposal, persisted: Boolean(persist) });
+      } catch (e) {
+        return fail((e as Error).message);
+      }
+    }
+  );
+
+  server.tool(
+    'proposal_save',
+    'Persist a fully-formed proposal record to holosphere under the `quests` lens.',
+    {
+      holon: z.string().describe('Holon id.'),
+      proposal: z.string().describe('Proposal JSON.'),
+    },
+    async ({ holon, proposal }) => {
+      try {
+        const record = parseJSON<Proposal>(proposal, 'proposal');
+        const store = await withStore(deps);
+        await saveProposal(store, holon, record);
+        return ok({ holon, lens: PROPOSAL_LENS, id: record.id });
+      } catch (e) {
+        return fail((e as Error).message);
+      }
+    }
+  );
+
+  server.tool(
+    'proposal_delete',
+    'Delete a proposal by id from holosphere.',
+    {
+      holon: z.string().describe('Holon id.'),
+      proposalId: z.string().describe('Proposal id to delete.'),
+    },
+    async ({ holon, proposalId }) => {
+      try {
+        const store = await withStore(deps);
+        await deleteProposal(store, holon, proposalId);
+        return ok({ holon, proposalId, deleted: true });
+      } catch (e) {
+        return fail((e as Error).message);
+      }
+    }
+  );
+
+  server.tool(
+    'vote_cast',
+    'Cast a vote on a proposal. Direction `agree` toggles support; `block` toggles a veto. `abstain` clears any prior vote from the voter (not natively supported by core — emulated by clearing both sides).',
+    {
+      holon: z.string().describe('Holon id.'),
+      proposalId: z.string().describe('Target proposal id.'),
+      voter: z.string().describe('Voter JSON or bare id.'),
+      direction: z.enum(['agree', 'block', 'abstain']).describe('Vote direction.'),
+      reason: z.string().optional().describe('Optional reason / comment.'),
+    },
+    async ({ holon, proposalId, voter, direction, reason }) => {
+      try {
+        const voterEntry = coerceVoter(voter);
+        const store = await withStore(deps);
+        let updated: Proposal | null;
+        if (direction === 'abstain') {
+          const current = await store.get(holon, PROPOSAL_LENS, proposalId);
+          if (!current) return fail('proposal not found', { holon, proposalId });
+          const targetId = entryIdOf(voterEntry);
+          updated = {
+            ...current,
+            participants: (current.participants ?? []).filter((e) => entryIdOf(e) !== targetId),
+            stoppers: (current.stoppers ?? []).filter((e) => entryIdOf(e) !== targetId),
+          };
+          await saveProposal(store, holon, updated);
+        } else {
+          updated = await castVote(store, holon, proposalId, voterEntry, direction);
+        }
+        if (!updated) return fail('proposal not found', { holon, proposalId });
+        return ok({ proposal: updated, direction, reason: reason ?? null });
+      } catch (e) {
+        return fail((e as Error).message);
+      }
+    }
+  );
+
+  server.tool(
+    'vote_agree',
+    'Convenience: cast an agree vote (toggles membership in `participants`).',
+    {
+      holon: z.string().describe('Holon id.'),
+      proposalId: z.string().describe('Target proposal id.'),
+      voter: z.string().describe('Voter JSON or bare id.'),
+    },
+    async ({ holon, proposalId, voter }) => {
+      try {
+        const store = await withStore(deps);
+        const updated = await agree(store, holon, proposalId, coerceVoter(voter));
+        if (!updated) return fail('proposal not found', { holon, proposalId });
+        return ok({ proposal: updated });
+      } catch (e) {
+        return fail((e as Error).message);
+      }
+    }
+  );
+
+  server.tool(
+    'vote_block',
+    'Convenience: cast a block (veto) vote (toggles membership in `stoppers`).',
+    {
+      holon: z.string().describe('Holon id.'),
+      proposalId: z.string().describe('Target proposal id.'),
+      voter: z.string().describe('Voter JSON or bare id.'),
+      reason: z.string().optional().describe('Optional reason / comment.'),
+    },
+    async ({ holon, proposalId, voter, reason }) => {
+      try {
+        const store = await withStore(deps);
+        const updated = await block(store, holon, proposalId, coerceVoter(voter));
+        if (!updated) return fail('proposal not found', { holon, proposalId });
+        return ok({ proposal: updated, reason: reason ?? null });
+      } catch (e) {
+        return fail((e as Error).message);
+      }
+    }
+  );
+
+  server.tool(
+    'vote_tally',
+    'Pure tally — given a proposal JSON, return its current vote counts and derived status. No HoloSphere I/O.',
+    {
+      proposal: z.string().describe('Proposal JSON.'),
+      quorum: z.number().int().positive().optional().describe('Quorum threshold (default 5).'),
+    },
+    async ({ proposal, quorum }) => {
+      try {
+        const record = parseJSON<Proposal>(proposal, 'proposal');
+        const tally = tallyVotes(record, quorum);
+        return ok({ tally });
+      } catch (e) {
+        return fail((e as Error).message);
+      }
+    }
+  );
+}

--- a/packages/mcp-ui/src/tools/index.ts
+++ b/packages/mcp-ui/src/tools/index.ts
@@ -1,0 +1,38 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Actor } from '../identity.js';
+
+export interface ToolDeps {
+  getHoloSphere: () => Promise<any>;
+  resolveActor: (override?: Partial<Actor>) => Actor;
+}
+
+const DOMAINS = [
+  'holosphere',
+  'tasks',
+  'expenses',
+  'scoring',
+  'calendar',
+  'users',
+  'council',
+  'checklists',
+  'dna',
+  'library',
+  'shopping',
+  'federation',
+  'commands',
+  'settings',
+];
+
+export async function registerAllTools(server: McpServer, deps: ToolDeps): Promise<void> {
+  for (const domain of DOMAINS) {
+    try {
+      const mod: any = await import(`./${domain}.js`);
+      const registerName = `register${domain[0].toUpperCase()}${domain.slice(1)}Tools`;
+      if (typeof mod[registerName] === 'function') {
+        mod[registerName](server, deps);
+      }
+    } catch {
+      // Domain file not yet present in this worktree — skip silently.
+    }
+  }
+}

--- a/packages/mcp-ui/tsconfig.json
+++ b/packages/mcp-ui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary

Unit 7 of the 15-unit `mcp-ui` migration. Scaffolds the new `@holons/mcp-ui` package and lands the **council** domain.

- New `packages/mcp-ui` MCP server (stdio + SSE) exposing `@holons/core` functions as independently-callable tools. Replaces the legacy `telegram-ui` HTTP bot API and the duplicate MCP wrappers in `telegram-ui/mcp`.
- Council domain: 7 tools — `proposal_create`, `proposal_save`, `proposal_delete`, `vote_cast`, `vote_agree`, `vote_block`, `vote_tally`. Pure `@holons/core/council` — no Telegram side-effects.
- Small `HoloSphere -> ProposalStore` adapter so core's persistence helpers work unmodified.
- `vote_cast` supports `agree` / `block` (core-native) plus an emulated `abstain` that clears both sides on the current record.

## Tools registered

| Tool | Core call |
|------|-----------|
| `proposal_create` | `createProposal` (+ optional `saveProposal`) |
| `proposal_save`   | `saveProposal` |
| `proposal_delete` | `deleteProposal` |
| `vote_cast`       | `castVote` (or manual clear for `abstain`) |
| `vote_agree`      | `agree` |
| `vote_block`      | `block` |
| `vote_tally`      | `tallyVotes` (pure, no HoloSphere I/O) |

## Test plan

- [x] `pnpm -F @holons/core build` succeeds
- [x] `pnpm -F @holons/mcp-ui build` succeeds (tsc, strict)
- [x] Stdio smoke test: `tools/list` returns all 7 council tools (PASS)
- [ ] End-to-end vote round-trip against a live HoloSphere peer (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)