### PR TITLE
mcp-ui: scaffold + holosphere-direct tools (unit 1/15)

### DIFF
--- a/packages/mcp-ui/README.md
+++ b/packages/mcp-ui/README.md
@@ -1,0 +1,27 @@
+# @holons/mcp-ui
+
+MCP server exposing every `@holons/core` function as an independently-callable tool. Replaces the legacy `telegram-ui` HTTP bot API (port 3101) and the duplicate MCP wrappers in `telegram-ui/mcp`.
+
+## Usage
+
+```bash
+pnpm -F @holons/mcp-ui build
+
+# stdio (default)
+node packages/mcp-ui/dist/index.js
+
+# SSE on a port
+node packages/mcp-ui/dist/index.js --port 3200
+```
+
+## Env
+
+- `HOLONS_PEER` — Gun peer URL (default `https://gun.holons.io/gun`)
+- `HOLONS_APP` — HoloSphere app name (default `Holons`)
+- `HOLONS_ACTOR_ID` — default acting user id for write tools
+- `HOLONS_ACTOR_NAME` — default acting user display name
+- `HOLONS_ACTOR_USERNAME` — default acting user @handle
+
+## Tool catalog
+
+One file per `@holons/core` domain under `src/tools/`. Each tool maps 1:1 to a public exported function.

--- a/packages/mcp-ui/package.json
+++ b/packages/mcp-ui/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@holons/mcp-ui",
+  "version": "0.1.0",
+  "private": true,
+  "description": "MCP server exposing every @holons/core function as an independently-callable tool. Replaces the telegram-ui HTTP bot API.",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": "./dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@holons/core": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "holosphere": "1.3.0-alpha4",
+    "zod": "^3.23.8",
+    "dotenv": "^17.2.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.17",
+    "tsx": "^4.21.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/mcp-ui/src/holosphere.ts
+++ b/packages/mcp-ui/src/holosphere.ts
@@ -1,0 +1,16 @@
+const PEER = process.env.HOLONS_PEER || 'https://gun.holons.io/gun';
+const APP = process.env.HOLONS_APP || 'Holons';
+
+let hs: any;
+export async function getHoloSphere(): Promise<any> {
+  if (hs) return hs;
+  const mod: any = await import('holosphere');
+  const HoloSphere = mod.HoloSphere || mod.default;
+  hs = new HoloSphere(APP, false, null, { peers: [PEER] });
+  await new Promise((r) => setTimeout(r, 1500));
+  return hs;
+}
+
+export function getApp(): string {
+  return APP;
+}

--- a/packages/mcp-ui/src/identity.ts
+++ b/packages/mcp-ui/src/identity.ts
@@ -1,0 +1,14 @@
+export interface Actor {
+  id: string | number;
+  first_name?: string;
+  username?: string;
+}
+
+export function resolveActor(override?: Partial<Actor>): Actor {
+  const id = override?.id ?? process.env.HOLONS_ACTOR_ID ?? 'mcp-ui';
+  return {
+    id,
+    first_name: override?.first_name ?? process.env.HOLONS_ACTOR_NAME ?? 'MCP-UI',
+    username: override?.username ?? process.env.HOLONS_ACTOR_USERNAME,
+  };
+}

--- a/packages/mcp-ui/src/index.ts
+++ b/packages/mcp-ui/src/index.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import http from 'http';
+import { createServer } from './server.js';
+
+async function main() {
+  const server = await createServer();
+  const portArg = process.argv.indexOf('--port');
+  if (portArg !== -1 && process.argv[portArg + 1]) {
+    const port = parseInt(process.argv[portArg + 1], 10);
+    let sseTransport: SSEServerTransport | undefined;
+    const httpServer = http.createServer(async (req, res) => {
+      if (req.method === 'GET' && req.url === '/sse') {
+        sseTransport = new SSEServerTransport('/messages', res);
+        await server.connect(sseTransport);
+      } else if (req.method === 'POST' && req.url === '/messages') {
+        if (sseTransport) {
+          let body = '';
+          req.on('data', (c) => (body += c));
+          req.on('end', async () => {
+            await sseTransport!.handlePostMessage(req, res, body);
+          });
+        } else {
+          res.writeHead(400);
+          res.end('No SSE connection');
+        }
+      } else {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ name: 'holons-mcp-ui', version: '0.1.0' }));
+      }
+    });
+    httpServer.listen(port, () => {
+      console.error(`holons-mcp-ui listening on port ${port} (SSE)`);
+    });
+  } else {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    console.error('holons-mcp-ui running on stdio');
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/packages/mcp-ui/src/server.ts
+++ b/packages/mcp-ui/src/server.ts
@@ -1,0 +1,16 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getHoloSphere } from './holosphere.js';
+import { resolveActor } from './identity.js';
+import { registerAllTools, type ToolDeps } from './tools/index.js';
+
+export async function createServer(): Promise<McpServer> {
+  const server = new McpServer({
+    name: 'holons-mcp-ui',
+    version: '0.1.0',
+    description:
+      'MCP server exposing every @holons/core function as an independently-callable tool.',
+  });
+  const deps: ToolDeps = { getHoloSphere, resolveActor };
+  await registerAllTools(server, deps);
+  return server;
+}

