### PR TITLE
mcp-ui: commands dispatcher (unit 13/15)

### DIFF
--- a/packages/mcp-ui/README.md
+++ b/packages/mcp-ui/README.md
@@ -1,0 +1,15 @@
+# @holons/mcp-ui
+
+MCP server exposing every `@holons/core` function as an independently-callable tool. Replaces the legacy `telegram-ui` HTTP bot API (port 3101) and the duplicate MCP wrappers in `telegram-ui/mcp`.
+
+## Usage
+
+```bash
+pnpm -F @holons/mcp-ui build
+node packages/mcp-ui/dist/index.js                 # stdio
+node packages/mcp-ui/dist/index.js --port 3200     # SSE
+```
+
+## Env
+
+- `HOLONS_PEER` / `HOLONS_APP` / `HOLONS_ACTOR_ID` / `HOLONS_ACTOR_NAME` / `HOLONS_ACTOR_USERNAME`

--- a/packages/mcp-ui/package.json
+++ b/packages/mcp-ui/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@holons/mcp-ui",
+  "version": "0.1.0",
+  "private": true,
+  "description": "MCP server exposing every @holons/core function as an independently-callable tool. Replaces the telegram-ui HTTP bot API.",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": "./dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@holons/core": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "holosphere": "1.3.0-alpha4",
+    "zod": "^3.23.8",
+    "dotenv": "^17.2.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.17",
+    "tsx": "^4.21.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/mcp-ui/src/holosphere.ts
+++ b/packages/mcp-ui/src/holosphere.ts
@@ -1,0 +1,16 @@
+const PEER = process.env.HOLONS_PEER || 'https://gun.holons.io/gun';
+const APP = process.env.HOLONS_APP || 'Holons';
+
+let hs: any;
+export async function getHoloSphere(): Promise<any> {
+  if (hs) return hs;
+  const mod: any = await import('holosphere');
+  const HoloSphere = mod.HoloSphere || mod.default;
+  hs = new HoloSphere(APP, false, null, { peers: [PEER] });
+  await new Promise((r) => setTimeout(r, 1500));
+  return hs;
+}
+
+export function getApp(): string {
+  return APP;
+}

--- a/packages/mcp-ui/src/identity.ts
+++ b/packages/mcp-ui/src/identity.ts
@@ -1,0 +1,14 @@
+export interface Actor {
+  id: string | number;
+  first_name?: string;
+  username?: string;
+}
+
+export function resolveActor(override?: Partial<Actor>): Actor {
+  const id = override?.id ?? process.env.HOLONS_ACTOR_ID ?? 'mcp-ui';
+  return {
+    id,
+    first_name: override?.first_name ?? process.env.HOLONS_ACTOR_NAME ?? 'MCP-UI',
+    username: override?.username ?? process.env.HOLONS_ACTOR_USERNAME,
+  };
+}

