### PR TITLE
mcp-ui: federation domain (unit 12/15)

### DIFF
--- a/packages/mcp-ui/README.md
+++ b/packages/mcp-ui/README.md
@@ -1,0 +1,15 @@
+# @holons/mcp-ui
+
+MCP server exposing every `@holons/core` function as an independently-callable tool. Replaces the legacy `telegram-ui` HTTP bot API (port 3101) and the duplicate MCP wrappers in `telegram-ui/mcp`.
+
+## Usage
+
+```bash
+pnpm -F @holons/mcp-ui build
+node packages/mcp-ui/dist/index.js                 # stdio
+node packages/mcp-ui/dist/index.js --port 3200     # SSE
+```
+
+## Env
+
+- `HOLONS_PEER` / `HOLONS_APP` / `HOLONS_ACTOR_ID` / `HOLONS_ACTOR_NAME` / `HOLONS_ACTOR_USERNAME`

--- a/packages/mcp-ui/package.json
+++ b/packages/mcp-ui/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@holons/mcp-ui",
+  "version": "0.1.0",
+  "private": true,
+  "description": "MCP server exposing every @holons/core function as an independently-callable tool. Replaces the telegram-ui HTTP bot API.",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": "./dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@holons/core": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "holosphere": "1.3.0-alpha4",
+    "zod": "^3.23.8",
+    "dotenv": "^17.2.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.17",
+    "tsx": "^4.21.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/mcp-ui/src/holosphere.ts
+++ b/packages/mcp-ui/src/holosphere.ts
@@ -1,0 +1,16 @@
+const PEER = process.env.HOLONS_PEER || 'https://gun.holons.io/gun';
+const APP = process.env.HOLONS_APP || 'Holons';
+
+let hs: any;
+export async function getHoloSphere(): Promise<any> {
+  if (hs) return hs;
+  const mod: any = await import('holosphere');
+  const HoloSphere = mod.HoloSphere || mod.default;
+  hs = new HoloSphere(APP, false, null, { peers: [PEER] });
+  await new Promise((r) => setTimeout(r, 1500));
+  return hs;
+}
+
+export function getApp(): string {
+  return APP;
+}

--- a/packages/mcp-ui/src/identity.ts
+++ b/packages/mcp-ui/src/identity.ts
@@ -1,0 +1,14 @@
+export interface Actor {
+  id: string | number;
+  first_name?: string;
+  username?: string;
+}
+
+export function resolveActor(override?: Partial<Actor>): Actor {
+  const id = override?.id ?? process.env.HOLONS_ACTOR_ID ?? 'mcp-ui';
+  return {
+    id,
+    first_name: override?.first_name ?? process.env.HOLONS_ACTOR_NAME ?? 'MCP-UI',
+    username: override?.username ?? process.env.HOLONS_ACTOR_USERNAME,
+  };
+}

--- a/packages/mcp-ui/src/index.ts
+++ b/packages/mcp-ui/src/index.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import http from 'http';
+import { createServer } from './server.js';
+
+async function main() {
+  const server = await createServer();
+  const portArg = process.argv.indexOf('--port');
+  if (portArg !== -1 && process.argv[portArg + 1]) {
+    const port = parseInt(process.argv[portArg + 1], 10);
+    let sseTransport: SSEServerTransport | undefined;
+    const httpServer = http.createServer(async (req, res) => {
+      if (req.method === 'GET' && req.url === '/sse') {
+        sseTransport = new SSEServerTransport('/messages', res);
+        await server.connect(sseTransport);
+      } else if (req.method === 'POST' && req.url === '/messages') {
+        if (sseTransport) {
+          let body = '';
+          req.on('data', (c) => (body += c));
+          req.on('end', async () => {
+            await sseTransport!.handlePostMessage(req, res, body);
+          });
+        } else {
+          res.writeHead(400);
+          res.end('No SSE connection');
+        }
+      } else {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ name: 'holons-mcp-ui', version: '0.1.0' }));
+      }
+    });
+    httpServer.listen(port, () => {
+      console.error(`holons-mcp-ui listening on port ${port} (SSE)`);
+    });
+  } else {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    console.error('holons-mcp-ui running on stdio');
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/packages/mcp-ui/src/server.ts
+++ b/packages/mcp-ui/src/server.ts
@@ -1,0 +1,16 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getHoloSphere } from './holosphere.js';
+import { resolveActor } from './identity.js';
+import { registerAllTools, type ToolDeps } from './tools/index.js';
+
+export async function createServer(): Promise<McpServer> {
+  const server = new McpServer({
+    name: 'holons-mcp-ui',
+    version: '0.1.0',
+    description:
+      'MCP server exposing every @holons/core function as an independently-callable tool.',
+  });
+  const deps: ToolDeps = { getHoloSphere, resolveActor };
+  await registerAllTools(server, deps);
+  return server;
+}

