### PR TITLE
mcp-ui + checklists: fill MCP gaps + investigate web duplication (unit 8/12)

### DIFF
--- a/apps/web/src/components/Checklists.svelte
+++ b/apps/web/src/components/Checklists.svelte
@@ -15,20 +15,19 @@
     import { Plus } from 'svelte-feathers';
     import { loadFilters, saveFilters } from '$lib/util/persistedFilters';
     import { notifyWriteDenied } from "../lib/stores/writeNotifications";
-
-    interface ChecklistItem {
-        text: string;
-        checked: boolean;
-    }
-
-    interface Checklist {
-        id: string;
-        items: ChecklistItem[];
-        creator?: string;
-        created?: Date;
-        questId?: string; // Optional property to indicate if checklist is attached to a quest
-        roleId?: string; // Optional property to indicate if checklist is attached to a role
-    }
+    import {
+        CHECKLIST_TYPES,
+        appendItems,
+        clearChecklist as coreClearChecklist,
+        createChecklist,
+        createChecklistObject,
+        deleteChecklist as coreDeleteChecklist,
+        removeItemAt,
+        toggleItem,
+        type Checklist,
+        type ChecklistItem,
+        type ChecklistStore,
+    } from "@holons/core/checklists";
 
     const holosphere = getContext("holosphere") as HoloSphere;
     let holonID: string = $page.params.id;
