### PR TITLE
mcp-ui: tasks domain (unit 2/15)

### DIFF
--- a/packages/mcp-ui/README.md
+++ b/packages/mcp-ui/README.md
@@ -1,0 +1,17 @@
+# @holons/mcp-ui
+
+MCP server exposing every `@holons/core` function as an independently-callable tool. Replaces the legacy `telegram-ui` HTTP bot API (port 3101) and the duplicate MCP wrappers in `telegram-ui/mcp`.
+
+## Usage
+
+```bash
+pnpm -F @holons/mcp-ui build
+node packages/mcp-ui/dist/index.js                 # stdio
+node packages/mcp-ui/dist/index.js --port 3200     # SSE
+```
+
+## Env
+
+- `HOLONS_PEER` — Gun peer URL (default `https://gun.holons.io/gun`)
+- `HOLONS_APP` — HoloSphere app name (default `Holons`)
+- `HOLONS_ACTOR_ID` / `HOLONS_ACTOR_NAME` / `HOLONS_ACTOR_USERNAME` — default acting user

--- a/packages/mcp-ui/package.json
+++ b/packages/mcp-ui/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@holons/mcp-ui",
+  "version": "0.1.0",
+  "private": true,
+  "description": "MCP server exposing every @holons/core function as an independently-callable tool. Replaces the telegram-ui HTTP bot API.",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": "./dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@holons/core": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "holosphere": "1.3.0-alpha4",
+    "zod": "^3.23.8",
+    "dotenv": "^17.2.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.17",
+    "tsx": "^4.21.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/mcp-ui/src/holosphere.ts
+++ b/packages/mcp-ui/src/holosphere.ts
@@ -1,0 +1,16 @@
+const PEER = process.env.HOLONS_PEER || 'https://gun.holons.io/gun';
+const APP = process.env.HOLONS_APP || 'Holons';
+
+let hs: any;
+export async function getHoloSphere(): Promise<any> {
+  if (hs) return hs;
+  const mod: any = await import('holosphere');
+  const HoloSphere = mod.HoloSphere || mod.default;
+  hs = new HoloSphere(APP, false, null, { peers: [PEER] });
+  await new Promise((r) => setTimeout(r, 1500));
+  return hs;
+}
+
+export function getApp(): string {
+  return APP;
+}

--- a/packages/mcp-ui/src/identity.ts
+++ b/packages/mcp-ui/src/identity.ts
@@ -1,0 +1,14 @@
+export interface Actor {
+  id: string | number;
+  first_name?: string;
+  username?: string;
+}
+
+export function resolveActor(override?: Partial<Actor>): Actor {
+  const id = override?.id ?? process.env.HOLONS_ACTOR_ID ?? 'mcp-ui';
+  return {
+    id,
+    first_name: override?.first_name ?? process.env.HOLONS_ACTOR_NAME ?? 'MCP-UI',
+    username: override?.username ?? process.env.HOLONS_ACTOR_USERNAME,
+  };
+}