--- a/packages/mcp-ui/src/tools/federation.ts
+++ b/packages/mcp-ui/src/tools/federation.ts
@@ -1,0 +1,165 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import {
+  publishToFederation,
+  getFederationSnapshot,
+  readSettingsHex,
+  type PublishContext,
+  type PublishOptions,
+  type PublishTarget,
+} from '@holons/core/federation';
+import type { ToolDeps } from './index.js';
+
+// ---- helpers ----------------------------------------------------------------
+
+function ok(payload: Record<string, unknown>) {
+  return {
+    content: [
+      { type: 'text' as const, text: JSON.stringify({ success: true, ...payload }, null, 2) },
+    ],
+  };
+}
+
+function fail(error: string, extra: Record<string, unknown> = {}) {
+  return {
+    content: [
+      { type: 'text' as const, text: JSON.stringify({ success: false, error, ...extra }, null, 2) },
+    ],
+    isError: true,
+  };
+}
+
+function parseJSON<T = unknown>(raw: string, label: string): T {
+  try {
+    return JSON.parse(raw) as T;
+  } catch (e) {
+    throw new Error(`${label}: invalid JSON — ${(e as Error).message}`);
+  }
+}
+
+/**
+ * Coerce a tool-input `context` JSON into a partial PublishContext.
+ * `holosphere` is injected at call-time (it isn't JSON-serializable).
+ */
+function coerceContext(raw: string): Omit<PublishContext, 'holosphere'> {
+  const parsed = parseJSON<Record<string, unknown>>(raw, 'context');
+  const holonId = typeof parsed.holonId === 'string' ? parsed.holonId : '';
+  const lens = typeof parsed.lens === 'string' ? parsed.lens : '';
+  const item = parsed.item;
+  if (!holonId) throw new Error('context: holonId is required');
+  if (!lens) throw new Error('context: lens is required');
+  if (!item || typeof item !== 'object' || typeof (item as any).id !== 'string') {
+    throw new Error('context: item with string id is required');
+  }
+  return { holonId, lens, item: item as PublishContext['item'] };
+}
+
+/**
+ * Coerce a tool-input `options` JSON into `{ target, opts }`.
+ * Accepts either a flat object with a `target` field or a wrapper
+ * `{ target, ...publishOptions }`. Targets default to `{ kind: 'all' }`.
+ *
+ * `onWriteDenied` is intentionally dropped — callbacks can't cross the
+ * MCP boundary; errors come back in the `PublishOutcome.errors[]`.
+ */
+function coerceOptions(raw: string): { target: PublishTarget; opts: PublishOptions } {
+  const parsed = parseJSON<Record<string, unknown>>(raw, 'options');
+  const rawTarget = parsed.target;
+  let target: PublishTarget = { kind: 'all' };
+  if (rawTarget && typeof rawTarget === 'object') {
+    const t = rawTarget as Record<string, unknown>;
+    if (t.kind === 'partner' && typeof t.holonId === 'string') {
+      target = { kind: 'partner', holonId: t.holonId };
+    } else if (t.kind === 'hex' && typeof t.cell === 'string') {
+      target = { kind: 'hex', cell: t.cell };
+    } else if (t.kind === 'all') {
+      target = { kind: 'all' };
+    } else {
+      throw new Error(
+        'options.target: expected { kind: "all" } | { kind: "partner", holonId } | { kind: "hex", cell }'
+      );
+    }
+  }
+  const opts: PublishOptions = {};
+  if (typeof parsed.includeSettingsHex === 'boolean') {
+    opts.includeSettingsHex = parsed.includeSettingsHex;
+  }
+  if (typeof parsed.federationSourceId === 'string') {
+    opts.federationSourceId = parsed.federationSourceId;
+  }
+  return { target, opts };
+}
+
+// ---- registration -----------------------------------------------------------
+
+export function registerFederationTools(server: McpServer, deps: ToolDeps): void {
+  // 1. federation_publish ----------------------------------------------------
+  server.tool(
+    'federation_publish',
+    'Publish an item as a hologram to the federation. Wraps the item in a hologram first, then routes to one of three targets: `all` (propagate to every federated partner + settings.hex if configured), `partner` (a single holon id), or `hex` (a single H3 cell). Stamping the source item with published/publishedAt/publishedTo is the caller\'s responsibility.',
+    {
+      context: z
+        .string()
+        .describe(
+          'PublishContext JSON: { holonId, lens, item: { id, ... } }. holosphere is injected automatically.'
+        ),
+      options: z
+        .string()
+        .describe(
+          'Publish options JSON: { target: { kind: "all" } | { kind: "partner", holonId } | { kind: "hex", cell }, includeSettingsHex?, federationSourceId? }. Defaults to target.kind = "all".'
+        ),
+    },
+    async ({ context, options }) => {
+      try {
+        const ctxPartial = coerceContext(context);
+        const { target, opts } = coerceOptions(options);
+        const hs = await deps.getHoloSphere();
+        const ctx: PublishContext = { holosphere: hs, ...ctxPartial };
+        const outcome = await publishToFederation(ctx, target, opts);
+        return ok({ outcome });
+      } catch (e) {
+        return fail((e as Error).message);
+      }
+    }
+  );
+
+  // 2. federation_snapshot_get -----------------------------------------------
+  server.tool(
+    'federation_snapshot_get',
+    "Read a holon's federation snapshot: the list of federated partner ids and a partnerId → name map. Pass `federationSourceId` to key federation off a nostr pubkey instead of the holon id.",
+    {
+      holon: z.string().describe('Holon id (home holon).'),
+      federationSourceId: z
+        .string()
+        .optional()
+        .describe('Federation source id (defaults to `holon`). Use this for nostr-keyed setups.'),
+    },
+    async ({ holon, federationSourceId }) => {
+      try {
+        const hs = await deps.getHoloSphere();
+        const snapshot = await getFederationSnapshot(hs, holon, federationSourceId);
+        return ok({ holon, snapshot });
+      } catch (e) {
+        return fail((e as Error).message);
+      }
+    }
+  );
+
+  // 3. federation_settings_hex_read -----------------------------------------
+  server.tool(
+    'federation_settings_hex_read',
+    "Read `settings.hex` for a holon. Returns the configured H3 cell string, or null if absent / unreachable.",
+    {
+      holon: z.string().describe('Holon id.'),
+    },
+    async ({ holon }) => {
+      try {
+        const hs = await deps.getHoloSphere();
+        const hex = await readSettingsHex(hs, holon);
+        return ok({ holon, hex });
+      } catch (e) {
+        return fail((e as Error).message);
+      }
+    }
+  );
+}

