### PR TITLE
mcp-ui + federation: verify MCP coverage + refactor H3 publish (unit 10/12)

### DIFF
--- a/packages/telegram-ui/src/H3.js
+++ b/packages/telegram-ui/src/H3.js
@@ -10,6 +10,7 @@ import holonsschema from '../schemas/holons_schema-v0.0.1.json' with { type: "js
 import { createHash } from "crypto";
 import { markAsUntransferable } from 'worker_threads';
 import { parse } from 'path';
+import { publishToFederation } from '@holons/core/federation';
 
 
 var p = { "linked_schemas": ["offers_wants-v0.0.2"], "profile_url": "https:\/\/hamlets.communityforge.net\/ad\/150\/murmurations.json", "primary_url": "https:\/\/hamlets.communityforge.net", "geolocation": { "lat": 46.8145624, "lon": 8.239973599999999 }, "country": "CH", "title": "A traditional stress-tested dolly from the orient.", "description": "\u003Cp\u003E\u003Cstrong\u003EDolus euismod \u003C\/strong\u003Ehos luptatum olim paratus similis. Bene gravis in letalis nisl odio pagus qui saluto validus. Abdo antehabeo consectetuer esse exputo os similis voco. Causa ea iaceo incassum macto minim nibh ratis sed. Humo macto nutus populus tum utrum velit vero vulputate zelus.\u003C\/p\u003E\r\n\r\n\u003Cp\u003EBlandit feugiat macto quibus. Elit macto mauris nobis nostrud patria secundum te venio. Commoveo interdico mos neque pagus paulatim scisco. Aliquam diam esse iriure jus magna quibus utrum vindico. Abbas adipiscing at distineo iustum olim velit.\u003C\/p\u003E", "exchange_type": "want", "item_type": "service", "transaction_type": ["receive-donate", "borrow-lend"], "geographic_scope": "local", "expires_at": 1702422000, "tags": ["Business Services \u0026 Clerical"], "contact_details": { "contact_form": "https:\/\/hamlets.communityforge.net\/user\/28\/contact" } }
@@ -176,20 +177,20 @@ class H3 {
                 // Save the federation configuration
                 await this.db.putGlobal('federation', fedInfo);
 
-                // Create hologram for the quest
-                const questReference = { id: messageId };
-                const hologram = this.db.createHologram(holonId, 'quests', questReference);
+                const outcome = await publishToFederation(
+                    {
+                        holosphere: this.db,
+                        holonId,
+                        lens: 'quests',
+                        item: { id: messageId }
+                    },
+                    { kind: 'hex', cell: hex }
+                );
 
-                // Use federation propagation to publish to the hex
-                const propagationResult = await this.db.propagate(holonId, 'quests', hologram, {
-                    useHolograms: true,
-                    targetSpaces: [hex]
-                });
-
-                if (propagationResult.success > 0) {
+                if (outcome.publishedTo > 0) {
                     ctx.reply(`Quest published to hex ${hex} via federation`);
                 } else {
-                    const errorMessage = propagationResult.message || 'Unknown propagation error';
+                    const errorMessage = outcome.errors[0] || 'Unknown propagation error';
                     ctx.reply(`Failed to publish: ${errorMessage}`);
                 }
 


### PR DESCRIPTION
## Summary

- Verified `packages/mcp-ui/src/tools/federation.ts` wraps every public helper exported by `@holons/core/federation` (`publishToFederation`, `getFederationSnapshot`, `readSettingsHex`). No additional exports exist in the federation barrel.
- Refactored `packages/telegram-ui/src/H3.js` `publish` command (the `/publish` Telegram handler around lines 179-194) to call `publishToFederation({ holosphere: this.db, holonId, lens: 'quests', item: { id: messageId } }, { kind: 'hex', cell: hex })` instead of hand-rolling `createHologram` + `propagate(..., { targetSpaces: [hex] })`. Federation config setup above this point (fedInfo inbound/outbound/lensConfig) is orthogonal and unchanged.

### Quests.ts / Events.ts `publish()` — intentionally left alone

`packages/telegram-ui/src/Quests.ts` lines 1645-1683 and `packages/telegram-ui/src/Events.ts` lines 1045-1057 are simple `published` flag toggles followed by `updateMessage(...)`. They are not hand-rolled propagation — federation writes happen inside `updateMessage` ("Unified save and update (handles federation internally)"). Refactoring would re-route through a different code path with potentially different semantics and was out of scope for this unit.

## Test plan

- [x] `pnpm -F @holons/core build`
- [x] `pnpm -F @holons/mcp-ui build`
- [x] `pnpm -F @holons/telegram-ui typecheck` — clean
- [x] MCP smoke test: `tools/list` lists `federation_publish`, `federation_snapshot_get`, `federation_settings_hex_read` (plus pre-existing `federation_link_add`/`federation_link_remove` from earlier units). `MCP PASS`.

Generated with Claude Code.