--- a/packages/mcp-ui/src/index.ts
+++ b/packages/mcp-ui/src/index.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import http from 'http';
+import { createServer } from './server.js';
+
+async function main() {
+  const server = await createServer();
+  const portArg = process.argv.indexOf('--port');
+  if (portArg !== -1 && process.argv[portArg + 1]) {
+    const port = parseInt(process.argv[portArg + 1], 10);
+    let sseTransport: SSEServerTransport | undefined;
+    const httpServer = http.createServer(async (req, res) => {
+      if (req.method === 'GET' && req.url === '/sse') {
+        sseTransport = new SSEServerTransport('/messages', res);
+        await server.connect(sseTransport);
+      } else if (req.method === 'POST' && req.url === '/messages') {
+        if (sseTransport) {
+          let body = '';
+          req.on('data', (c) => (body += c));
+          req.on('end', async () => {
+            await sseTransport!.handlePostMessage(req, res, body);
+          });
+        } else {
+          res.writeHead(400);
+          res.end('No SSE connection');
+        }
+      } else {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ name: 'holons-mcp-ui', version: '0.1.0' }));
+      }
+    });
+    httpServer.listen(port, () => {
+      console.error(`holons-mcp-ui listening on port ${port} (SSE)`);
+    });
+  } else {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    console.error('holons-mcp-ui running on stdio');
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/packages/mcp-ui/src/server.ts
+++ b/packages/mcp-ui/src/server.ts
@@ -1,0 +1,16 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getHoloSphere } from './holosphere.js';
+import { resolveActor } from './identity.js';
+import { registerAllTools, type ToolDeps } from './tools/index.js';
+
+export async function createServer(): Promise<McpServer> {
+  const server = new McpServer({
+    name: 'holons-mcp-ui',
+    version: '0.1.0',
+    description:
+      'MCP server exposing every @holons/core function as an independently-callable tool.',
+  });
+  const deps: ToolDeps = { getHoloSphere, resolveActor };
+  await registerAllTools(server, deps);
+  return server;
+}

--- a/packages/mcp-ui/src/tools/index.ts
+++ b/packages/mcp-ui/src/tools/index.ts
@@ -1,0 +1,38 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Actor } from '../identity.js';
+
+export interface ToolDeps {
+  getHoloSphere: () => Promise<any>;
+  resolveActor: (override?: Partial<Actor>) => Actor;
+}
+
+const DOMAINS = [
+  'holosphere',
+  'tasks',
+  'expenses',
+  'scoring',
+  'calendar',
+  'users',
+  'council',
+  'checklists',
+  'dna',
+  'library',
+  'shopping',
+  'federation',
+  'commands',
+  'settings',
+];
+
+export async function registerAllTools(server: McpServer, deps: ToolDeps): Promise<void> {
+  for (const domain of DOMAINS) {
+    try {
+      const mod: any = await import(`./${domain}.js`);
+      const registerName = `register${domain[0].toUpperCase()}${domain.slice(1)}Tools`;
+      if (typeof mod[registerName] === 'function') {
+        mod[registerName](server, deps);
+      }
+    } catch {
+      // Domain file not yet present in this worktree — skip silently.
+    }
+  }
+}

