### PR TITLE
mcp-ui: shopping domain (unit 11/15)

### DIFF
--- a/packages/mcp-ui/README.md
+++ b/packages/mcp-ui/README.md
@@ -1,0 +1,15 @@
+# @holons/mcp-ui
+
+MCP server exposing every `@holons/core` function as an independently-callable tool. Replaces the legacy `telegram-ui` HTTP bot API (port 3101) and the duplicate MCP wrappers in `telegram-ui/mcp`.
+
+## Usage
+
+```bash
+pnpm -F @holons/mcp-ui build
+node packages/mcp-ui/dist/index.js                 # stdio
+node packages/mcp-ui/dist/index.js --port 3200     # SSE
+```
+
+## Env
+
+- `HOLONS_PEER` / `HOLONS_APP` / `HOLONS_ACTOR_ID` / `HOLONS_ACTOR_NAME` / `HOLONS_ACTOR_USERNAME`

--- a/packages/mcp-ui/package.json
+++ b/packages/mcp-ui/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@holons/mcp-ui",
+  "version": "0.1.0",
+  "private": true,
+  "description": "MCP server exposing every @holons/core function as an independently-callable tool. Replaces the telegram-ui HTTP bot API.",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": "./dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@holons/core": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "holosphere": "1.3.0-alpha4",
+    "zod": "^3.23.8",
+    "dotenv": "^17.2.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.17",
+    "tsx": "^4.21.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/mcp-ui/src/holosphere.ts
+++ b/packages/mcp-ui/src/holosphere.ts
@@ -1,0 +1,16 @@
+const PEER = process.env.HOLONS_PEER || 'https://gun.holons.io/gun';
+const APP = process.env.HOLONS_APP || 'Holons';
+
+let hs: any;
+export async function getHoloSphere(): Promise<any> {
+  if (hs) return hs;
+  const mod: any = await import('holosphere');
+  const HoloSphere = mod.HoloSphere || mod.default;
+  hs = new HoloSphere(APP, false, null, { peers: [PEER] });
+  await new Promise((r) => setTimeout(r, 1500));
+  return hs;
+}
+
+export function getApp(): string {
+  return APP;
+}

--- a/packages/mcp-ui/src/identity.ts
+++ b/packages/mcp-ui/src/identity.ts
@@ -1,0 +1,14 @@
+export interface Actor {
+  id: string | number;
+  first_name?: string;
+  username?: string;
+}
+
+export function resolveActor(override?: Partial<Actor>): Actor {
+  const id = override?.id ?? process.env.HOLONS_ACTOR_ID ?? 'mcp-ui';
+  return {
+    id,
+    first_name: override?.first_name ?? process.env.HOLONS_ACTOR_NAME ?? 'MCP-UI',
+    username: override?.username ?? process.env.HOLONS_ACTOR_USERNAME,
+  };
+}

--- a/packages/mcp-ui/src/index.ts
+++ b/packages/mcp-ui/src/index.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import http from 'http';
+import { createServer } from './server.js';
+
+async function main() {
+  const server = await createServer();
+  const portArg = process.argv.indexOf('--port');
+  if (portArg !== -1 && process.argv[portArg + 1]) {
+    const port = parseInt(process.argv[portArg + 1], 10);
+    let sseTransport: SSEServerTransport | undefined;
+    const httpServer = http.createServer(async (req, res) => {
+      if (req.method === 'GET' && req.url === '/sse') {
+        sseTransport = new SSEServerTransport('/messages', res);
+        await server.connect(sseTransport);
+      } else if (req.method === 'POST' && req.url === '/messages') {
+        if (sseTransport) {
+          let body = '';
+          req.on('data', (c) => (body += c));
+          req.on('end', async () => {
+            await sseTransport!.handlePostMessage(req, res, body);
+          });
+        } else {
+          res.writeHead(400);
+          res.end('No SSE connection');
+        }
+      } else {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ name: 'holons-mcp-ui', version: '0.1.0' }));
+      }
+    });
+    httpServer.listen(port, () => {
+      console.error(`holons-mcp-ui listening on port ${port} (SSE)`);
+    });
+  } else {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    console.error('holons-mcp-ui running on stdio');
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/packages/mcp-ui/src/server.ts
+++ b/packages/mcp-ui/src/server.ts
@@ -1,0 +1,16 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getHoloSphere } from './holosphere.js';
+import { resolveActor } from './identity.js';
+import { registerAllTools, type ToolDeps } from './tools/index.js';
+
+export async function createServer(): Promise<McpServer> {
+  const server = new McpServer({
+    name: 'holons-mcp-ui',
+    version: '0.1.0',
+    description:
+      'MCP server exposing every @holons/core function as an independently-callable tool.',
+  });
+  const deps: ToolDeps = { getHoloSphere, resolveActor };
+  await registerAllTools(server, deps);
+  return server;
+}

