### PR TITLE
mcp-ui: dna domain (unit 9/15)

### DIFF
--- a/packages/mcp-ui/README.md
+++ b/packages/mcp-ui/README.md
@@ -1,0 +1,15 @@
+# @holons/mcp-ui
+
+MCP server exposing every `@holons/core` function as an independently-callable tool. Replaces the legacy `telegram-ui` HTTP bot API (port 3101) and the duplicate MCP wrappers in `telegram-ui/mcp`.
+
+## Usage
+
+```bash
+pnpm -F @holons/mcp-ui build
+node packages/mcp-ui/dist/index.js                 # stdio
+node packages/mcp-ui/dist/index.js --port 3200     # SSE
+```
+
+## Env
+
+- `HOLONS_PEER` / `HOLONS_APP` / `HOLONS_ACTOR_ID` / `HOLONS_ACTOR_NAME` / `HOLONS_ACTOR_USERNAME`

--- a/packages/mcp-ui/package.json
+++ b/packages/mcp-ui/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@holons/mcp-ui",
+  "version": "0.1.0",
+  "private": true,
+  "description": "MCP server exposing every @holons/core function as an independently-callable tool. Replaces the telegram-ui HTTP bot API.",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": "./dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@holons/core": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "holosphere": "1.3.0-alpha4",
+    "zod": "^3.23.8",
+    "dotenv": "^17.2.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.17",
+    "tsx": "^4.21.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/mcp-ui/src/holosphere.ts
+++ b/packages/mcp-ui/src/holosphere.ts
@@ -1,0 +1,16 @@
+const PEER = process.env.HOLONS_PEER || 'https://gun.holons.io/gun';
+const APP = process.env.HOLONS_APP || 'Holons';
+
+let hs: any;
+export async function getHoloSphere(): Promise<any> {
+  if (hs) return hs;
+  const mod: any = await import('holosphere');
+  const HoloSphere = mod.HoloSphere || mod.default;
+  hs = new HoloSphere(APP, false, null, { peers: [PEER] });
+  await new Promise((r) => setTimeout(r, 1500));
+  return hs;
+}
+
+export function getApp(): string {
+  return APP;
+}

--- a/packages/mcp-ui/src/identity.ts
+++ b/packages/mcp-ui/src/identity.ts
@@ -1,0 +1,14 @@
+export interface Actor {
+  id: string | number;
+  first_name?: string;
+  username?: string;
+}
+
+export function resolveActor(override?: Partial<Actor>): Actor {
+  const id = override?.id ?? process.env.HOLONS_ACTOR_ID ?? 'mcp-ui';
+  return {
+    id,
+    first_name: override?.first_name ?? process.env.HOLONS_ACTOR_NAME ?? 'MCP-UI',
+    username: override?.username ?? process.env.HOLONS_ACTOR_USERNAME,
+  };
+}

--- a/packages/mcp-ui/src/index.ts
+++ b/packages/mcp-ui/src/index.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import http from 'http';
+import { createServer } from './server.js';
+
+async function main() {
+  const server = await createServer();
+  const portArg = process.argv.indexOf('--port');
+  if (portArg !== -1 && process.argv[portArg + 1]) {
+    const port = parseInt(process.argv[portArg + 1], 10);
+    let sseTransport: SSEServerTransport | undefined;
+    const httpServer = http.createServer(async (req, res) => {
+      if (req.method === 'GET' && req.url === '/sse') {
+        sseTransport = new SSEServerTransport('/messages', res);
+        await server.connect(sseTransport);
+      } else if (req.method === 'POST' && req.url === '/messages') {
+        if (sseTransport) {
+          let body = '';
+          req.on('data', (c) => (body += c));
+          req.on('end', async () => {
+            await sseTransport!.handlePostMessage(req, res, body);
+          });
+        } else {
+          res.writeHead(400);
+          res.end('No SSE connection');
+        }
+      } else {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ name: 'holons-mcp-ui', version: '0.1.0' }));
+      }
+    });
+    httpServer.listen(port, () => {
+      console.error(`holons-mcp-ui listening on port ${port} (SSE)`);
+    });
+  } else {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    console.error('holons-mcp-ui running on stdio');
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/packages/mcp-ui/src/server.ts
+++ b/packages/mcp-ui/src/server.ts
@@ -1,0 +1,16 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getHoloSphere } from './holosphere.js';
+import { resolveActor } from './identity.js';
+import { registerAllTools, type ToolDeps } from './tools/index.js';
+
+export async function createServer(): Promise<McpServer> {
+  const server = new McpServer({
+    name: 'holons-mcp-ui',
+    version: '0.1.0',
+    description:
+      'MCP server exposing every @holons/core function as an independently-callable tool.',
+  });
+  const deps: ToolDeps = { getHoloSphere, resolveActor };
+  await registerAllTools(server, deps);
+  return server;
+}

