### PR TITLE
mcp-ui + users: fill profile MCP gaps (unit 7/12)

### DIFF
--- a/packages/mcp-ui/src/tools/users.ts
+++ b/packages/mcp-ui/src/tools/users.ts
@@ -1,7 +1,9 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import {
+  createDefaultProfile,
   getUserProfile,
+  getUsers,
   ensureUserProfile,
   saveUserProfile,
   addUserValues,
@@ -61,6 +63,23 @@ function resolveTargetUser(userId: string | number, userJson?: string): Telegram
 
 export function registerUsersTools(server: McpServer, deps: ToolDeps): void {
   server.tool(
+    'user_create_default_profile',
+    'Build a default UserProfile object for the given TelegramUserLike (pure; no I/O).',
+    {
+      user: z.string().describe('JSON-encoded TelegramUserLike'),
+    },
+    async ({ user }) => {
+      try {
+        const u = parseJson<TelegramUserLike>('user', user);
+        const profile = createDefaultProfile(u);
+        return ok({ profile });
+      } catch (e) {
+        return fail(e);
+      }
+    },
+  );
+
+  server.tool(
     'user_profile_get',
     'Load a user profile for a holon. Creates a default profile if absent.',
     {
@@ -115,6 +134,23 @@ export function registerUsersTools(server: McpServer, deps: ToolDeps): void {
         const p = parseJson<UserProfile>('profile', profile);
         await saveUserProfile(db, holon, p);
         return ok({ saved: true, holon, userId: p.id });
+      } catch (e) {
+        return fail(e);
+      }
+    },
+  );
+
+  server.tool(
+    'users_list',
+    'List every stored user profile in a holon.',
+    {
+      holon: z.string().describe('Holon id'),
+    },
+    async ({ holon }) => {
+      try {
+        const db = (await deps.getHoloSphere()) as UserDB;
+        const users = await getUsers(db, holon);
+        return ok({ users });
       } catch (e) {
         return fail(e);
       }


### PR DESCRIPTION
## Summary
- Add `user_create_default_profile` MCP tool wrapping pure `createDefaultProfile(user)` from `@holons/core/users`.
- Add `users_list` MCP tool wrapping `getUsers(db, holon)`.
- `user_profile_ensure` was already registered in `users.ts`; left as-is.

Stacks onto `mcp-ui` (PR #50). Part of parallel unit pass (unit 7/12).

## Test plan
- [x] `pnpm -F @holons/core build` clean
- [x] `pnpm -F @holons/mcp-ui build` clean
- [x] MCP `tools/list` smoke test: `user_create_default_profile` + `users_list` both present (grep PASS)

Generated with Claude Code