--- a/packages/mcp-ui/src/tools/index.ts
+++ b/packages/mcp-ui/src/tools/index.ts
@@ -1,0 +1,38 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Actor } from '../identity.js';
+
+export interface ToolDeps {
+  getHoloSphere: () => Promise<any>;
+  resolveActor: (override?: Partial<Actor>) => Actor;
+}
+
+const DOMAINS = [
+  'holosphere',
+  'tasks',
+  'expenses',
+  'scoring',
+  'calendar',
+  'users',
+  'council',
+  'checklists',
+  'dna',
+  'library',
+  'shopping',
+  'federation',
+  'commands',
+  'settings',
+];
+
+export async function registerAllTools(server: McpServer, deps: ToolDeps): Promise<void> {
+  for (const domain of DOMAINS) {
+    try {
+      const mod: any = await import(`./${domain}.js`);
+      const registerName = `register${domain[0].toUpperCase()}${domain.slice(1)}Tools`;
+      if (typeof mod[registerName] === 'function') {
+        mod[registerName](server, deps);
+      }
+    } catch {
+      // Domain file not yet present in this worktree — skip silently.
+    }
+  }
+}

--- a/packages/mcp-ui/src/tools/shopping.ts
+++ b/packages/mcp-ui/src/tools/shopping.ts
@@ -1,0 +1,213 @@
+// Thin MCP wrappers around @holons/core/shopping. Persistence layout matches
+// telegram-ui Shopping.ts: a single container doc at (holon, 'checklists') with
+// id 'shopping' holding all items. We always write the *whole list* back since
+// that is the shape the web and telegram UIs expect.
+
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  createShoppingItem,
+  toggleItem,
+  removeItem,
+  normalizeChecklist,
+  createEmptyChecklist,
+  CHECKLISTS_COLLECTION,
+  SHOPPING_KEY,
+  type ShoppingChecklist,
+  type ShoppingItem,
+} from '@holons/core/shopping';
+import type { ToolDeps } from './index.js';
+
+// --- helpers -------------------------------------------------------------
+
+function ok(payload: unknown) {
+  return {
+    content: [
+      { type: 'text' as const, text: JSON.stringify(payload, null, 2) },
+    ],
+  };
+}
+
+function fail(message: string, extra?: Record<string, unknown>) {
+  return {
+    isError: true,
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(
+          { success: false, error: message, ...(extra ?? {}) },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}
+
+/**
+ * Load the current shopping checklist for a holon, falling back to a fresh
+ * empty container when nothing is stored yet. Returns `null` if the HoloSphere
+ * instance lacks `get` (mostly relevant in unit-test environments).
+ */
+async function loadList(
+  hs: any,
+  holon: string,
+): Promise<ShoppingChecklist | null> {
+  if (typeof hs.get !== 'function') return null;
+  const raw = await hs.get(holon, CHECKLISTS_COLLECTION, SHOPPING_KEY);
+  return normalizeChecklist(raw) ?? createEmptyChecklist();
+}
+
+/**
+ * Persist a checklist back under (holon, 'checklists'). Web + telegram both
+ * call `put(holon, 'checklists', list)` — the list's own `id: 'shopping'`
+ * disambiguates it from other checklist docs.
+ */
+async function saveList(
+  hs: any,
+  holon: string,
+  list: ShoppingChecklist,
+): Promise<boolean> {
+  if (typeof hs.put !== 'function') return false;
+  await hs.put(holon, CHECKLISTS_COLLECTION, list);
+  return true;
+}
+
+/** Parse the `item` arg, which may be a JSON string or a raw text string. */
+function parseItemArg(raw: string): { text: string; opts: Parameters<typeof createShoppingItem>[1] } {
+  const trimmed = raw.trim();
+  if (trimmed.startsWith('{') || trimmed.startsWith('"')) {
+    try {
+      const decoded = JSON.parse(trimmed);
+      if (typeof decoded === 'string') return { text: decoded, opts: {} };
+      if (decoded && typeof decoded === 'object') {
+        const { text, id, createdBy, checked } = decoded as Record<string, unknown>;
+        return {
+          text: String(text ?? ''),
+          opts: {
+            ...(id !== undefined ? { id: id as string | number } : {}),
+            ...(createdBy !== undefined ? { createdBy: createdBy as string | number } : {}),
+            ...(checked !== undefined ? { checked: Boolean(checked) } : {}),
+          },
+        };
+      }
+    } catch {
+      // Fall through to treating it as a plain string.
+    }
+  }
+  return { text: trimmed, opts: {} };
+}
+
+// --- registration --------------------------------------------------------
+
+export function registerShoppingTools(server: McpServer, deps: ToolDeps): void {
+  server.registerTool(
+    'shopping_item_create',
+    {
+      description:
+        'Create a shopping item record for a holon. Wraps @holons/core/shopping createShoppingItem. Pass persist:true to append it to the holon\'s checklist under (holon, "checklists", "shopping").',
+      inputSchema: {
+        holon: z.string().describe('Holon id (e.g. Telegram chat id, Discord channel id).'),
+        item: z
+          .string()
+          .describe(
+            'JSON-encoded item. Either a plain string (treated as text) or an object {text, id?, createdBy?, checked?}.',
+          ),
+        persist: z
+          .boolean()
+          .optional()
+          .describe('If true, write the updated checklist to HoloSphere under (holon, "checklists").'),
+      },
+    },
+    async (args) => {
+      try {
+        const actor = deps.resolveActor();
+        const { text, opts } = parseItemArg(args.item);
+        if (!text) return fail("'item' must decode to a non-empty text or { text } object.");
+
+        const item: ShoppingItem = createShoppingItem(text, {
+          createdBy: actor.id,
+          ...opts,
+        });
+
+        let persisted = false;
+        let list: ShoppingChecklist | null = null;
+        if (args.persist) {
+          const hs = await deps.getHoloSphere();
+          list = (await loadList(hs, args.holon)) ?? createEmptyChecklist();
+          list = { ...list, items: [...list.items, item] };
+          persisted = await saveList(hs, args.holon, list);
+        }
+        return ok({ success: true, persisted, item, list });
+      } catch (err) {
+        return fail((err as Error).message);
+      }
+    },
+  );
+
+  server.registerTool(
+    'shopping_item_toggle',
+    {
+      description:
+        'Toggle the `checked` flag on one shopping item. Wraps @holons/core/shopping toggleItem and writes the result back to HoloSphere.',
+      inputSchema: {
+        holon: z.string(),
+        itemId: z
+          .union([z.string(), z.number()])
+          .describe('The id of the item to toggle (compared via String()).'),
+      },
+    },
+    async (args) => {
+      try {
+        const hs = await deps.getHoloSphere();
+        const list = await loadList(hs, args.holon);
+        if (!list) return fail('No shopping checklist exists for this holon.');
+
+        const target = String(args.itemId);
+        if (!list.items.some((i) => String(i.id) === target)) {
+          return fail(`Item ${args.itemId} not found in checklist.`, {
+            itemIds: list.items.map((i) => i.id),
+          });
+        }
+
+        const updated = toggleItem(list, args.itemId)!;
+        const persisted = await saveList(hs, args.holon, updated);
+        return ok({ success: true, persisted, list: updated });
+      } catch (err) {
+        return fail((err as Error).message);
+      }
+    },
+  );
+
+  // Tool id `_delete` maps to core's `removeItem` — they are the same operation.
+  server.registerTool(
+    'shopping_item_delete',
+    {
+      description:
+        'Delete one shopping item from a holon\'s checklist by id. Wraps @holons/core/shopping removeItem and writes the result back to HoloSphere.',
+      inputSchema: {
+        holon: z.string(),
+        itemId: z.union([z.string(), z.number()]),
+      },
+    },
+    async (args) => {
+      try {
+        const hs = await deps.getHoloSphere();
+        const list = await loadList(hs, args.holon);
+        if (!list) return fail('No shopping checklist exists for this holon.');
+
+        const updated = removeItem(list, args.itemId)!;
+        if (updated.items.length === list.items.length) {
+          return fail(`Item ${args.itemId} not found in checklist.`, {
+            itemIds: list.items.map((i) => i.id),
+          });
+        }
+
+        const persisted = await saveList(hs, args.holon, updated);
+        return ok({ success: true, persisted, removedId: args.itemId, list: updated });
+      } catch (err) {
+        return fail((err as Error).message);
+      }
+    },
+  );
+}

--- a/packages/mcp-ui/tsconfig.json
+++ b/packages/mcp-ui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Part of /batch mcp-ui rollout. See plan: `@holons/mcp-ui` MCP server replacing the telegram-ui HTTP bot API.

Bundles byte-identical scaffold + this unit's domain file in `packages/mcp-ui/src/tools/`. Sibling units land independently; the dynamic-import aggregator in `src/tools/index.ts` tolerates missing siblings.

Note: `@holons/core` must be built first for runtime imports to resolve (its exports map points at `dist/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)