--- a/packages/mcp-ui/src/tools/dna.ts
+++ b/packages/mcp-ui/src/tools/dna.ts
@@ -1,0 +1,231 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import {
+  addChromosome,
+  getChromosomeLibrary,
+  getDNASequence,
+  removeChromosome,
+  saveDNASequence,
+  seedChromosomeLibrary,
+  validateDNA,
+  type Chromosome,
+  type DNASequence,
+} from '@holons/core/dna';
+import type { ToolDeps } from './index.js';
+
+// ---- helpers ----------------------------------------------------------------
+
+function ok(payload: Record<string, unknown>) {
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify({ success: true, ...payload }, null, 2),
+      },
+    ],
+  };
+}
+
+function fail(error: string, extra: Record<string, unknown> = {}) {
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify({ success: false, error, ...extra }, null, 2),
+      },
+    ],
+    isError: true,
+  };
+}
+
+function parseJSON<T = unknown>(raw: string, label: string): T {
+  try {
+    return JSON.parse(raw) as T;
+  } catch (e) {
+    throw new Error(`${label}: invalid JSON — ${(e as Error).message}`);
+  }
+}
+
+/** Coerce a `sequence` arg into the shape `saveDNASequence` expects.
+ *  Accepts either a bare JSON array of ids or a full DNASequence object. */
+function coerceSequenceInput(raw: string): { chromosomeIds: string[]; version?: number } {
+  const parsed = parseJSON<unknown>(raw, 'sequence');
+  if (Array.isArray(parsed)) {
+    return { chromosomeIds: parsed.map(String) };
+  }
+  if (parsed && typeof parsed === 'object') {
+    const seq = parsed as Partial<DNASequence>;
+    if (!Array.isArray(seq.chromosomeIds)) {
+      throw new Error('sequence: missing chromosomeIds[]');
+    }
+    return {
+      chromosomeIds: seq.chromosomeIds.map(String),
+      version: typeof seq.version === 'number' ? seq.version : undefined,
+    };
+  }
+  throw new Error('sequence: expected JSON array of ids or DNASequence object');
+}
+
+// ---- registration -----------------------------------------------------------
+
+export function registerDnaTools(server: McpServer, deps: ToolDeps): void {
+  // 1. dna_validate ----------------------------------------------------------
+  server.tool(
+    'dna_validate',
+    'Validate a DNA sequence against business rules (duplicates, max length, reference integrity). Library is loaded from holosphere if `holon` is supplied, otherwise it must be provided inline.',
+    {
+      sequence: z.string().describe('DNA sequence JSON ({ holonId, chromosomeIds, ... }).'),
+      holon: z
+        .string()
+        .optional()
+        .describe('Holon id — when set, the library is fetched from holosphere.'),
+      library: z
+        .string()
+        .optional()
+        .describe('Optional inline library JSON (Chromosome[]). Overrides the holosphere fetch.'),
+    },
+    async ({ sequence, holon, library }) => {
+      try {
+        const seq = parseJSON<DNASequence>(sequence, 'sequence');
+        let lib: Chromosome[] = [];
+        if (library) {
+          const parsed = parseJSON<unknown>(library, 'library');
+          if (!Array.isArray(parsed)) throw new Error('library: expected an array of Chromosome');
+          lib = parsed as Chromosome[];
+        } else if (holon) {
+          const hs = await deps.getHoloSphere();
+          lib = await getChromosomeLibrary(hs, holon);
+        }
+        const result = validateDNA(seq, lib);
+        return ok({ result, librarySize: lib.length });
+      } catch (e) {
+        return fail((e as Error).message);
+      }
+    }
+  );
+
+  // 2. chromosome_add --------------------------------------------------------
+  server.tool(
+    'chromosome_add',
+    "Add a new chromosome to a holon's library. Returns the persisted record (with generated id/timestamps).",
+    {
+      holon: z.string().describe('Holon id.'),
+      chromosome: z
+        .string()
+        .describe('Chromosome JSON: { name, type: value|tool|practice, description, icon?, color? }.'),
+    },
+    async ({ holon, chromosome }) => {
+      try {
+        const raw = parseJSON<Record<string, unknown>>(chromosome, 'chromosome');
+        const draft = {
+          holonId: typeof raw.holonId === 'string' ? raw.holonId : holon,
+          name: String(raw.name ?? ''),
+          type: raw.type as Chromosome['type'],
+          description: String(raw.description ?? ''),
+          icon: typeof raw.icon === 'string' ? raw.icon : undefined,
+          color: typeof raw.color === 'string' ? raw.color : undefined,
+        };
+        const hs = await deps.getHoloSphere();
+        const created = await addChromosome(hs, holon, draft);
+        return ok({ chromosome: created });
+      } catch (e) {
+        return fail((e as Error).message);
+      }
+    }
+  );
+
+  // 3. chromosome_remove -----------------------------------------------------
+  server.tool(
+    'chromosome_remove',
+    "Remove a chromosome from a holon's library by id.",
+    {
+      holon: z.string().describe('Holon id.'),
+      chromosomeId: z.string().describe('Chromosome id to remove.'),
+    },
+    async ({ holon, chromosomeId }) => {
+      try {
+        const hs = await deps.getHoloSphere();
+        await removeChromosome(hs, holon, chromosomeId);
+        return ok({ holon, chromosomeId, removed: true });
+      } catch (e) {
+        return fail((e as Error).message);
+      }
+    }
+  );
+
+  // 4. chromosome_library_get ------------------------------------------------
+  server.tool(
+    'chromosome_library_get',
+    "Read all chromosomes in a holon's library.",
+    {
+      holon: z.string().describe('Holon id.'),
+    },
+    async ({ holon }) => {
+      try {
+        const hs = await deps.getHoloSphere();
+        const chromosomes = await getChromosomeLibrary(hs, holon);
+        return ok({ holon, count: chromosomes.length, chromosomes });
+      } catch (e) {
+        return fail((e as Error).message);
+      }
+    }
+  );
+
+  // 5. chromosome_library_seed -----------------------------------------------
+  server.tool(
+    'chromosome_library_seed',
+    "Seed a holon's library with the default value/tool/practice chromosomes.",
+    {
+      holon: z.string().describe('Holon id.'),
+    },
+    async ({ holon }) => {
+      try {
+        const hs = await deps.getHoloSphere();
+        await seedChromosomeLibrary(hs, holon);
+        return ok({ holon, seeded: true });
+      } catch (e) {
+        return fail((e as Error).message);
+      }
+    }
+  );
+
+  // 6. dna_sequence_get ------------------------------------------------------
+  server.tool(
+    'dna_sequence_get',
+    "Read a holon's DNA sequence from holosphere, or null if absent.",
+    {
+      holon: z.string().describe('Holon id.'),
+    },
+    async ({ holon }) => {
+      try {
+        const hs = await deps.getHoloSphere();
+        const sequence = await getDNASequence(hs, holon);
+        return ok({ holon, sequence });
+      } catch (e) {
+        return fail((e as Error).message);
+      }
+    }
+  );
+
+  // 7. dna_sequence_save -----------------------------------------------------
+  server.tool(
+    'dna_sequence_save',
+    "Save (or update) a holon's DNA sequence. Accepts either a JSON array of chromosome ids or a full DNASequence object.",
+    {
+      holon: z.string().describe('Holon id.'),
+      sequence: z
+        .string()
+        .describe('DNASequence JSON ({ chromosomeIds, version? }) or a bare JSON array of ids.'),
+    },
+    async ({ holon, sequence }) => {
+      try {
+        const { chromosomeIds, version } = coerceSequenceInput(sequence);
+        const hs = await deps.getHoloSphere();
+        const saved = await saveDNASequence(hs, holon, chromosomeIds, version);
+        return ok({ sequence: saved });
+      } catch (e) {
+        return fail((e as Error).message);
+      }
+    }
+  );
+}