--- a/packages/mcp-ui/src/index.ts
+++ b/packages/mcp-ui/src/index.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import http from 'http';
+import { createServer } from './server.js';
+
+async function main() {
+  const server = await createServer();
+  const portArg = process.argv.indexOf('--port');
+  if (portArg !== -1 && process.argv[portArg + 1]) {
+    const port = parseInt(process.argv[portArg + 1], 10);
+    let sseTransport: SSEServerTransport | undefined;
+    const httpServer = http.createServer(async (req, res) => {
+      if (req.method === 'GET' && req.url === '/sse') {
+        sseTransport = new SSEServerTransport('/messages', res);
+        await server.connect(sseTransport);
+      } else if (req.method === 'POST' && req.url === '/messages') {
+        if (sseTransport) {
+          let body = '';
+          req.on('data', (c) => (body += c));
+          req.on('end', async () => {
+            await sseTransport!.handlePostMessage(req, res, body);
+          });
+        } else {
+          res.writeHead(400);
+          res.end('No SSE connection');
+        }
+      } else {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ name: 'holons-mcp-ui', version: '0.1.0' }));
+      }
+    });
+    httpServer.listen(port, () => {
+      console.error(`holons-mcp-ui listening on port ${port} (SSE)`);
+    });
+  } else {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    console.error('holons-mcp-ui running on stdio');
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/packages/mcp-ui/src/server.ts
+++ b/packages/mcp-ui/src/server.ts
@@ -1,0 +1,16 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { getHoloSphere } from './holosphere.js';
+import { resolveActor } from './identity.js';
+import { registerAllTools, type ToolDeps } from './tools/index.js';
+
+export async function createServer(): Promise<McpServer> {
+  const server = new McpServer({
+    name: 'holons-mcp-ui',
+    version: '0.1.0',
+    description:
+      'MCP server exposing every @holons/core function as an independently-callable tool.',
+  });
+  const deps: ToolDeps = { getHoloSphere, resolveActor };
+  await registerAllTools(server, deps);
+  return server;
+}

--- a/packages/mcp-ui/src/tools/commands.ts
+++ b/packages/mcp-ui/src/tools/commands.ts
@@ -1,0 +1,162 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import {
+  commandRegistry,
+  executeCommand,
+  type CommandContext,
+} from '@holons/core/commands';
+import type { Actor } from '../identity.js';
+import type { ToolDeps } from './index.js';
+
+/**
+ * Parse a JSON string argument, throwing a clear error if it is malformed.
+ * Empty/undefined input falls back to `fallback`.
+ */
+function parseJson<T>(raw: string | undefined, label: string, fallback: T): T {
+  if (raw === undefined || raw === null || raw === '') return fallback;
+  try {
+    return JSON.parse(raw) as T;
+  } catch (err) {
+    throw new Error(
+      `${label} must be valid JSON: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}
+
+/**
+ * The MCP-UI surface accepts a friendlier `{ holon, actor, ... }` context shape
+ * and translates it into the real `CommandContext` (`holonId`, `userId`,
+ * `userName`, `holosphere`, ...). Anything extra is forwarded via `extra` so
+ * downstream commands can opt in.
+ */
+interface ToolContext {
+  holon?: string;
+  holonId?: string;
+  actor?: Partial<Actor>;
+  userId?: string;
+  userName?: string;
+  source?: string;
+  [k: string]: unknown;
+}
+
+async function buildCommandContext(
+  raw: ToolContext,
+  deps: ToolDeps
+): Promise<CommandContext> {
+  const actor = deps.resolveActor(raw.actor);
+  const {
+    holon,
+    holonId,
+    actor: _ignoredActor,
+    userId,
+    userName,
+    source,
+    ...extra
+  } = raw;
+  return {
+    holonId: holonId ?? holon,
+    userId: userId ?? (actor.id !== undefined ? String(actor.id) : undefined),
+    userName: userName ?? actor.first_name ?? actor.username,
+    source: source ?? 'mcp-ui',
+    holosphere: await deps.getHoloSphere(),
+    extra: {
+      ...extra,
+      actor,
+    },
+  };
+}
+
+function ok(payload: Record<string, unknown>) {
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify({ success: true, ...payload }, null, 2),
+      },
+    ],
+  };
+}
+
+function fail(message: string, details?: unknown) {
+  return {
+    isError: true,
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(
+          { success: false, error: message, details },
+          null,
+          2
+        ),
+      },
+    ],
+  };
+}
+
+export function registerCommandsTools(server: McpServer, deps: ToolDeps): void {
+  server.tool(
+    'command_execute',
+    'Execute a registered @holons/core command by name. Built-ins include createTask, logHours, addToShoppingList.',
+    {
+      name: z.string().describe('Command name (e.g. "createTask")'),
+      params: z
+        .string()
+        .describe('JSON-encoded params object for the command'),
+      context: z
+        .string()
+        .describe(
+          'JSON-encoded CommandContext. Should include `holon` (holon id) and optionally `actor` ({ id, first_name, username }).'
+        ),
+      options: z
+        .string()
+        .optional()
+        .describe('JSON-encoded ExecuteOptions (rarely needed)'),
+    },
+    async ({ name, params, context, options }) => {
+      try {
+        const parsedParams = parseJson<unknown>(params, 'params', {});
+        const parsedCtx = parseJson<ToolContext>(context, 'context', {});
+        // ExecuteOptions only supports `registry` (a class instance), which
+        // can't survive JSON round-tripping; we parse it for forward-compat
+        // but never forward a `registry` field.
+        const parsedOpts = parseJson<Record<string, unknown>>(
+          options,
+          'options',
+          {}
+        );
+        const { registry: _ignoredRegistry, ...forwardOpts } = parsedOpts;
+
+        const ctx = await buildCommandContext(parsedCtx, deps);
+        const result = await executeCommand(name, parsedParams, ctx, forwardOpts);
+
+        if (result.ok) {
+          return ok({ command: result.command, data: result.data });
+        }
+        return fail(result.error.message, {
+          code: result.error.code,
+          command: result.command,
+        });
+      } catch (err) {
+        return fail(err instanceof Error ? err.message : String(err));
+      }
+    }
+  );
+
+  server.tool(
+    'command_list',
+    'List every command registered on the shared @holons/core commandRegistry.',
+    {},
+    async () => {
+      try {
+        const commands = commandRegistry.all().map((c) => ({
+          name: c.name,
+          description: c.description,
+          paramsSchema: c.paramsSchema,
+        }));
+        return ok({ count: commands.length, commands });
+      } catch (err) {
+        return fail(err instanceof Error ? err.message : String(err));
+      }
+    }
+  );
+}

--- a/packages/mcp-ui/src/tools/index.ts
+++ b/packages/mcp-ui/src/tools/index.ts
@@ -1,0 +1,38 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Actor } from '../identity.js';
+
+export interface ToolDeps {
+  getHoloSphere: () => Promise<any>;
+  resolveActor: (override?: Partial<Actor>) => Actor;
+}
+
+const DOMAINS = [
+  'holosphere',
+  'tasks',
+  'expenses',
+  'scoring',
+  'calendar',
+  'users',
+  'council',
+  'checklists',
+  'dna',
+  'library',
+  'shopping',
+  'federation',
+  'commands',
+  'settings',
+];
+
+export async function registerAllTools(server: McpServer, deps: ToolDeps): Promise<void> {
+  for (const domain of DOMAINS) {
+    try {
+      const mod: any = await import(`./${domain}.js`);
+      const registerName = `register${domain[0].toUpperCase()}${domain.slice(1)}Tools`;
+      if (typeof mod[registerName] === 'function') {
+        mod[registerName](server, deps);
+      }
+    } catch {
+      // Domain file not yet present in this worktree — skip silently.
+    }
+  }
+}

--- a/packages/mcp-ui/tsconfig.json
+++ b/packages/mcp-ui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Part of /batch mcp-ui rollout. See plan: `@holons/mcp-ui` MCP server replacing the telegram-ui HTTP bot API.

Bundles byte-identical scaffold + this unit's domain file in `packages/mcp-ui/src/tools/`. Sibling units land independently; the dynamic-import aggregator in `src/tools/index.ts` tolerates missing siblings.

Note: `@holons/core` must be built first for runtime imports to resolve (its exports map points at `dist/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)