### PR TITLE
mcp-ui + scoring: fill MCP gaps + refactor Settings.calculateUserScores (unit 2/12)

### DIFF
--- a/packages/mcp-ui/src/tools/scoring.ts
+++ b/packages/mcp-ui/src/tools/scoring.ts
@@ -10,7 +10,11 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import {
   DEFAULT_EQUATION,
+  calculateAllUserScores,
   calculatePercentageShare,
+  calculateTaskCompletionScores,
+  calculateUserScore,
+  getActionScore,
   getScoreBreakdown,
   loadEquation,
   toAggregates,
@@ -178,6 +182,152 @@ export function registerScoringTools(server: McpServer, deps: ToolDeps): void {
         const hs = await deps.getHoloSphere();
         const equation = await loadEquation(hs, holon);
         return ok({ holon, equation });
+      } catch (e: any) {
+        return err(e?.message ?? String(e));
+      }
+    },
+  );
+
+  server.tool(
+    'score_calculate_user',
+    "Calculate a single user's total score from raw user data using the supplied (or default) value equation. Internally derives aggregates via toAggregates(). Wraps @holons/core/scoring: calculateUserScore.",
+    {
+      user: z
+        .string()
+        .describe(
+          'JSON-encoded user data (object with initiated/completed/sent/received/hours/collaboration/wants/offers — arrays or counts).',
+        ),
+      equation: z
+        .string()
+        .optional()
+        .describe('JSON-encoded ScoreEquation. Defaults to DEFAULT_EQUATION when omitted.'),
+    },
+    async ({ user, equation }) => {
+      try {
+        const userData = parseJson<any>(user, {}, 'user');
+        const eq = parseJson<ScoreEquation>(equation, DEFAULT_EQUATION, 'equation');
+        const aggregates = toAggregates(userData);
+        const score = calculateUserScore(aggregates, eq);
+        return ok({ score, aggregates });
+      } catch (e: any) {
+        return err(e?.message ?? String(e));
+      }
+    },
+  );
+
+  server.tool(
+    'score_calculate_all',
+    'Calculate scores + percentage shares for every user in a list using the supplied (or default) value equation. Wraps @holons/core/scoring: calculateAllUserScores.',
+    {
+      users: z
+        .string()
+        .describe('JSON-encoded array of user objects (each with id + REA fields).'),
+      equation: z
+        .string()
+        .optional()
+        .describe('JSON-encoded ScoreEquation. Defaults to DEFAULT_EQUATION when omitted.'),
+    },
+    async ({ users, equation }) => {
+      try {
+        const userList = parseJson<any[]>(users, [], 'users');
+        if (!Array.isArray(userList)) {
+          throw new Error('users must be a JSON array');
+        }
+        const eq = parseJson<ScoreEquation>(equation, DEFAULT_EQUATION, 'equation');
+        const scored = calculateAllUserScores(userList, eq);
+        return ok({ scored, count: scored.length });
+      } catch (e: any) {
+        return err(e?.message ?? String(e));
+      }
+    },
+  );
+
+  server.tool(
+    'score_action',
+    'Compute the score delta for a specific action (initiated/completed/joined/hours/sent/received). Wraps @holons/core/scoring: getActionScore.',
+    {
+      actionType: z
+        .enum(['initiated', 'completed', 'joined', 'hours', 'sent', 'received'])
+        .describe('Action type to score.'),
+      amount: z
+        .number()
+        .optional()
+        .describe('Quantity (e.g., hours, count). Defaults to 1.'),
+      equation: z
+        .string()
+        .optional()
+        .describe('JSON-encoded ScoreEquation. Defaults to DEFAULT_EQUATION when omitted.'),
+    },
+    async ({ actionType, amount, equation }) => {
+      try {
+        const eq = parseJson<ScoreEquation>(equation, DEFAULT_EQUATION, 'equation');
+        const action = getActionScore(actionType, amount ?? 1, eq);
+        return ok({ action });
+      } catch (e: any) {
+        return err(e?.message ?? String(e));
+      }
+    },
+  );
+
+  server.tool(
+    'score_task_completion',
+    'Compute contribution scores for task completion: the initiator earns initiated points, each participant earns completed + hours + collaboration points. Wraps @holons/core/scoring: calculateTaskCompletionScores.',
+    {
+      initiatorId: z
+        .string()
+        .nullable()
+        .optional()
+        .describe('Initiator user id, or null/omitted when no initiator.'),
+      participantIds: z
+        .array(z.string())
+        .describe('Participant user ids who completed the task.'),
+      timeTracking: z
+        .string()
+        .optional()
+        .describe(
+          'JSON-encoded Record<userId, hours>. Hours logged per participant. Defaults to {}.',
+        ),
+      equation: z
+        .string()
+        .optional()
+        .describe('JSON-encoded ScoreEquation. Defaults to DEFAULT_EQUATION when omitted.'),
+    },
+    async ({ initiatorId, participantIds, timeTracking, equation }) => {
+      try {
+        const tt = parseJson<Record<string, number>>(timeTracking, {}, 'timeTracking');
+        const eq = parseJson<ScoreEquation>(equation, DEFAULT_EQUATION, 'equation');
+        const scoresMap = calculateTaskCompletionScores(
+          initiatorId ?? null,
+          participantIds,
+          tt,
+          eq,
+        );
+        const scores: Record<string, { total: number; breakdown: any[] }> = {};
+        for (const [userId, entry] of scoresMap.entries()) {
+          scores[userId] = entry;
+        }
+        return ok({ scores, count: scoresMap.size });
+      } catch (e: any) {
+        return err(e?.message ?? String(e));
+      }
+    },
+  );
+
+  server.tool(
+    'score_aggregator_to_aggregates',
+    'Convert raw user data (or REA-style event-derived object) into the canonical UserAggregates shape used by scoring. Wraps @holons/core/scoring: toAggregates.',
+    {
+      events: z
+        .string()
+        .describe(
+          'JSON-encoded user data object whose fields will be normalized into UserAggregates.',
+        ),
+    },
+    async ({ events }) => {
+      try {
+        const userData = parseJson<any>(events, {}, 'events');
+        const aggregates = toAggregates(userData);
+        return ok({ aggregates });
       } catch (e: any) {
         return err(e?.message ?? String(e));
       }

--- a/packages/telegram-ui/src/Settings.ts
+++ b/packages/telegram-ui/src/Settings.ts
@@ -19,6 +19,11 @@ import {
     type HolonSettings,
     type LensType as AvailableLens,
 } from '@holons/core/settings';
+import {
+    DEFAULT_EQUATION,
+    calculateUserScore,
+    toAggregates,
+} from '@holons/core/scoring';
 
 // Re-export so other modules (web, ai-ui) can import the canonical settings
 // shape from either `./Settings.js` or `@holons/core/settings`.
@@ -2464,53 +2469,35 @@ export default class Settings {
 
     async calculateUserScores(users, holonId, expensesInstance) {
         const settings = await this.getSettings(holonId);
-        const equation = settings.valueEquation;
+        const equation = settings.valueEquation ?? DEFAULT_EQUATION;
         const currencies = settings.currencies || [];
-        
+        const currencyWeights = equation?.currencies ?? {};
+
         const userScores = [];
         for (const userId in users) {
             const user = users[userId];
             if (!user || user.id === undefined) continue; // Skip if user or user.id is undefined
 
-            let score = (user.initiated && user.initiated.length * equation.initiated || 0) +
-                (user.completed && user.completed.length * equation.completed || 0) +
-                (user.sent * equation.sent || 0) +
-                (user.received * equation.received || 0) +
-                // (user.hours * equation.hours || 0) + // COMMENTED OUT FOR TESTING
-                (user.collaboration * equation.collaboration || 0) +
-                (user.wants && user.wants.length * equation.wants || 0) +
-                (user.offers && user.offers.length * equation.offers || 0);
-
-            let currencyScoreContribution = 0;
-            console.log(`\n=== CURRENCY CALCULATION FOR USER ${user.id} ===`);
-            console.log(`Available currencies: [${currencies.join(', ')}]`);
-            console.log(`Equation keys: [${Object.keys(equation).join(', ')}]`);
-            
-            if (currencies && currencies.length > 0 && expensesInstance) {
+            // Fetch per-currency balances so core/scoring can apply the
+            // equation's currency weights uniformly.
+            const currencyBalances = {};
+            if (currencies.length > 0 && expensesInstance) {
                 for (const currencyName of currencies) {
                     const currencyKey = currencyName.toLowerCase().replace(/[^a-z0-9_]/g, '');
-                    console.log(`\nProcessing currency: ${currencyName} -> ${currencyKey}`);
-                    
-                    if (currencyKey && equation[currencyKey] !== undefined) {
-                        try {
-                            const balance = await expensesInstance.getUserCurrencyBalance(holonId, user.id, currencyKey);
-                            const weight = equation[currencyKey] || 0;
-                            const contribution = balance * weight;
-                            currencyScoreContribution += contribution;
-                            console.log(`  ✅ Balance: ${balance}, Weight: ${weight}, Contribution: ${contribution}`);
-                        } catch (e) {
-                            console.error(`❌ Error getting balance for ${currencyKey} for user ${user.id}:`, e);
-                        }
-                    } else {
-                        console.log(`  ⏭️ Skipped - currencyKey: ${currencyKey}, equation[currencyKey]: ${equation[currencyKey]}`);
+                    if (!currencyKey || currencyWeights[currencyKey] === undefined) continue;
+                    try {
+                        currencyBalances[currencyKey] = await expensesInstance.getUserCurrencyBalance(
+                            holonId,
+                            user.id,
+                            currencyKey,
+                        );
+                    } catch (e) {
+                        console.error(`Error getting balance for ${currencyKey} for user ${user.id}:`, e);
                     }
                 }
-            } else {
-                console.log(`  ⏭️ No currencies or expenses instance available`);
             }
-            
-            console.log(`Total currency contribution: ${currencyScoreContribution}`);
-            score += currencyScoreContribution;
+
+            const score = calculateUserScore(toAggregates(user), equation, currencyBalances);
             userScores.push({ ...user, score });
         }
 


### PR DESCRIPTION
## Summary
- Adds five MCP tools wrapping the remaining `@holons/core/scoring` surface so every public function is reachable: `score_calculate_user`, `score_calculate_all`, `score_action`, `score_task_completion`, `score_aggregator_to_aggregates`.
- Refactors `telegram-ui` `Settings.calculateUserScores` to delegate the value-equation math to `calculateUserScore` + `toAggregates` from core, dropping the hand-rolled aggregate × weight arithmetic and noisy per-currency `console.log` chatter.
- Method signature and return shape preserved — `Holons.js` (lines 1361-1366, 3058-3065) and `UI.js` (line 359) keep working unchanged.

## Test plan
- [x] `pnpm -F @holons/core build`
- [x] `pnpm -F @holons/mcp-ui build`
- [x] `pnpm -F @holons/telegram-ui typecheck` (clean)
- [x] MCP `tools/list` smoke test: all 5 new tools listed (`MCP PASS`)

Stacked on PR #50 (`mcp-ui`). Part of the parallel unit 2/12 pass.

Generated with [Claude Code](https://claude.com/claude-code)