--- a/packages/mcp-ui/src/tools/index.ts
+++ b/packages/mcp-ui/src/tools/index.ts
@@ -1,0 +1,38 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Actor } from '../identity.js';
+
+export interface ToolDeps {
+  getHoloSphere: () => Promise<any>;
+  resolveActor: (override?: Partial<Actor>) => Actor;
+}
+
+const DOMAINS = [
+  'holosphere',
+  'tasks',
+  'expenses',
+  'scoring',
+  'calendar',
+  'users',
+  'council',
+  'checklists',
+  'dna',
+  'library',
+  'shopping',
+  'federation',
+  'commands',
+  'settings',
+];
+
+export async function registerAllTools(server: McpServer, deps: ToolDeps): Promise<void> {
+  for (const domain of DOMAINS) {
+    try {
+      const mod: any = await import(`./${domain}.js`);
+      const registerName = `register${domain[0].toUpperCase()}${domain.slice(1)}Tools`;
+      if (typeof mod[registerName] === 'function') {
+        mod[registerName](server, deps);
+      }
+    } catch {
+      // Domain file not yet present in this worktree — skip silently.
+    }
+  }
+}

--- a/packages/mcp-ui/tsconfig.json
+++ b/packages/mcp-ui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Part of /batch mcp-ui rollout. See plan: `@holons/mcp-ui` MCP server replacing the telegram-ui HTTP bot API.

Bundles byte-identical scaffold + this unit's domain file in `packages/mcp-ui/src/tools/`. Sibling units land independently; the dynamic-import aggregator in `src/tools/index.ts` tolerates missing siblings.

Note: `@holons/core` must be built first for runtime imports to resolve (its exports map points at `dist/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)