### PR TITLE
mcp-ui: settings domain (unit 14/15)

### DIFF
--- a/packages/mcp-ui/README.md
+++ b/packages/mcp-ui/README.md
@@ -1,0 +1,15 @@
+# @holons/mcp-ui
+
+MCP server exposing every `@holons/core` function as an independently-callable tool. Replaces the legacy `telegram-ui` HTTP bot API (port 3101) and the duplicate MCP wrappers in `telegram-ui/mcp`.
+
+## Usage
+
+```bash
+pnpm -F @holons/mcp-ui build
+node packages/mcp-ui/dist/index.js                 # stdio
+node packages/mcp-ui/dist/index.js --port 3200     # SSE
+```
+
+## Env
+
+- `HOLONS_PEER` / `HOLONS_APP` / `HOLONS_ACTOR_ID` / `HOLONS_ACTOR_NAME` / `HOLONS_ACTOR_USERNAME`

--- a/packages/mcp-ui/package.json
+++ b/packages/mcp-ui/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@holons/mcp-ui",
+  "version": "0.1.0",
+  "private": true,
+  "description": "MCP server exposing every @holons/core function as an independently-callable tool. Replaces the telegram-ui HTTP bot API.",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": "./dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@holons/core": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "holosphere": "1.3.0-alpha4",
+    "zod": "^3.23.8",
+    "dotenv": "^17.2.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.17",
+    "tsx": "^4.21.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/mcp-ui/src/holosphere.ts
+++ b/packages/mcp-ui/src/holosphere.ts
@@ -1,0 +1,16 @@
+const PEER = process.env.HOLONS_PEER || 'https://gun.holons.io/gun';
+const APP = process.env.HOLONS_APP || 'Holons';
+
+let hs: any;
+export async function getHoloSphere(): Promise<any> {
+  if (hs) return hs;
+  const mod: any = await import('holosphere');
+  const HoloSphere = mod.HoloSphere || mod.default;
+  hs = new HoloSphere(APP, false, null, { peers: [PEER] });
+  await new Promise((r) => setTimeout(r, 1500));
+  return hs;
+}
+
+export function getApp(): string {
+  return APP;
+}

--- a/packages/mcp-ui/src/identity.ts
+++ b/packages/mcp-ui/src/identity.ts
@@ -1,0 +1,14 @@
+export interface Actor {
+  id: string | number;
+  first_name?: string;
+  username?: string;
+}
+
+export function resolveActor(override?: Partial<Actor>): Actor {
+  const id = override?.id ?? process.env.HOLONS_ACTOR_ID ?? 'mcp-ui';
+  return {
+    id,
+    first_name: override?.first_name ?? process.env.HOLONS_ACTOR_NAME ?? 'MCP-UI',
+    username: override?.username ?? process.env.HOLONS_ACTOR_USERNAME,
+  };
+}

--- a/packages/mcp-ui/src/index.ts
+++ b/packages/mcp-ui/src/index.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import http from 'http';
+import { createServer } from './server.js';
+
+async function main() {
+  const server = await createServer();
+  const portArg = process.argv.indexOf('--port');
+  if (portArg !== -1 && process.argv[portArg + 1]) {
+    const port = parseInt(process.argv[portArg + 1], 10);
+    let sseTransport: SSEServerTransport | undefined;
+    const httpServer = http.createServer(async (req, res) => {
+      if (req.method === 'GET' && req.url === '/sse') {
+        sseTransport = new SSEServerTransport('/messages', res);
+        await server.connect(sseTransport);
+      } else if (req.method === 'POST' && req.url === '/messages') {
+        if (sseTransport) {
+          let body = '';
+          req.on('data', (c) => (body += c));
+          req.on('end', async () => {
+            await sseTransport!.handlePostMessage(req, res, body);
+          });
+        } else {
+          res.writeHead(400);
+          res.end('No SSE connection');
+        }
+      } else {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ name: 'holons-mcp-ui', version: '0.1.0' }));
+      }
+    });
+    httpServer.listen(port, () => {
+      console.error(`holons-mcp-ui listening on port ${port} (SSE)`);
+    });
+  } else {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    console.error('holons-mcp-ui running on stdio');
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/packages/mcp-ui/src/server.ts
+++ b/packages/mcp-ui/src/server.ts
@@ -1,0 +1,16 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getHoloSphere } from './holosphere.js';
+import { resolveActor } from './identity.js';
+import { registerAllTools, type ToolDeps } from './tools/index.js';
+
+export async function createServer(): Promise<McpServer> {
+  const server = new McpServer({
+    name: 'holons-mcp-ui',
+    version: '0.1.0',
+    description:
+      'MCP server exposing every @holons/core function as an independently-callable tool.',
+  });
+  const deps: ToolDeps = { getHoloSphere, resolveActor };
+  await registerAllTools(server, deps);
+  return server;
+}