--- a/packages/mcp-ui/src/tools/holosphere.ts
+++ b/packages/mcp-ui/src/tools/holosphere.ts
@@ -1,0 +1,291 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { getApp } from '../holosphere.js';
+import type { ToolDeps } from './index.js';
+
+/**
+ * Strip GunDB / Nostr metadata that is noisy in tool output.
+ */
+function clean<T extends Record<string, any>>(item: T): Omit<T, '_nostr'> {
+  const { _nostr, ...rest } = item;
+  return rest;
+}
+
+export function registerHolosphereTools(server: McpServer, deps: ToolDeps): void {
+  // 1. List known holons in the network.
+  server.tool(
+    'holon_list',
+    'List known holons (spaces/groups) in the network with their names',
+    {
+      limit: z.number().optional().describe('Max holons to return (default 50)'),
+    },
+    async ({ limit = 50 }) => {
+      const h = await deps.getHoloSphere();
+      const app = getApp();
+      const holons: string[] = [];
+
+      await new Promise<void>((resolve) => {
+        let timer: NodeJS.Timeout | undefined;
+        const reset = () => {
+          if (timer) clearTimeout(timer);
+          timer = setTimeout(() => resolve(), 3000);
+        };
+        reset();
+        h.gun.get(app).map().once((_data: any, key: string) => {
+          if (
+            key &&
+            key !== '_' &&
+            !key.startsWith('federation') &&
+            !key.startsWith('cell')
+          ) {
+            holons.push(key);
+            reset();
+          }
+        });
+      });
+
+      const subset = holons.slice(0, limit);
+      const results = await Promise.all(
+        subset.map(async (id) => {
+          try {
+            const settings = await h.getAll(id, 'settings');
+            const s = Array.isArray(settings) ? settings[0] : null;
+            const name = s?.name || s?.title || id;
+            return { id, name };
+          } catch {
+            return { id, name: id };
+          }
+        }),
+      );
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ total: holons.length, holons: results }, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  // 2. Get all items from a lens.
+  server.tool(
+    'lens_get_all',
+    'Get all items from a holon lens (quests, events, offers, shopping, roles, announcements, etc.)',
+    {
+      holon: z.string().describe('Holon ID'),
+      lens: z.string().describe('Lens/category to read'),
+    },
+    async ({ holon, lens }) => {
+      const h = await deps.getHoloSphere();
+      const items = await h.getAll(holon, lens);
+      const arr = Array.isArray(items) ? items : [];
+      const cleaned = arr.map(clean);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              { holon, lens, count: cleaned.length, items: cleaned },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    },
+  );
+
+  // 3. Get a single item by id.
+  server.tool(
+    'lens_get',
+    'Get a specific item from a holon lens by ID',
+    {
+      holon: z.string().describe('Holon ID'),
+      lens: z.string().describe('Lens/category'),
+      id: z.string().describe('Item ID'),
+    },
+    async ({ holon, lens, id }) => {
+      const h = await deps.getHoloSphere();
+      const item = await h.get(holon, lens, id);
+      if (!item) {
+        return {
+          content: [{ type: 'text', text: `Item ${id} not found in ${holon}/${lens}` }],
+        };
+      }
+      return {
+        content: [{ type: 'text', text: JSON.stringify(clean(item), null, 2) }],
+      };
+    },
+  );
+
+  // 4. Create / update an item.
+  server.tool(
+    'lens_put',
+    'Create or update an item in a holon lens. Data must be a JSON string; include "id" or one will be assigned by HoloSphere.',
+    {
+      holon: z.string().describe('Holon ID'),
+      lens: z.string().describe('Lens/category'),
+      data: z.string().describe('JSON string of the item data'),
+    },
+    async ({ holon, lens, data }) => {
+      const h = await deps.getHoloSphere();
+      let parsed: any;
+      try {
+        parsed = JSON.parse(data);
+      } catch {
+        return {
+          content: [{ type: 'text', text: 'Error: invalid JSON in data field' }],
+          isError: true,
+        };
+      }
+      const result = await h.put(holon, lens, parsed);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              { success: true, holon, lens, id: parsed.id, result },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    },
+  );
+
+  // 5. Delete an item.
+  server.tool(
+    'lens_delete',
+    'Delete an item from a holon lens',
+    {
+      holon: z.string().describe('Holon ID'),
+      lens: z.string().describe('Lens/category'),
+      id: z.string().describe('Item ID to delete'),
+    },
+    async ({ holon, lens, id }) => {
+      const h = await deps.getHoloSphere();
+      await h.delete(holon, lens, id);
+      return {
+        content: [{ type: 'text', text: `Deleted ${id} from ${holon}/${lens}` }],
+      };
+    },
+  );
+
+  // 6. Get holon settings + summary counts.
+  server.tool(
+    'holon_info',
+    'Get settings and summary for a holon (name, description, member count, quest count, etc.)',
+    {
+      holon: z.string().describe('Holon ID'),
+    },
+    async ({ holon }) => {
+      const h = await deps.getHoloSphere();
+      const [settings, users, quests, events, roles] = await Promise.all([
+        h.getAll(holon, 'settings').catch(() => []),
+        h.getAll(holon, 'users').catch(() => []),
+        h.getAll(holon, 'quests').catch(() => []),
+        h.getAll(holon, 'events').catch(() => []),
+        h.getAll(holon, 'roles').catch(() => []),
+      ]);
+      const s = Array.isArray(settings) && settings[0] ? settings[0] : {};
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                id: holon,
+                name: s.name || s.title || holon,
+                description: s.description || '',
+                language: s.language || 'en',
+                settings: s,
+                counts: {
+                  users: Array.isArray(users) ? users.length : 0,
+                  quests: Array.isArray(quests) ? quests.length : 0,
+                  events: Array.isArray(events) ? events.length : 0,
+                  roles: Array.isArray(roles) ? roles.length : 0,
+                },
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    },
+  );
+
+  // 7. Keyword search across lenses in a holon.
+  server.tool(
+    'holon_search',
+    'Search for items across one or more lenses in a holon by keyword',
+    {
+      holon: z.string().describe('Holon ID'),
+      query: z.string().describe('Search keyword'),
+      lenses: z
+        .array(z.string())
+        .optional()
+        .describe('Lenses to search (default: quests, events, offers, announcements)'),
+    },
+    async ({ holon, query, lenses }) => {
+      const h = await deps.getHoloSphere();
+      const searchLenses = lenses && lenses.length
+        ? lenses
+        : ['quests', 'events', 'offers', 'announcements'];
+      const q = query.toLowerCase();
+      const perLens = await Promise.all(
+        searchLenses.map(async (lens) => {
+          try {
+            const items = await h.getAll(holon, lens);
+            if (!Array.isArray(items)) return [];
+            return items
+              .filter((item) => JSON.stringify(item).toLowerCase().includes(q))
+              .map((item) => ({ lens, ...clean(item) }));
+          } catch {
+            return [];
+          }
+        }),
+      );
+      const results = perLens.flat();
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              { holon, query, matches: results.length, results },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    },
+  );
+
+  // 8. Global (non-holon-scoped) data.
+  server.tool(
+    'global_get',
+    'Read global (non-holon-specific) data by table and key',
+    {
+      table: z.string().describe('Global table name (e.g. "federation", "cell")'),
+      key: z.string().describe('Key within the table'),
+    },
+    async ({ table, key }) => {
+      const h = await deps.getHoloSphere();
+      const data = await h.getGlobal(table, key);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: data ? JSON.stringify(data, null, 2) : `No data at ${table}/${key}`,
+          },
+        ],
+      };
+    },
+  );
+}