--- a/packages/mcp-ui/src/tools/tasks.ts
+++ b/packages/mcp-ui/src/tools/tasks.ts
@@ -1,0 +1,158 @@
+// Thin MCP wrappers around @holons/core/tasks. `task_get` is the only tool
+// that isn't a direct re-export — core has no read helper, so we go through
+// HoloSphere.get directly.
+
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  createTaskRecord,
+  saveTaskToHolon,
+  saveTasksToHolon,
+  type Quest,
+} from '@holons/core/tasks';
+import type { ToolDeps } from './index.js';
+
+const TASK_TYPE = z.enum(['task', 'quest', 'proposal', 'bounty']);
+
+// --- helpers -------------------------------------------------------------
+
+function ok(payload: unknown) {
+  return {
+    content: [
+      { type: 'text' as const, text: JSON.stringify(payload, null, 2) },
+    ],
+  };
+}
+
+function fail(message: string, extra?: Record<string, unknown>) {
+  return {
+    isError: true,
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(
+          { success: false, error: message, ...(extra ?? {}) },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}
+
+function actorAsInitiator(actor: { id: string | number; first_name?: string; username?: string }): Quest['initiator'] {
+  return {
+    id: actor.id,
+    username: actor.username,
+    firstName: actor.first_name,
+  };
+}
+
+// --- registration --------------------------------------------------------
+
+export function registerTasksTools(server: McpServer, deps: ToolDeps): void {
+  // task_create — build a Quest via createTaskRecord, optionally persist.
+  server.registerTool(
+    'task_create',
+    {
+      description:
+        'Create a new task/quest record for a holon. Wraps @holons/core/tasks createTaskRecord. Pass persist:true to write it to HoloSphere under the "quests" bucket.',
+      inputSchema: {
+        holon: z.string().describe('Holon id (e.g. Telegram chat id, Discord channel id).'),
+        title: z.string().min(1),
+        description: z.string().optional(),
+        orderIndex: z.number().int().optional(),
+        id: z.string().optional().describe('Override the generated id (createTaskRecord leaves it empty by default).'),
+        type: TASK_TYPE.optional(),
+        category: z.string().optional(),
+        when: z.string().optional(),
+        until: z.string().optional(),
+        persist: z.boolean().optional().describe('If true, write the new Quest to HoloSphere under (holon, "quests").'),
+      },
+    },
+    async (args) => {
+      try {
+        const actor = deps.resolveActor();
+        const task = createTaskRecord({
+          holonId: args.holon,
+          initiator: actorAsInitiator(actor),
+          title: args.title,
+          type: args.type,
+          category: args.category,
+        });
+        if (args.id !== undefined) task.id = args.id;
+        if (args.description !== undefined) task.description = args.description;
+        if (args.orderIndex !== undefined) task.orderIndex = args.orderIndex;
+        if (args.when !== undefined) task.when = args.when;
+        if (args.until !== undefined) task.until = args.until;
+
+        let persisted = false;
+        if (args.persist) {
+          const hs = await deps.getHoloSphere();
+          persisted = await saveTaskToHolon(hs, args.holon, task);
+        }
+        return ok({ success: true, persisted, task });
+      } catch (err) {
+        return fail((err as Error).message);
+      }
+    },
+  );
+
+  // task_get — fetch a single Quest by id from HoloSphere.
+  server.registerTool(
+    'task_get',
+    {
+      description:
+        'Fetch a single task/quest by id from HoloSphere via get(holon, "quests", taskId).',
+      inputSchema: {
+        holon: z.string(),
+        taskId: z.string(),
+      },
+    },
+    async (args) => {
+      try {
+        const hs = await deps.getHoloSphere();
+        if (typeof hs.get !== 'function') {
+          return fail('HoloSphere instance does not expose a `get` method.');
+        }
+        const task = await hs.get(args.holon, 'quests', args.taskId);
+        return ok({ success: true, task: task ?? null });
+      } catch (err) {
+        return fail((err as Error).message);
+      }
+    },
+  );
+
+  // tasks_save — persist a batch of Quests via saveTasksToHolon.
+  server.registerTool(
+    'tasks_save',
+    {
+      description:
+        'Persist a batch of tasks to a holon. Accepts a JSON-encoded array of Quest objects. Wraps @holons/core/tasks saveTasksToHolon.',
+      inputSchema: {
+        holon: z.string(),
+        tasks: z
+          .string()
+          .describe('JSON-encoded array of Quest objects.'),
+      },
+    },
+    async (args) => {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(args.tasks);
+      } catch (err) {
+        return fail(`Invalid JSON for 'tasks': ${(err as Error).message}`);
+      }
+      if (!Array.isArray(parsed)) {
+        return fail("'tasks' must decode to a JSON array of Quest objects.");
+      }
+      try {
+        const hs = await deps.getHoloSphere();
+        const saved = await saveTasksToHolon(hs, args.holon, parsed as Quest[]);
+        return ok({ success: true, requested: parsed.length, saved });
+      } catch (err) {
+        return fail((err as Error).message);
+      }
+    },
+  );
+}

--- a/packages/mcp-ui/tsconfig.json
+++ b/packages/mcp-ui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Part of /batch mcp-ui rollout. See plan: `@holons/mcp-ui` MCP server replacing the telegram-ui HTTP bot API.

Bundles byte-identical scaffold + this unit's domain file in `packages/mcp-ui/src/tools/`. Sibling units land independently; the dynamic-import aggregator in `src/tools/index.ts` tolerates missing siblings.

Note: `@holons/core` must be built first for runtime imports to resolve (its exports map points at `dist/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)