--- a/packages/mcp-ui/src/tools/index.ts
+++ b/packages/mcp-ui/src/tools/index.ts
@@ -1,0 +1,38 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Actor } from '../identity.js';
+
+export interface ToolDeps {
+  getHoloSphere: () => Promise<any>;
+  resolveActor: (override?: Partial<Actor>) => Actor;
+}
+
+const DOMAINS = [
+  'holosphere',
+  'tasks',
+  'expenses',
+  'scoring',
+  'calendar',
+  'users',
+  'council',
+  'checklists',
+  'dna',
+  'library',
+  'shopping',
+  'federation',
+  'commands',
+  'settings',
+];
+
+export async function registerAllTools(server: McpServer, deps: ToolDeps): Promise<void> {
+  for (const domain of DOMAINS) {
+    try {
+      const mod: any = await import(`./${domain}.js`);
+      const registerName = `register${domain[0].toUpperCase()}${domain.slice(1)}Tools`;
+      if (typeof mod[registerName] === 'function') {
+        mod[registerName](server, deps);
+      }
+    } catch {
+      // Domain file not yet present in this worktree — skip silently.
+    }
+  }
+}

--- a/packages/mcp-ui/src/tools/settings.ts
+++ b/packages/mcp-ui/src/tools/settings.ts
@@ -1,0 +1,235 @@
+// Thin MCP wrappers around @holons/core/settings — holon settings, flow
+// settings, federation link helpers, and value-equation persistence. Web and
+// Telegram both import the same primitives from `@holons/core/settings` so
+// settings written through this MCP surface land in the same `(holon,
+// 'settings', holon)` slot they read back from.
+
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  FlowSettings,
+  addFederationLink,
+  loadSettings,
+  removeFederationLink,
+  saveSettings,
+  type FederationLink,
+  type HolonSettings,
+} from '@holons/core/settings';
+import type { ToolDeps } from './index.js';
+
+// --- helpers -------------------------------------------------------------
+
+function ok(payload: unknown) {
+  return {
+    content: [
+      { type: 'text' as const, text: JSON.stringify(payload, null, 2) },
+    ],
+  };
+}
+
+function fail(message: string, extra?: Record<string, unknown>) {
+  return {
+    isError: true,
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(
+          { success: false, error: message, ...(extra ?? {}) },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}
+
+/** Parse a JSON arg, returning null if the result is not an object. */
+function parseJsonObject(raw: string): Record<string, unknown> | null {
+  try {
+    const decoded = JSON.parse(raw);
+    if (decoded && typeof decoded === 'object' && !Array.isArray(decoded)) {
+      return decoded as Record<string, unknown>;
+    }
+  } catch {
+    // fall through
+  }
+  return null;
+}
+
+// --- registration --------------------------------------------------------
+
+export function registerSettingsTools(server: McpServer, deps: ToolDeps): void {
+  // settings_load --------------------------------------------------------
+  server.registerTool(
+    'settings_load',
+    {
+      description:
+        "Load raw holon settings via @holons/core/settings loadSettings. Returns the persisted object (or null) from (holon, 'settings', holon).",
+      inputSchema: {
+        holon: z.string().describe('Holon id (e.g. Telegram chat id, Discord channel id).'),
+      },
+    },
+    async (args) => {
+      try {
+        const hs = await deps.getHoloSphere();
+        const settings = await loadSettings(hs, args.holon);
+        return ok({ success: true, holon: args.holon, settings });
+      } catch (err) {
+        return fail((err as Error).message);
+      }
+    },
+  );
+
+  // settings_save --------------------------------------------------------
+  server.registerTool(
+    'settings_save',
+    {
+      description:
+        "Save a raw HolonSettings (or partial settings) document via @holons/core/settings saveSettings. Persists to (holon, 'settings').",
+      inputSchema: {
+        holon: z.string(),
+        settings: z
+          .string()
+          .describe('JSON-encoded HolonSettings object (or any settings-shaped object).'),
+      },
+    },
+    async (args) => {
+      try {
+        const parsed = parseJsonObject(args.settings);
+        if (!parsed) return fail("'settings' must be a JSON-encoded object.");
+        const hs = await deps.getHoloSphere();
+        await saveSettings(hs, args.holon, parsed);
+        return ok({ success: true, holon: args.holon, settings: parsed });
+      } catch (err) {
+        return fail((err as Error).message);
+      }
+    },
+  );
+
+  // flow_settings_get ---------------------------------------------------
+  server.registerTool(
+    'flow_settings_get',
+    {
+      description:
+        'Construct a FlowSettings instance for the holon and return the normalised HolonSettings (parsed from holosphere, or defaults when nothing is stored).',
+      inputSchema: {
+        holon: z.string(),
+      },
+    },
+    async (args) => {
+      try {
+        const hs = await deps.getHoloSphere();
+        const flow = new FlowSettings(args.holon);
+        const settings: HolonSettings = await flow.loadSettings(hs, args.holon);
+        return ok({ success: true, holon: args.holon, settings });
+      } catch (err) {
+        return fail((err as Error).message);
+      }
+    },
+  );
+
+  // federation_link_add -------------------------------------------------
+  server.registerTool(
+    'federation_link_add',
+    {
+      description:
+        "Add (or update) a federation link via @holons/core/settings addFederationLink. The `target` JSON must include at least { targetId, targetName, relationship } — additional FederationLink fields (lenses, timestamp) are accepted but recomputed on save.",
+      inputSchema: {
+        holon: z.string(),
+        target: z
+          .string()
+          .describe(
+            'JSON-encoded FederationLink seed { targetId: string, targetName: string, relationship: "federated"|"notifies" }.',
+          ),
+      },
+    },
+    async (args) => {
+      try {
+        const parsed = parseJsonObject(args.target) as Partial<FederationLink> | null;
+        if (!parsed) return fail("'target' must be a JSON-encoded object.");
+        const { targetId, targetName, relationship } = parsed;
+        if (typeof targetId !== 'string' || !targetId) {
+          return fail("'target.targetId' is required (string).");
+        }
+        if (typeof targetName !== 'string') {
+          return fail("'target.targetName' is required (string).");
+        }
+        if (relationship !== 'federated' && relationship !== 'notifies') {
+          return fail("'target.relationship' must be 'federated' or 'notifies'.");
+        }
+
+        const hs = await deps.getHoloSphere();
+        const settings = await addFederationLink(
+          hs,
+          args.holon,
+          targetId,
+          targetName,
+          relationship,
+        );
+        return ok({ success: true, holon: args.holon, settings });
+      } catch (err) {
+        return fail((err as Error).message);
+      }
+    },
+  );
+
+  // federation_link_remove ----------------------------------------------
+  server.registerTool(
+    'federation_link_remove',
+    {
+      description:
+        'Remove a federation link (and its lens config) for the holon via @holons/core/settings removeFederationLink.',
+      inputSchema: {
+        holon: z.string(),
+        target: z.string().describe('Target holon id to unlink.'),
+      },
+    },
+    async (args) => {
+      try {
+        if (!args.target) return fail("'target' is required.");
+        const hs = await deps.getHoloSphere();
+        const settings = await removeFederationLink(hs, args.holon, args.target);
+        return ok({ success: true, holon: args.holon, removedTarget: args.target, settings });
+      } catch (err) {
+        return fail((err as Error).message);
+      }
+    },
+  );
+
+  // equation_save -------------------------------------------------------
+  // The settings barrel re-exports `./equation.ts`. That module is currently
+  // empty (Unit 1 owns the value-equation logic in core/scoring) so we go via
+  // the public settings primitives: load → merge → save. Equation is stored
+  // under `settings.valueEquation`, which is exactly what
+  // `loadEquation(holosphere, holonId)` reads back from core/scoring.
+  server.registerTool(
+    'equation_save',
+    {
+      description:
+        "Persist a ScoreEquation for the holon by merging it into the holon's settings under `valueEquation`. Reads the existing settings, layers the new equation in, and writes the whole document back via saveSettings.",
+      inputSchema: {
+        holon: z.string(),
+        equation: z
+          .string()
+          .describe('JSON-encoded ScoreEquation object (see @holons/core/scoring).'),
+      },
+    },
+    async (args) => {
+      try {
+        const equation = parseJsonObject(args.equation);
+        if (!equation) return fail("'equation' must be a JSON-encoded object.");
+
+        const hs = await deps.getHoloSphere();
+        const existing = (await loadSettings(hs, args.holon)) ?? {};
+        const updated = {
+          ...(existing as Record<string, unknown>),
+          valueEquation: equation,
+        };
+        await saveSettings(hs, args.holon, updated);
+        return ok({ success: true, holon: args.holon, equation, settings: updated });
+      } catch (err) {
+        return fail((err as Error).message);
+      }
+    },
+  );
+}

--- a/packages/mcp-ui/tsconfig.json
+++ b/packages/mcp-ui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary

- Scaffold `packages/mcp-ui` — an MCP server (stdio + SSE) exposing `@holons/core` functions as independently-callable tools. Replaces the legacy `telegram-ui` HTTP bot API.
- Add the `settings` domain module wrapping `@holons/core/settings`:
  - `settings_load` / `settings_save` — raw `loadSettings` / `saveSettings`.
  - `flow_settings_get` — constructs a `FlowSettings` instance and returns the normalised `HolonSettings`.
  - `federation_link_add` / `federation_link_remove` — wrap `addFederationLink` / `removeFederationLink`.
  - `equation_save` — merges a `ScoreEquation` into the holon settings under `valueEquation` (the field `core/scoring`'s `loadEquation` reads back).

## Test plan

- [x] `pnpm install && pnpm run build` in `packages/mcp-ui` — clean tsc.
- [x] MCP smoke test (`tools/list` over stdio) — `settings_load`, `settings_save`, `flow_settings_get`, `federation_link_add`, `federation_link_remove`, `equation_save` all register.
- [ ] Wire-level happy paths against a live HoloSphere peer (out of scope here; covered when the parent units land).

Generated with [Claude Code](https://claude.com/claude-code)