--- a/packages/mcp-ui/src/tools/index.ts
+++ b/packages/mcp-ui/src/tools/index.ts
@@ -1,0 +1,38 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Actor } from '../identity.js';
+
+export interface ToolDeps {
+  getHoloSphere: () => Promise<any>;
+  resolveActor: (override?: Partial<Actor>) => Actor;
+}
+
+const DOMAINS = [
+  'holosphere',
+  'tasks',
+  'expenses',
+  'scoring',
+  'calendar',
+  'users',
+  'council',
+  'checklists',
+  'dna',
+  'library',
+  'shopping',
+  'federation',
+  'commands',
+  'settings',
+];
+
+export async function registerAllTools(server: McpServer, deps: ToolDeps): Promise<void> {
+  for (const domain of DOMAINS) {
+    try {
+      const mod: any = await import(`./${domain}.js`);
+      const registerName = `register${domain[0].toUpperCase()}${domain.slice(1)}Tools`;
+      if (typeof mod[registerName] === 'function') {
+        mod[registerName](server, deps);
+      }
+    } catch {
+      // Domain file not yet present in this worktree — skip silently.
+    }
+  }
+}

--- a/packages/mcp-ui/tsconfig.json
+++ b/packages/mcp-ui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Part of /batch mcp-ui rollout. See plan: `@holons/mcp-ui` MCP server replacing the telegram-ui HTTP bot API.

Bundles byte-identical scaffold + this unit's domain file in `packages/mcp-ui/src/tools/`. Sibling units land independently; the dynamic-import aggregator in `src/tools/index.ts` tolerates missing siblings.

Note: `@holons/core` must be built first for runtime imports to resolve (its exports map points at `dist/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)