### PR TITLE
mcp-ui: library domain (unit 10/15)

### DIFF
--- a/packages/mcp-ui/README.md
+++ b/packages/mcp-ui/README.md
@@ -1,0 +1,15 @@
+# @holons/mcp-ui
+
+MCP server exposing every `@holons/core` function as an independently-callable tool. Replaces the legacy `telegram-ui` HTTP bot API (port 3101) and the duplicate MCP wrappers in `telegram-ui/mcp`.
+
+## Usage
+
+```bash
+pnpm -F @holons/mcp-ui build
+node packages/mcp-ui/dist/index.js                 # stdio
+node packages/mcp-ui/dist/index.js --port 3200     # SSE
+```
+
+## Env
+
+- `HOLONS_PEER` / `HOLONS_APP` / `HOLONS_ACTOR_ID` / `HOLONS_ACTOR_NAME` / `HOLONS_ACTOR_USERNAME`

--- a/packages/mcp-ui/package.json
+++ b/packages/mcp-ui/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@holons/mcp-ui",
+  "version": "0.1.0",
+  "private": true,
+  "description": "MCP server exposing every @holons/core function as an independently-callable tool. Replaces the telegram-ui HTTP bot API.",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": "./dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@holons/core": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "holosphere": "1.3.0-alpha4",
+    "zod": "^3.23.8",
+    "dotenv": "^17.2.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.17",
+    "tsx": "^4.21.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/mcp-ui/src/holosphere.ts
+++ b/packages/mcp-ui/src/holosphere.ts
@@ -1,0 +1,16 @@
+const PEER = process.env.HOLONS_PEER || 'https://gun.holons.io/gun';
+const APP = process.env.HOLONS_APP || 'Holons';
+
+let hs: any;
+export async function getHoloSphere(): Promise<any> {
+  if (hs) return hs;
+  const mod: any = await import('holosphere');
+  const HoloSphere = mod.HoloSphere || mod.default;
+  hs = new HoloSphere(APP, false, null, { peers: [PEER] });
+  await new Promise((r) => setTimeout(r, 1500));
+  return hs;
+}
+
+export function getApp(): string {
+  return APP;
+}

--- a/packages/mcp-ui/src/identity.ts
+++ b/packages/mcp-ui/src/identity.ts
@@ -1,0 +1,14 @@
+export interface Actor {
+  id: string | number;
+  first_name?: string;
+  username?: string;
+}
+
+export function resolveActor(override?: Partial<Actor>): Actor {
+  const id = override?.id ?? process.env.HOLONS_ACTOR_ID ?? 'mcp-ui';
+  return {
+    id,
+    first_name: override?.first_name ?? process.env.HOLONS_ACTOR_NAME ?? 'MCP-UI',
+    username: override?.username ?? process.env.HOLONS_ACTOR_USERNAME,
+  };
+}

--- a/packages/mcp-ui/src/index.ts
+++ b/packages/mcp-ui/src/index.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import http from 'http';
+import { createServer } from './server.js';
+
+async function main() {
+  const server = await createServer();
+  const portArg = process.argv.indexOf('--port');
+  if (portArg !== -1 && process.argv[portArg + 1]) {
+    const port = parseInt(process.argv[portArg + 1], 10);
+    let sseTransport: SSEServerTransport | undefined;
+    const httpServer = http.createServer(async (req, res) => {
+      if (req.method === 'GET' && req.url === '/sse') {
+        sseTransport = new SSEServerTransport('/messages', res);
+        await server.connect(sseTransport);
+      } else if (req.method === 'POST' && req.url === '/messages') {
+        if (sseTransport) {
+          let body = '';
+          req.on('data', (c) => (body += c));
+          req.on('end', async () => {
+            await sseTransport!.handlePostMessage(req, res, body);
+          });
+        } else {
+          res.writeHead(400);
+          res.end('No SSE connection');
+        }
+      } else {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ name: 'holons-mcp-ui', version: '0.1.0' }));
+      }
+    });
+    httpServer.listen(port, () => {
+      console.error(`holons-mcp-ui listening on port ${port} (SSE)`);
+    });
+  } else {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    console.error('holons-mcp-ui running on stdio');
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/packages/mcp-ui/src/server.ts
+++ b/packages/mcp-ui/src/server.ts
@@ -1,0 +1,16 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getHoloSphere } from './holosphere.js';
+import { resolveActor } from './identity.js';
+import { registerAllTools, type ToolDeps } from './tools/index.js';
+
+export async function createServer(): Promise<McpServer> {
+  const server = new McpServer({
+    name: 'holons-mcp-ui',
+    version: '0.1.0',
+    description:
+      'MCP server exposing every @holons/core function as an independently-callable tool.',
+  });
+  const deps: ToolDeps = { getHoloSphere, resolveActor };
+  await registerAllTools(server, deps);
+  return server;
+}