@@ -312,16 +311,16 @@
         if (!allChecklists[checklistId] || !holonID) return;
 
         try {
-            const checklist = { ...allChecklists[checklistId] };
-            checklist.items = [...checklist.items];
-            checklist.items[itemIndex] = {
-                ...checklist.items[itemIndex],
-                checked: !checklist.items[itemIndex].checked,
-            };
-
-            await holosphere.put(holonID, "checklists", checklist);
-            allChecklists[checklistId] = checklist;
-            allChecklists = allChecklists;
+            const updated = await toggleItem(
+                holosphere as unknown as ChecklistStore,
+                holonID,
+                checklistId,
+                itemIndex,
+            );
+            if (updated) {
+                allChecklists[checklistId] = updated;
+                allChecklists = allChecklists;
+            }
         } catch (error: any) {
             if (error?.name === 'AuthorizationError') {
                 notifyWriteDenied('Unable to save - no write permission for this holon');
@@ -350,15 +349,15 @@
         if (!checklistId || !allChecklists[checklistId] || !holonID) return;
 
         try {
-            const checklist = { ...allChecklists[checklistId] };
-            checklist.items = (checklist.items || []).map((item) => ({
-                ...item,
-                checked: false,
-            }));
-
-            await holosphere.put(holonID, "checklists", checklist);
-            allChecklists[checklistId] = checklist;
-            allChecklists = allChecklists;
+            const result = await coreClearChecklist(
+                holosphere as unknown as ChecklistStore,
+                holonID,
+                checklistId,
+            );
+            if (result.ok) {
+                allChecklists[checklistId] = result.checklist;
+                allChecklists = allChecklists;
+            }
         } catch (error: any) {
             if (error?.name === 'AuthorizationError') {
                 notifyWriteDenied('Unable to save - no write permission for this holon');
@@ -380,6 +379,7 @@
         if (!holonID) return;
         const items = event.detail;
         try {
+            const store = holosphere as unknown as ChecklistStore;
             for (const raw of items) {
                 const src = raw ?? {};
                 const id = String(src.id ?? src.title ?? src.name ?? src.text ?? '').trim();
@@ -398,13 +398,10 @@
                     })
                     .filter(Boolean) as ChecklistItem[];
 
-                const newChecklist: Checklist = {
-                    id,
-                    items: checklistItems,
+                await appendItems(store, holonID, id, checklistItems, {
                     creator: "Dashboard User",
-                    created: new Date()
-                };
-                await holosphere.put(holonID, "checklists", newChecklist);
+                    type: CHECKLIST_TYPES.CHECKLIST,
+                });
             }
             showImportModal = false;
         } catch (error: any) {
@@ -420,25 +417,24 @@
         if (!inputText.trim() || !holonID) return;
 
         try {
+            const store = holosphere as unknown as ChecklistStore;
             if (isAddingChecklist) {
-                const newChecklistId = inputText.trim();
-                const newChecklist = {
-                    id: newChecklistId,
-                    items: [],
-                    creator: "Dashboard User",
-                    created: new Date().toISOString(),
-                };
-                await holosphere.put(holonID, "checklists", newChecklist);
+                const result = await createChecklist(
+                    store,
+                    holonID,
+                    inputText.trim(),
+                    { creator: "Dashboard User" },
+                );
+                if (!result.ok && result.reason === 'invalid_name') {
+                    console.warn(`Invalid checklist name: ${inputText.trim()}`);
+                }
             } else if (selectedChecklist && allChecklists[selectedChecklist]) {
-                const checklist = { ...allChecklists[selectedChecklist] };
-                checklist.items = [
-                    ...checklist.items,
-                    {
-                        text: inputText.trim(),
-                        checked: false,
-                    },
-                ];
-                await holosphere.put(holonID, "checklists", checklist);
+                await appendItems(
+                    store,
+                    holonID,
+                    selectedChecklist,
+                    [{ text: inputText.trim(), checked: false }],
+                );
             }
 
             showInput = false;
@@ -458,16 +454,18 @@
 
         try {
             const newChecklistId = `task_${taskId}_checklist`;
-            const newChecklist = {
-                id: newChecklistId,
-                items: [],
-                creator: "Dashboard User",
-                created: new Date().toISOString(),
-                questId: taskId // Link to the specific task
-            };
-
+            const newChecklist = createChecklistObject(
+                newChecklistId,
+                CHECKLIST_TYPES.QUEST,
+                {
+                    creator: "Dashboard User",
+                    questId: taskId,
+                    parentTitle: taskTitle,
+                    holonId: holonID,
+                },
+            );
             await holosphere.put(holonID, "checklists", newChecklist);
-            
+
             // Update the task to include the checklist ID
             const task = await holosphere.get(holonID, "quests", taskId);
             if (task) {
@@ -476,7 +474,7 @@
                     checklistId: newChecklistId
                 });
             }
-            
+
             console.log(`Created checklist for task ${taskId}: ${newChecklistId}`);
         } catch (error: any) {
             if (error?.name === 'AuthorizationError') {
@@ -491,7 +489,15 @@
         if (!holonID) return;
 
         try {
-            await holosphere.delete(holonID, "checklists", checklistId);
+            const result = await coreDeleteChecklist(
+                holosphere as unknown as ChecklistStore,
+                holonID,
+                checklistId,
+            );
+            if (!result.ok && result.reason === 'special') {
+                console.warn(`Cannot delete special checklist: ${checklistId}`);
+                return;
+            }
             delete allChecklists[checklistId];
             allChecklists = allChecklists;
             if (selectedChecklist === checklistId) {
@@ -514,17 +520,19 @@
         }
 
         try {
-            const checklist = { ...allChecklists[checklistId] };
-            const originalLength = (checklist.items || []).length;
-            checklist.items = (checklist.items || []).filter(
-                (_, index) => index !== itemIndex
+            const result = await removeItemAt(
+                holosphere as unknown as ChecklistStore,
+                holonID,
+                checklistId,
+                itemIndex,
             );
-            console.log('Items before:', originalLength, 'after:', checklist.items.length);
-
-            await holosphere.put(holonID, "checklists", checklist);
-            allChecklists[checklistId] = checklist;
-            allChecklists = allChecklists;
-            console.log('removeItem: put succeeded');
+            if (result) {
+                allChecklists[checklistId] = result.checklist;
+                allChecklists = allChecklists;
+                console.log('removeItem: put succeeded');
+            } else {
+                console.log('removeItem: item not found at index', itemIndex);
+            }
         } catch (error: any) {
             if (error?.name === 'AuthorizationError') {
                 notifyWriteDenied('Unable to save - no write permission for this holon');

--- a/apps/web/src/components/TaskModal.svelte
+++ b/apps/web/src/components/TaskModal.svelte
@@ -25,6 +25,10 @@
     import { nostrPublicKey } from "../lib/stores/nostr";
     import { telegramStore } from "../lib/stores/telegram";
     import { notifyWriteDenied } from "../lib/stores/writeNotifications";
+    import {
+        CHECKLIST_TYPES,
+        createChecklistObject,
+    } from "@holons/core/checklists";
 
     export let quest: any;
     export let questId: string;
@@ -878,14 +882,16 @@
         }
 
         try {
-            const newChecklist = {
-                id: `task_${questId}_checklist`,
-                items: [],
-                creator: "Dashboard User",
-                created: new Date().toISOString(),
-                questId: questId // Link to this task
-            };
-
+            const newChecklist = createChecklistObject(
+                `task_${questId}_checklist`,
+                CHECKLIST_TYPES.QUEST,
+                {
+                    creator: "Dashboard User",
+                    questId,
+                    parentTitle: quest?.title,
+                    holonId,
+                },
+            );
             await holosphere.put(holonId, "checklists", newChecklist);
 
             // Update the quest to include the checklist ID

--- a/packages/mcp-ui/src/tools/checklists.ts
+++ b/packages/mcp-ui/src/tools/checklists.ts
@@ -19,12 +19,18 @@ import {
   CHECKLIST_TYPES,
   addItemsToChecklist,
   createChecklist,
+  createChecklistObject,
   getChecklist,
+  migrateLegacyChecklistType,
   removeItemAt,
   toggleItem,
+  type Checklist,
   type ChecklistStore,
+  type ChecklistType,
 } from '@holons/core/checklists';
 import type { ToolDeps } from './index.js';
+
+const CHECKLIST_TYPE_VALUES = Object.values(CHECKLIST_TYPES) as ChecklistType[];
 
 // --- helpers -------------------------------------------------------------
 
@@ -191,6 +197,98 @@ export function registerChecklistsTools(server: McpServer, deps: ToolDeps): void
         if (!checklist) {
           return fail('subtask_not_found', { reason: 'subtask_not_found' });
         }
+        return ok({ success: true, checklist });
+      } catch (err) {
+        return fail((err as Error).message);
+      }
+    },
+  );
+
+  // checklist_get — fetch a single checklist by id.
+  server.registerTool(
+    'checklist_get',
+    {
+      description:
+        'Fetch a single checklist (with items) by id. Wraps @holons/core/checklists getChecklist. Returns null in the `checklist` field if the record does not exist; legacy records are migrated to the typed shape transparently.',
+      inputSchema: {
+        holon: z.string().describe('Holon id.'),
+        checklistId: z.string().describe('Existing checklist id.'),
+      },
+    },
+    async (args) => {
+      try {
+        const hs = (await deps.getHoloSphere()) as ChecklistStore;
+        const checklist = await getChecklist(hs, args.holon, args.checklistId);
+        return ok({ success: true, checklist });
+      } catch (err) {
+        return fail((err as Error).message);
+      }
+    },
+  );
+
+  // checklist_migrate_legacy_type — pure migration helper.
+  server.registerTool(
+    'checklist_migrate_legacy_type',
+    {
+      description:
+        'Pure helper that infers the `type` field of a legacy checklist record (pre-typed-shape). Accepts a JSON string of a single checklist and returns the migrated checklist. Wraps @holons/core/checklists migrateLegacyChecklistType. No storage I/O.',
+      inputSchema: {
+        checklist: z
+          .string()
+          .describe('JSON-encoded Checklist record to migrate.'),
+      },
+    },
+    async (args) => {
+      try {
+        let parsed: Checklist;
+        try {
+          parsed = JSON.parse(args.checklist) as Checklist;
+        } catch (parseErr) {
+          return fail(`invalid_json: ${(parseErr as Error).message}`);
+        }
+        const migrated = migrateLegacyChecklistType(parsed);
+        return ok({ success: true, checklist: migrated });
+      } catch (err) {
+        return fail((err as Error).message);
+      }
+    },
+  );
+
+  // checklist_build_object — pure factory for a checklist record (no I/O).
+  // Distinct from `checklist_create`: this only builds the in-memory record
+  // (createChecklistObject), while `checklist_create` persists with a
+  // collision check (createChecklist). Useful when the caller wants to
+  // construct + inspect the record without committing it.
+  server.registerTool(
+    'checklist_build_object',
+    {
+      description:
+        'Pure helper that builds a checklist record with the right type-specific fields. Wraps @holons/core/checklists createChecklistObject — does NOT persist. Use `checklist_create` if you want to save it.',
+      inputSchema: {
+        id: z.string().describe('Checklist id (also used as name).'),
+        type: z
+          .enum(CHECKLIST_TYPE_VALUES as [ChecklistType, ...ChecklistType[]])
+          .describe('Checklist type (checklist|agenda|shopping|quest|role).'),
+        creator: z
+          .string()
+          .optional()
+          .describe('Creator id (optional). Falls back to resolved actor id.'),
+        questId: z.string().optional(),
+        roleId: z.string().optional(),
+        parentTitle: z.string().optional(),
+        holonId: z.string().optional(),
+      },
+    },
+    async (args) => {
+      try {
+        const actor = deps.resolveActor();
+        const checklist = createChecklistObject(args.id, args.type, {
+          creator: args.creator ?? actor.id,
+          questId: args.questId,
+          roleId: args.roleId,
+          parentTitle: args.parentTitle,
+          holonId: args.holonId,
+        });
         return ok({ success: true, checklist });
       } catch (err) {
         return fail((err as Error).message);


### PR DESCRIPTION
## Summary

- **MCP tools added** to `packages/mcp-ui/src/tools/checklists.ts`:
  - `checklist_get` — wraps `getChecklist(...)`. Returns `null` if missing; legacy records migrated transparently.
  - `checklist_migrate_legacy_type` — pure helper wrapping `migrateLegacyChecklistType(...)`. Accepts a JSON-string checklist, returns the migrated record. No storage I/O.
  - `checklist_build_object` — pure factory wrapping `createChecklistObject(...)`. Distinct from `checklist_create` (which persists with collision check); useful for building + inspecting a checklist record without committing it.
- **Web duplication audit** of `apps/web/src/components/Checklists.svelte`:
  - Every CRUD path (toggle, clear, add item, remove item, delete, create-for-task, import) was mutate-and-put against the raw `HoloSphere`. Refactored to call core ops: `toggleItem`, `clearChecklist`, `appendItems`, `removeItemAt`, `deleteChecklist`, `createChecklist`, `createChecklistObject`.
  - Local `Checklist` / `ChecklistItem` interfaces removed in favor of the core types.
  - `TaskModal.svelte#createChecklistForTask` likewise uses `createChecklistObject` with the `QUEST` type + `parentTitle`/`holonId`.
- **Kept local** `getChecklistDisplayTitle` in `Checklists.svelte` — it resolves titles via the live `roles`/`quests` maps loaded in the component, which is semantically different from the core helper of the same name (which only reads `parentTitle`).
- Other `apps/web` components referencing `"checklists"` (Dashboard.svelte, ShoppingList.svelte) are either read-only or already domain-isolated; no refactor needed.

## Notes

- `createChecklist` and `createChecklistObject` are distinct exports (not aliases), so both are now exposed via MCP.
- The "Add Checklist" UI path now uses `createChecklist` (collision check) rather than `appendItems` with an empty items array, which would silently skip the `put` for a brand-new record.

## Test plan

- [x] `pnpm -F @holons/core build` — passes
- [x] `pnpm -F @holons/mcp-ui build` — passes
- [x] `pnpm -F harvest-web check` — no new errors in `Checklists.svelte` or `TaskModal.svelte` (the area I touched; pre-existing repo errors at unrelated lines remain)
- [x] MCP smoke (`tools/list` grep) — `checklist_get`, `checklist_migrate_legacy_type`, `checklist_build_object`, `checklist_create`, `subtask_add`, `subtask_toggle`, `subtask_delete` all registered
- [ ] Manual: open `/[holon]/checklists` in the web UI; create, toggle, clear, delete a checklist; create a quest-linked checklist via TaskModal

🤖 Generated with [Claude Code](https://claude.com/claude-code)