### PR TITLE
mcp-ui: checklists domain (unit 8/15)

### DIFF
--- a/packages/mcp-ui/.gitignore
+++ b/packages/mcp-ui/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/packages/mcp-ui/README.md
+++ b/packages/mcp-ui/README.md
@@ -1,0 +1,15 @@
+# @holons/mcp-ui
+
+MCP server exposing every `@holons/core` function as an independently-callable tool. Replaces the legacy `telegram-ui` HTTP bot API (port 3101) and the duplicate MCP wrappers in `telegram-ui/mcp`.
+
+## Usage
+
+```bash
+pnpm -F @holons/mcp-ui build
+node packages/mcp-ui/dist/index.js                 # stdio
+node packages/mcp-ui/dist/index.js --port 3200     # SSE
+```
+
+## Env
+
+- `HOLONS_PEER` / `HOLONS_APP` / `HOLONS_ACTOR_ID` / `HOLONS_ACTOR_NAME` / `HOLONS_ACTOR_USERNAME`

--- a/packages/mcp-ui/package.json
+++ b/packages/mcp-ui/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@holons/mcp-ui",
+  "version": "0.1.0",
+  "private": true,
+  "description": "MCP server exposing every @holons/core function as an independently-callable tool. Replaces the telegram-ui HTTP bot API.",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": "./dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@holons/core": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "holosphere": "1.3.0-alpha4",
+    "zod": "^3.23.8",
+    "dotenv": "^17.2.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.17",
+    "tsx": "^4.21.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/mcp-ui/src/holosphere.ts
+++ b/packages/mcp-ui/src/holosphere.ts
@@ -1,0 +1,16 @@
+const PEER = process.env.HOLONS_PEER || 'https://gun.holons.io/gun';
+const APP = process.env.HOLONS_APP || 'Holons';
+
+let hs: any;
+export async function getHoloSphere(): Promise<any> {
+  if (hs) return hs;
+  const mod: any = await import('holosphere');
+  const HoloSphere = mod.HoloSphere || mod.default;
+  hs = new HoloSphere(APP, false, null, { peers: [PEER] });
+  await new Promise((r) => setTimeout(r, 1500));
+  return hs;
+}
+
+export function getApp(): string {
+  return APP;
+}

--- a/packages/mcp-ui/src/identity.ts
+++ b/packages/mcp-ui/src/identity.ts
@@ -1,0 +1,14 @@
+export interface Actor {
+  id: string | number;
+  first_name?: string;
+  username?: string;
+}
+
+export function resolveActor(override?: Partial<Actor>): Actor {
+  const id = override?.id ?? process.env.HOLONS_ACTOR_ID ?? 'mcp-ui';
+  return {
+    id,
+    first_name: override?.first_name ?? process.env.HOLONS_ACTOR_NAME ?? 'MCP-UI',
+    username: override?.username ?? process.env.HOLONS_ACTOR_USERNAME,
+  };
+}

--- a/packages/mcp-ui/src/index.ts
+++ b/packages/mcp-ui/src/index.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import http from 'http';
+import { createServer } from './server.js';
+
+async function main() {
+  const server = await createServer();
+  const portArg = process.argv.indexOf('--port');
+  if (portArg !== -1 && process.argv[portArg + 1]) {
+    const port = parseInt(process.argv[portArg + 1], 10);
+    let sseTransport: SSEServerTransport | undefined;
+    const httpServer = http.createServer(async (req, res) => {
+      if (req.method === 'GET' && req.url === '/sse') {
+        sseTransport = new SSEServerTransport('/messages', res);
+        await server.connect(sseTransport);
+      } else if (req.method === 'POST' && req.url === '/messages') {
+        if (sseTransport) {
+          let body = '';
+          req.on('data', (c) => (body += c));
+          req.on('end', async () => {
+            await sseTransport!.handlePostMessage(req, res, body);
+          });
+        } else {
+          res.writeHead(400);
+          res.end('No SSE connection');
+        }
+      } else {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ name: 'holons-mcp-ui', version: '0.1.0' }));
+      }
+    });
+    httpServer.listen(port, () => {
+      console.error(`holons-mcp-ui listening on port ${port} (SSE)`);
+    });
+  } else {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    console.error('holons-mcp-ui running on stdio');
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/packages/mcp-ui/src/server.ts
+++ b/packages/mcp-ui/src/server.ts
@@ -1,0 +1,16 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getHoloSphere } from './holosphere.js';
+import { resolveActor } from './identity.js';
+import { registerAllTools, type ToolDeps } from './tools/index.js';
+
+export async function createServer(): Promise<McpServer> {
+  const server = new McpServer({
+    name: 'holons-mcp-ui',
+    version: '0.1.0',
+    description:
+      'MCP server exposing every @holons/core function as an independently-callable tool.',
+  });
+  const deps: ToolDeps = { getHoloSphere, resolveActor };
+  await registerAllTools(server, deps);
+  return server;
+}