--- a/packages/mcp-ui/src/tools/index.ts
+++ b/packages/mcp-ui/src/tools/index.ts
@@ -1,0 +1,38 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Actor } from '../identity.js';
+
+export interface ToolDeps {
+  getHoloSphere: () => Promise<any>;
+  resolveActor: (override?: Partial<Actor>) => Actor;
+}
+
+const DOMAINS = [
+  'holosphere',
+  'tasks',
+  'expenses',
+  'scoring',
+  'calendar',
+  'users',
+  'council',
+  'checklists',
+  'dna',
+  'library',
+  'shopping',
+  'federation',
+  'commands',
+  'settings',
+];
+
+export async function registerAllTools(server: McpServer, deps: ToolDeps): Promise<void> {
+  for (const domain of DOMAINS) {
+    try {
+      const mod: any = await import(`./${domain}.js`);
+      const registerName = `register${domain[0].toUpperCase()}${domain.slice(1)}Tools`;
+      if (typeof mod[registerName] === 'function') {
+        mod[registerName](server, deps);
+      }
+    } catch {
+      // Domain file not yet present in this worktree — skip silently.
+    }
+  }
+}

--- a/packages/mcp-ui/src/tools/library.ts
+++ b/packages/mcp-ui/src/tools/library.ts
@@ -1,0 +1,210 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  addItem,
+  borrowItem,
+  getLibraryStats,
+  listItems,
+  removeItem,
+  returnItem,
+  setItemValue,
+  type BorrowActor,
+  type CreateLibraryItemOptions,
+  type LibraryDB,
+  type LibraryItemType,
+} from '@holons/core/library';
+import type { ToolDeps } from './index.js';
+
+type JsonResult = {
+  content: Array<{ type: 'text'; text: string }>;
+};
+
+function ok(payload: Record<string, unknown>): JsonResult {
+  return {
+    content: [
+      { type: 'text', text: JSON.stringify({ success: true, ...payload }, null, 2) },
+    ],
+  };
+}
+
+function fail(error: string, extra: Record<string, unknown> = {}): JsonResult {
+  return {
+    content: [
+      { type: 'text', text: JSON.stringify({ success: false, error, ...extra }, null, 2) },
+    ],
+  };
+}
+
+function parseJson<T>(raw: string | undefined, fallback: T): T {
+  if (!raw) return fallback;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+type ActorOverride = Partial<{
+  id: string | number;
+  first_name: string;
+  last_name: string;
+  username: string;
+}>;
+
+function buildBorrowActor(deps: ToolDeps, override: ActorOverride): BorrowActor {
+  const resolved = deps.resolveActor(override);
+  return {
+    id: resolved.id,
+    username: resolved.username,
+    first_name: resolved.first_name,
+    last_name: override.last_name,
+  };
+}
+
+export function registerLibraryTools(server: McpServer, deps: ToolDeps): void {
+  server.tool(
+    'library_item_add',
+    'Add a new item to a holon library. options JSON must include `id` plus optional CreateLibraryItemOptions (category, description, value, createdBy, createdByUsername).',
+    {
+      holon: z.string(),
+      options: z
+        .string()
+        .describe(
+          'JSON-encoded object: { id: string, category?: string, description?: string, value?: number, createdBy?: number|string, createdByUsername?: string }'
+        ),
+      actor: z.string().optional().describe('JSON-encoded Actor override.'),
+    },
+    async ({ holon, options, actor }) => {
+      const parsed = parseJson<CreateLibraryItemOptions & { id?: string; itemId?: string }>(
+        options,
+        {}
+      );
+      const itemId = parsed.id ?? parsed.itemId;
+      if (!itemId) return fail('options.id is required');
+
+      const resolved = deps.resolveActor(parseJson<ActorOverride>(actor, {}));
+      const opts: CreateLibraryItemOptions = {
+        createdBy: parsed.createdBy ?? resolved.id,
+        createdByUsername: parsed.createdByUsername ?? resolved.username,
+        category: parsed.category,
+        description: parsed.description,
+        value: parsed.value,
+      };
+
+      const db = (await deps.getHoloSphere()) as LibraryDB;
+      const result = await addItem(db, holon, itemId, opts);
+      if (!result.ok) return fail(result.reason ?? 'add_failed', { itemId });
+      return ok({ item: result.item });
+    }
+  );
+
+  server.tool(
+    'library_item_remove',
+    'Remove an item from a holon library by id.',
+    {
+      holon: z.string(),
+      itemId: z.string(),
+    },
+    async ({ holon, itemId }) => {
+      const db = (await deps.getHoloSphere()) as LibraryDB;
+      await removeItem(db, holon, itemId);
+      return ok({ itemId });
+    }
+  );
+
+  // The core helper requires a return date; default to 7 days when omitted
+  // (matches the existing bot flow).
+  server.tool(
+    'library_borrow',
+    'Borrow a library item. Optional borrower JSON overrides the configured actor. Optional `returnBy` ISO date inside borrower JSON defaults to +7 days.',
+    {
+      holon: z.string(),
+      itemId: z.string(),
+      borrower: z
+        .string()
+        .optional()
+        .describe(
+          'JSON-encoded BorrowActor + optional returnBy ISO string: { id, username?, first_name?, last_name?, returnBy? }'
+        ),
+    },
+    async ({ holon, itemId, borrower }) => {
+      const override = parseJson<ActorOverride & { returnBy?: string }>(borrower, {});
+      const actor = buildBorrowActor(deps, override);
+      const returnBy = override.returnBy
+        ? new Date(override.returnBy)
+        : new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+
+      const db = (await deps.getHoloSphere()) as LibraryDB;
+      const result = await borrowItem(db, holon, itemId, actor, returnBy);
+      if (!result.ok) return fail(result.reason ?? 'borrow_failed', { itemId });
+      return ok({ item: result.item, isOwner: result.isOwner });
+    }
+  );
+
+  server.tool(
+    'library_return',
+    'Return a borrowed library item. Defaults the returner to the configured actor.',
+    {
+      holon: z.string(),
+      itemId: z.string(),
+      actor: z
+        .string()
+        .optional()
+        .describe('JSON-encoded BorrowActor override for the returner.'),
+    },
+    async ({ holon, itemId, actor }) => {
+      const returner = buildBorrowActor(deps, parseJson<ActorOverride>(actor, {}));
+      const db = (await deps.getHoloSphere()) as LibraryDB;
+      const result = await returnItem(db, holon, itemId, returner);
+      if (!result.ok) return fail(result.reason ?? 'return_failed', { item: result.item });
+      return ok({ item: result.item, isOwner: result.isOwner });
+    }
+  );
+
+  server.tool(
+    'library_set_value',
+    "Set an item's credit value. Only the item's createdBy user may change it.",
+    {
+      holon: z.string(),
+      itemId: z.string(),
+      value: z.number(),
+      actor: z.string().optional().describe('JSON-encoded Actor override for the requesting user.'),
+    },
+    async ({ holon, itemId, value, actor }) => {
+      const resolved = deps.resolveActor(parseJson<ActorOverride>(actor, {}));
+      const db = (await deps.getHoloSphere()) as LibraryDB;
+      const result = await setItemValue(db, holon, itemId, value, resolved.id);
+      if (!result.ok) return fail(result.reason ?? 'set_value_failed', { itemId });
+      return ok({ item: result.item });
+    }
+  );
+
+  server.tool(
+    'library_list',
+    'List library items for a holon. Optional `type` filters to one of tool|book|equipment|other.',
+    {
+      holon: z.string(),
+      type: z.string().optional(),
+    },
+    async ({ holon, type }) => {
+      const db = (await deps.getHoloSphere()) as LibraryDB;
+      const all = await listItems(db, holon);
+      const items = type ? all.filter((i) => i.type === (type as LibraryItemType)) : all;
+      return ok({ count: items.length, items });
+    }
+  );
+
+  server.tool(
+    'library_stats',
+    'Aggregate library stats for a holon: totals, borrowed/available counts, and byType breakdown.',
+    {
+      holon: z.string(),
+    },
+    async ({ holon }) => {
+      const db = (await deps.getHoloSphere()) as LibraryDB;
+      const items = await listItems(db, holon);
+      const stats = getLibraryStats(items);
+      return ok({ stats });
+    }
+  );
+}

--- a/packages/mcp-ui/tsconfig.json
+++ b/packages/mcp-ui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Part of /batch mcp-ui rollout. See plan: `@holons/mcp-ui` MCP server replacing the telegram-ui HTTP bot API.

Bundles byte-identical scaffold + this unit's domain file in `packages/mcp-ui/src/tools/`. Sibling units land independently; the dynamic-import aggregator in `src/tools/index.ts` tolerates missing siblings.

Note: `@holons/core` must be built first for runtime imports to resolve (its exports map points at `dist/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)