--- a/packages/mcp-ui/src/tools/index.ts
+++ b/packages/mcp-ui/src/tools/index.ts
@@ -1,0 +1,38 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Actor } from '../identity.js';
+
+export interface ToolDeps {
+  getHoloSphere: () => Promise<any>;
+  resolveActor: (override?: Partial<Actor>) => Actor;
+}
+
+const DOMAINS = [
+  'holosphere',
+  'tasks',
+  'expenses',
+  'scoring',
+  'calendar',
+  'users',
+  'council',
+  'checklists',
+  'dna',
+  'library',
+  'shopping',
+  'federation',
+  'commands',
+  'settings',
+];
+
+export async function registerAllTools(server: McpServer, deps: ToolDeps): Promise<void> {
+  for (const domain of DOMAINS) {
+    try {
+      const mod: any = await import(`./${domain}.js`);
+      const registerName = `register${domain[0].toUpperCase()}${domain.slice(1)}Tools`;
+      if (typeof mod[registerName] === 'function') {
+        mod[registerName](server, deps);
+      }
+    } catch {
+      // Domain file not yet present in this worktree — skip silently.
+    }
+  }
+}

--- a/packages/mcp-ui/tsconfig.json
+++ b/packages/mcp-ui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Part of /batch mcp-ui rollout. See plan: `@holons/mcp-ui` MCP server replacing the telegram-ui HTTP bot API.

Bundles byte-identical scaffold + this unit's domain file in `packages/mcp-ui/src/tools/`. Sibling units land independently; the dynamic-import aggregator in `src/tools/index.ts` tolerates missing siblings.

Note: `@holons/core` must be built first for runtime imports to resolve (its exports map points at `dist/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)