--- a/packages/mcp-ui/src/tools/checklists.ts
+++ b/packages/mcp-ui/src/tools/checklists.ts
@@ -1,0 +1,244 @@
+// Thin MCP wrappers around @holons/core/checklists.
+//
+// Mapping note: the unit-8 brief calls these "subtasks", but @holons/core
+// models a checklist as { id, items: ChecklistItem[] } where ChecklistItem
+// is { text, checked } addressed by INDEX (no per-item stable id). We expose
+// the brief's tool names verbatim (`subtask_add` / `subtask_toggle` /
+// `subtask_delete`) and resolve `subtaskId` to a numeric index — either
+// directly (numeric string) or by matching the item's `text` field.
+//
+// `checklist_create` accepts an optional `taskId` to link the checklist to a
+// quest (core stores this as questId + type='quest').
+//
+// All tools route persistence through deps.getHoloSphere() — HoloSphere
+// already satisfies the ChecklistStore shape (get/getAll/put/delete).
+
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  CHECKLIST_TYPES,
+  addItemsToChecklist,
+  createChecklist,
+  getChecklist,
+  removeItemAt,
+  toggleItem,
+  type ChecklistStore,
+} from '@holons/core/checklists';
+import type { ToolDeps } from './index.js';
+
+// --- helpers -------------------------------------------------------------
+
+function ok(payload: unknown) {
+  return {
+    content: [
+      { type: 'text' as const, text: JSON.stringify(payload, null, 2) },
+    ],
+  };
+}
+
+function fail(message: string, extra?: Record<string, unknown>) {
+  return {
+    isError: true,
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(
+          { success: false, error: message, ...(extra ?? {}) },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}
+
+/** Resolve a `subtaskId` (numeric index OR item text) to a numeric index. */
+async function resolveItemIndex(
+  store: ChecklistStore,
+  holon: string,
+  checklistId: string,
+  subtaskId: string,
+): Promise<{ index: number } | { error: string }> {
+  // Numeric path — accept "0", "3", etc.
+  if (/^\d+$/.test(subtaskId)) {
+    return { index: parseInt(subtaskId, 10) };
+  }
+  // Text path — look up the checklist and match item.text.
+  const cl = await getChecklist(store, holon, checklistId);
+  if (!cl) return { error: 'checklist_not_found' };
+  const idx = cl.items.findIndex((i) => i.text === subtaskId);
+  if (idx === -1) return { error: 'subtask_not_found' };
+  return { index: idx };
+}
+
+// --- registration --------------------------------------------------------
+
+export function registerChecklistsTools(server: McpServer, deps: ToolDeps): void {
+  // checklist_create — create a checklist (optionally quest-linked via taskId).
+  server.registerTool(
+    'checklist_create',
+    {
+      description:
+        'Create a new checklist for a holon. Wraps @holons/core/checklists createChecklist. Pass taskId to link the checklist to a quest (stored as questId, type="quest"). The `title` is used as the checklist id (underscores not allowed).',
+      inputSchema: {
+        holon: z
+          .string()
+          .describe('Holon id (e.g. Telegram chat id, Discord channel id).'),
+        title: z
+          .string()
+          .min(1)
+          .describe('Checklist name; becomes the checklist id. Must not contain underscores.'),
+        taskId: z
+          .string()
+          .optional()
+          .describe('If set, link this checklist to a quest (stored as questId, type="quest").'),
+      },
+    },
+    async (args) => {
+      try {
+        const hs = (await deps.getHoloSphere()) as ChecklistStore;
+        const actor = deps.resolveActor();
+        const result = await createChecklist(hs, args.holon, args.title, {
+          creator: actor.id,
+          ...(args.taskId
+            ? {
+                type: CHECKLIST_TYPES.QUEST,
+                questId: args.taskId,
+                parentTitle: args.title,
+                holonId: args.holon,
+              }
+            : {}),
+        });
+        if (!result.ok) {
+          return fail(`Cannot create checklist: ${result.reason}`, {
+            reason: result.reason,
+          });
+        }
+        return ok({ success: true, checklist: result.checklist });
+      } catch (err) {
+        return fail((err as Error).message);
+      }
+    },
+  );
+
+  // subtask_add — append a single item to an existing checklist.
+  server.registerTool(
+    'subtask_add',
+    {
+      description:
+        'Append a subtask (ChecklistItem) to an existing checklist. Wraps @holons/core/checklists addItemsToChecklist with a single item.',
+      inputSchema: {
+        holon: z.string(),
+        checklistId: z.string().describe('Existing checklist id.'),
+        title: z.string().min(1).describe('Subtask text.'),
+      },
+    },
+    async (args) => {
+      try {
+        const hs = (await deps.getHoloSphere()) as ChecklistStore;
+        const result = await addItemsToChecklist(
+          hs,
+          args.holon,
+          args.checklistId,
+          args.title,
+        );
+        if (!result.ok) {
+          return fail(`Cannot add subtask: ${result.reason}`, {
+            reason: result.reason,
+          });
+        }
+        return ok({
+          success: true,
+          checklist: result.checklist,
+          added: result.added,
+        });
+      } catch (err) {
+        return fail((err as Error).message);
+      }
+    },
+  );
+
+  // subtask_toggle — flip the `checked` flag on one item.
+  server.registerTool(
+    'subtask_toggle',
+    {
+      description:
+        'Toggle the checked state of a subtask. `subtaskId` is either a numeric index ("0", "3") or the subtask text. Wraps @holons/core/checklists toggleItem.',
+      inputSchema: {
+        holon: z.string(),
+        checklistId: z.string(),
+        subtaskId: z
+          .string()
+          .describe('Numeric item index or exact subtask text.'),
+      },
+    },
+    async (args) => {
+      try {
+        const hs = (await deps.getHoloSphere()) as ChecklistStore;
+        const resolved = await resolveItemIndex(
+          hs,
+          args.holon,
+          args.checklistId,
+          args.subtaskId,
+        );
+        if ('error' in resolved) return fail(resolved.error);
+        const checklist = await toggleItem(
+          hs,
+          args.holon,
+          args.checklistId,
+          resolved.index,
+        );
+        if (!checklist) {
+          return fail('subtask_not_found', { reason: 'subtask_not_found' });
+        }
+        return ok({ success: true, checklist });
+      } catch (err) {
+        return fail((err as Error).message);
+      }
+    },
+  );
+
+  // subtask_delete — remove one item.
+  server.registerTool(
+    'subtask_delete',
+    {
+      description:
+        'Delete a subtask from a checklist. `subtaskId` is either a numeric index ("0", "3") or the subtask text. Wraps @holons/core/checklists removeItemAt.',
+      inputSchema: {
+        holon: z.string(),
+        checklistId: z.string(),
+        subtaskId: z
+          .string()
+          .describe('Numeric item index or exact subtask text.'),
+      },
+    },
+    async (args) => {
+      try {
+        const hs = (await deps.getHoloSphere()) as ChecklistStore;
+        const resolved = await resolveItemIndex(
+          hs,
+          args.holon,
+          args.checklistId,
+          args.subtaskId,
+        );
+        if ('error' in resolved) return fail(resolved.error);
+        const result = await removeItemAt(
+          hs,
+          args.holon,
+          args.checklistId,
+          resolved.index,
+        );
+        if (!result) {
+          return fail('subtask_not_found', { reason: 'subtask_not_found' });
+        }
+        return ok({
+          success: true,
+          checklist: result.checklist,
+          removed: result.removed,
+        });
+      } catch (err) {
+        return fail((err as Error).message);
+      }
+    },
+  );
+}

--- a/packages/mcp-ui/src/tools/index.ts
+++ b/packages/mcp-ui/src/tools/index.ts
@@ -1,0 +1,38 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Actor } from '../identity.js';
+
+export interface ToolDeps {
+  getHoloSphere: () => Promise<any>;
+  resolveActor: (override?: Partial<Actor>) => Actor;
+}
+
+const DOMAINS = [
+  'holosphere',
+  'tasks',
+  'expenses',
+  'scoring',
+  'calendar',
+  'users',
+  'council',
+  'checklists',
+  'dna',
+  'library',
+  'shopping',
+  'federation',
+  'commands',
+  'settings',
+];
+
+export async function registerAllTools(server: McpServer, deps: ToolDeps): Promise<void> {
+  for (const domain of DOMAINS) {
+    try {
+      const mod: any = await import(`./${domain}.js`);
+      const registerName = `register${domain[0].toUpperCase()}${domain.slice(1)}Tools`;
+      if (typeof mod[registerName] === 'function') {
+        mod[registerName](server, deps);
+      }
+    } catch {
+      // Domain file not yet present in this worktree — skip silently.
+    }
+  }
+}

--- a/packages/mcp-ui/tsconfig.json
+++ b/packages/mcp-ui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- Adds `packages/mcp-ui` scaffold (package.json, tsconfig, server, transport, identity, holosphere, README, .gitignore, tools/index registry).
- Adds `src/tools/checklists.ts` exposing 4 MCP tools that wrap `@holons/core/checklists`:
  - `checklist_create` -> `createChecklist` (optional `taskId` links the checklist to a quest)
  - `subtask_add` -> `addItemsToChecklist` (single item)
  - `subtask_toggle` -> `toggleItem`
  - `subtask_delete` -> `removeItemAt`
- `subtaskId` accepts either a numeric index ("0", "3") OR the exact item text — core models items by index, not stable id.

## Test plan
- [x] `pnpm install` in `packages/mcp-ui`
- [x] `pnpm -F @holons/core build && pnpm -F @holons/mcp-ui build` typechecks
- [x] Smoke test (initialize + tools/list over stdio) returns all 4 tool names — PASS

Unit 8 of 15 in the parallel mcp-ui migration. Replaces the legacy telegram-ui HTTP bot API and duplicate MCP wrappers.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

[Generated with Claude Code]