### PR TITLE
mcp-ui + council: fill voting MCP gaps (unit 6/12)

### DIFF
--- a/packages/mcp-ui/src/tools/council.ts
+++ b/packages/mcp-ui/src/tools/council.ts
@@ -2,13 +2,19 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import {
   agree,
+  applyVote,
   block,
   castVote,
+  createAndSaveProposal,
   createProposal,
   deleteProposal,
+  deriveStatus,
+  hasAgreed,
+  hasBlocked,
   saveProposal,
   tallyVotes,
   PROPOSAL_LENS,
+  type CreateProposalInput,
   type Proposal,
   type ProposalStore,
   type VoteEntry,
@@ -249,6 +255,115 @@ export function registerCouncilTools(server: McpServer, deps: ToolDeps): void {
         const record = parseJSON<Proposal>(proposal, 'proposal');
         const tally = tallyVotes(record, quorum);
         return ok({ tally });
+      } catch (e) {
+        return fail((e as Error).message);
+      }
+    }
+  );
+
+  server.tool(
+    'council_apply_vote',
+    'Pure — apply a vote to a proposal JSON and return the updated record. Does not persist.',
+    {
+      proposal: z.string().describe('Proposal JSON.'),
+      voter: z.string().describe('Voter JSON or bare id.'),
+      direction: z.enum(['agree', 'block']).describe('Vote direction.'),
+    },
+    async ({ proposal, voter, direction }) => {
+      try {
+        const record = parseJSON<Proposal>(proposal, 'proposal');
+        const next = applyVote(record, coerceVoter(voter), direction);
+        return ok({ proposal: next });
+      } catch (e) {
+        return fail((e as Error).message);
+      }
+    }
+  );
+
+  server.tool(
+    'council_derive_status',
+    'Pure — derive the lifecycle status (`ongoing` / `stopped` / `completed`) from a proposal JSON.',
+    {
+      proposal: z.string().describe('Proposal JSON.'),
+    },
+    async ({ proposal }) => {
+      try {
+        const record = parseJSON<Proposal>(proposal, 'proposal');
+        return ok({ status: deriveStatus(record) });
+      } catch (e) {
+        return fail((e as Error).message);
+      }
+    }
+  );
+
+  server.tool(
+    'council_has_agreed',
+    'Pure predicate — has the given voter agreed to the proposal?',
+    {
+      proposal: z.string().describe('Proposal JSON.'),
+      voter: z.string().describe('Voter JSON or bare id.'),
+    },
+    async ({ proposal, voter }) => {
+      try {
+        const record = parseJSON<Proposal>(proposal, 'proposal');
+        return ok({ agreed: hasAgreed(record, coerceVoter(voter)) });
+      } catch (e) {
+        return fail((e as Error).message);
+      }
+    }
+  );
+
+  server.tool(
+    'council_has_blocked',
+    'Pure predicate — has the given voter blocked (vetoed) the proposal?',
+    {
+      proposal: z.string().describe('Proposal JSON.'),
+      voter: z.string().describe('Voter JSON or bare id.'),
+    },
+    async ({ proposal, voter }) => {
+      try {
+        const record = parseJSON<Proposal>(proposal, 'proposal');
+        return ok({ blocked: hasBlocked(record, coerceVoter(voter)) });
+      } catch (e) {
+        return fail((e as Error).message);
+      }
+    }
+  );
+
+  server.tool(
+    'council_save_proposal',
+    'Persist a fully-formed proposal record via the shared core helper (HoloSphere under the `quests` lens).',
+    {
+      holon: z.string().describe('Holon id.'),
+      proposal: z.string().describe('Proposal JSON.'),
+    },
+    async ({ holon, proposal }) => {
+      try {
+        const record = parseJSON<Proposal>(proposal, 'proposal');
+        const store = await withStore(deps);
+        await saveProposal(store, holon, record);
+        return ok({ holon, lens: PROPOSAL_LENS, id: record.id });
+      } catch (e) {
+        return fail((e as Error).message);
+      }
+    }
+  );
+
+  server.tool(
+    'council_create_and_save_proposal',
+    'Create a proposal from a `CreateProposalInput` JSON and persist it in one call.',
+    {
+      holon: z.string().describe('Holon id.'),
+      input: z
+        .string()
+        .describe('CreateProposalInput JSON ({title, description?, creator?, date?, id?}).'),
+    },
+    async ({ holon, input }) => {
+      try {
+        const parsed = parseJSON<CreateProposalInput>(input, 'input');
+        const store = await withStore(deps);
+        const proposal = await createAndSaveProposal(store, holon, parsed);
+        return ok({ holon, lens: PROPOSAL_LENS, proposal });
       } catch (e) {
         return fail((e as Error).message);
       }


### PR DESCRIPTION
## Summary
- Adds the six remaining `@holons/core/council` helpers as MCP tools: `council_apply_vote`, `council_derive_status`, `council_has_agreed`, `council_has_blocked`, `council_save_proposal`, `council_create_and_save_proposal`.
- Pure helpers (apply/derive/predicates) execute with no HoloSphere I/O; the two persistence tools reuse the existing `holoSphereAsStore` adapter.
- No UI refactor required — telegram-ui's `src/council/proposals.js` is a clean re-export of core, and apps/web `Proposals.svelte` already imports from core.

## Test plan
- [x] `pnpm -F @holons/core build`
- [x] `pnpm -F @holons/mcp-ui build`
- [x] MCP tools/list smoke (all six new tool names present): MCP PASS

Stacks onto #50.

Generated with [Claude Code](https://claude.com/claude-code)