### PR TITLE
mcp-ui + library: fill MCP gaps + refactor Library.ts borrow/return (unit 4/12)

### DIFF
--- a/packages/mcp-ui/src/tools/library.ts
+++ b/packages/mcp-ui/src/tools/library.ts
@@ -3,17 +3,45 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import {
   addItem,
   borrowItem,
+  detectItemType,
+  getItem,
   getLibraryStats,
   listItems,
+  recordBorrowAccounting,
+  recordReturnAccounting,
   removeItem,
   returnItem,
   setItemValue,
+  type AccountingDeps,
   type BorrowActor,
   type CreateLibraryItemOptions,
   type LibraryDB,
+  type LibraryItem,
   type LibraryItemType,
+  type REAEventFactoryLike,
+  type REAEventStoreLike,
 } from '@holons/core/library';
 import type { ToolDeps } from './index.js';
+
+// MCP-side accounting helpers: the REA event store and factory live in
+// telegram-ui today. The MCP server has no transport for those domain
+// services, so we plug in no-op stubs that satisfy the core interface while
+// still letting `recordBorrow/ReturnAccounting` persist the credit-denominated
+// expense bookkeeping (which only needs the HoloSphere `db`).
+const NOOP_EVENT_STORE: REAEventStoreLike = {
+  async put() {
+    return undefined;
+  },
+};
+
+const NOOP_EVENT_FACTORY: REAEventFactoryLike = {
+  itemBorrowed() {
+    return [];
+  },
+  itemReturned() {
+    return [];
+  },
+};
 
 type JsonResult = {
   content: Array<{ type: 'text'; text: string }>;
@@ -205,6 +233,85 @@ export function registerLibraryTools(server: McpServer, deps: ToolDeps): void {
       const items = await listItems(db, holon);
       const stats = getLibraryStats(items);
       return ok({ stats });
+    }
+  );
+
+  server.tool(
+    'library_item_get',
+    'Fetch a single library item by id from a holon. Returns null when absent.',
+    {
+      holon: z.string(),
+      itemId: z.string(),
+    },
+    async ({ holon, itemId }) => {
+      const db = (await deps.getHoloSphere()) as LibraryDB;
+      const item = await getItem(db, holon, itemId);
+      return ok({ item });
+    }
+  );
+
+  server.tool(
+    'library_borrow_accounting_record',
+    'Record borrow-side bookkeeping for a library item (credit-denominated expense + REA events). Skipped when the borrower owns the item or the item has no value. REA events are no-ops in the MCP context — the expense entry is still persisted.',
+    {
+      holon: z.string(),
+      borrower: z
+        .string()
+        .optional()
+        .describe('JSON-encoded BorrowActor override: { id, username?, first_name?, last_name? }'),
+      item: z.string().describe('JSON-encoded LibraryItem snapshot to bill against.'),
+    },
+    async ({ holon, borrower, item }) => {
+      const actor = buildBorrowActor(deps, parseJson<ActorOverride>(borrower, {}));
+      const parsedItem = parseJson<LibraryItem | null>(item, null);
+      if (!parsedItem) return fail('item is required');
+
+      const db = (await deps.getHoloSphere()) as LibraryDB;
+      const accountingDeps: AccountingDeps = {
+        db,
+        eventStore: NOOP_EVENT_STORE,
+        eventFactory: NOOP_EVENT_FACTORY,
+      };
+      await recordBorrowAccounting(accountingDeps, holon, actor, parsedItem);
+      return ok({ itemId: parsedItem.id });
+    }
+  );
+
+  server.tool(
+    'library_return_accounting_record',
+    'Record return-side bookkeeping for a library item (refund expense + REA events). Skipped when the returner owns the item or the item has no value. REA events are no-ops in the MCP context — the refund expense is still persisted.',
+    {
+      holon: z.string(),
+      returner: z
+        .string()
+        .optional()
+        .describe('JSON-encoded BorrowActor override for the returner.'),
+      item: z.string().describe('JSON-encoded LibraryItem snapshot being returned.'),
+    },
+    async ({ holon, returner, item }) => {
+      const actor = buildBorrowActor(deps, parseJson<ActorOverride>(returner, {}));
+      const parsedItem = parseJson<LibraryItem | null>(item, null);
+      if (!parsedItem) return fail('item is required');
+
+      const db = (await deps.getHoloSphere()) as LibraryDB;
+      const accountingDeps: AccountingDeps = {
+        db,
+        eventStore: NOOP_EVENT_STORE,
+        eventFactory: NOOP_EVENT_FACTORY,
+      };
+      await recordReturnAccounting(accountingDeps, holon, actor, parsedItem);
+      return ok({ itemId: parsedItem.id });
+    }
+  );
+
+  server.tool(
+    'library_detect_item_type',
+    'Infer a likely library item category (tool|book|equipment|other) from free text.',
+    {
+      text: z.string(),
+    },
+    async ({ text }) => {
+      return ok({ type: detectItemType(text) });
     }
   );
 }

--- a/packages/telegram-ui/src/Library.ts
+++ b/packages/telegram-ui/src/Library.ts
@@ -7,7 +7,15 @@ import { Markup } from 'telegraf';
 import { REAEventStore, REAEventFactory, REAAggregator } from './domain/rea/index.js';
 import { extractItemsFromImage } from './AI.js';
 import { Calendar } from './Calendar.js';
-import { LIBRARY_TYPES as LIBRARY_TYPES_CORE, type LibraryItem } from '@holons/core/library';
+import {
+    LIBRARY_TYPES as LIBRARY_TYPES_CORE,
+    borrowItem as coreBorrowItem,
+    recordBorrowAccounting as coreRecordBorrowAccounting,
+    recordReturnAccounting as coreRecordReturnAccounting,
+    returnItem as coreReturnItem,
+    type AccountingDeps,
+    type LibraryItem,
+} from '@holons/core/library';
 
 // Re-export LIBRARY_TYPES so existing imports `from './Library.js'` keep working
 // while also making it sourceable from `@holons/core/library`.
@@ -455,15 +463,21 @@ class Library {
         const { itemName, username, firstName, lastName } = pendingBorrow;
         const returnDate = new Date(dateStr);
 
-        // Create initials from first name and last name
-        const firstInitial = firstName ? firstName.charAt(0).toUpperCase() : '';
-        const lastInitial = lastName ? lastName.charAt(0).toUpperCase() : '';
-        const initials = firstInitial + lastInitial || (username ? username.charAt(0).toUpperCase() : '?');
-
         try {
-            // Re-check item is still available
-            const freshItem = await this.db.get(holonId.toString(), 'library', itemName);
-            if (!freshItem || freshItem.borrowed) {
+            const borrowResult = await coreBorrowItem(
+                this.db as any,
+                holonId.toString(),
+                itemName,
+                {
+                    id: ctx.from.id,
+                    username,
+                    first_name: firstName,
+                    last_name: lastName,
+                },
+                returnDate
+            );
+
+            if (!borrowResult.ok || !borrowResult.item) {
                 await ctx.answerCbQuery('Item is no longer available.').catch(() => {});
                 this.pendingBorrows.delete(lockKey);
                 this.borrowLocks.delete(lockKey);
@@ -471,46 +485,17 @@ class Library {
                 return;
             }
 
-            // Check if it's the owner borrowing
-            const isOwner = freshItem.createdBy === ctx.from.id;
+            const freshItem = borrowResult.item;
+            const isOwner = !!borrowResult.isOwner;
 
-            // Create expense entry for borrowed item (if has value and not owner)
-            if (!isOwner && freshItem.value > 0) {
-                try {
-                    const expense = {
-                        id: Date.now(),
-                        date: Date.now(),
-                        amount: freshItem.value,
-                        currency: 'credits',
-                        description: `Borrowed: ${itemName}`,
-                        paidBy: freshItem.createdBy,
-                        splitWith: [ctx.from.id],
-                        itemId: itemName,
-                        type: 'borrow'
-                    };
-                    await this.db.put(holonId.toString(), 'expenses', expense);
-
-                    const events = this.eventFactory.itemBorrowed(
-                        holonId,
-                        ctx.from,
-                        freshItem,
-                        freshItem.value,
-                        0
-                    );
-                    await Promise.all(events.map(e => this.eventStore.put(holonId, e)));
-                } catch (error) {
-                    console.error('Error creating borrow expense/events:', error);
-                }
-            }
-
-            // Update item with borrow info including return date and initials
-            freshItem.borrowed = true;
-            freshItem.borrower = username;
-            freshItem.borrowerId = ctx.from.id;
-            freshItem.borrowerInitials = initials;
-            freshItem.borrowedAt = new Date();
-            freshItem.returnBy = returnDate;
-            await this.db.put(holonId.toString(), 'library', freshItem);
+            // Core helper internally skips owners + zero-value items and
+            // swallows persistence errors (matches the original inline path).
+            const accountingDeps: AccountingDeps = {
+                db: this.db as any,
+                eventStore: this.eventStore,
+                eventFactory: this.eventFactory,
+            };
+            await coreRecordBorrowAccounting(accountingDeps, holonId, ctx.from, freshItem);
 
             await ctx.answerCbQuery(`Borrowed until ${dateStr}`).catch(() => {});
 
@@ -592,68 +577,41 @@ class Library {
             return;
         }
 
-        let currentItem = await this.db.get(holonId.toString(), 'library', item);
-        if (!currentItem) {
-            if (fromKeyboard) await ctx.answerCbQuery(`${item} is not in the library.`).catch(() => {});
-            else ctx.reply(`${item} is not in the library.`);
-            return;
-        }
-        if (!currentItem.borrowed) {
-            if (fromKeyboard) await ctx.answerCbQuery(`${item} is not borrowed.`).catch(() => {});
-            else ctx.reply(`${item} is not borrowed.`);
-            return;
-        }
-
-        // Check by borrowerId (more reliable) or fall back to username
-        const isBorrower = currentItem.borrowerId === ctx.from.id ||
-                          currentItem.borrower === ctx.from.username;
-        if (!isBorrower) {
-            if (fromKeyboard) await ctx.answerCbQuery(`Only ${currentItem.borrower} can return this item.`).catch(() => {});
-            else ctx.reply(`Only ${currentItem.borrower} can return this item.`);
-            return;
-        }
-
-        // Check if it's the owner returning (owner doesn't pay/get refunded)
-        const isOwner = currentItem.createdBy === ctx.from.id;
-
-        // Create reverse expense entry to cancel the borrow charge
-        if (!isOwner && currentItem.value > 0) {
-            try {
-                const refundExpense = {
-                    id: Date.now(),
-                    date: Date.now(),
-                    amount: currentItem.value,
-                    currency: 'credits',
-                    description: `Returned: ${item}`,
-                    paidBy: ctx.from.id,
-                    splitWith: [currentItem.createdBy],
-                    itemId: item,
-                    type: 'return'
-                };
-                await this.db.put(holonId.toString(), 'expenses', refundExpense);
-            } catch (error) {
-                console.error('Error creating return expense:', error);
+        const returnResult = await coreReturnItem(
+            this.db as any,
+            holonId.toString(),
+            item,
+            {
+                id: ctx.from.id,
+                username: ctx.from.username,
+                first_name: ctx.from.first_name,
+                last_name: ctx.from.last_name,
             }
+        );
+
+        if (!returnResult.ok) {
+            const errorMessages: Record<string, string> = {
+                not_found: `${item} is not in the library.`,
+                not_borrowed: `${item} is not borrowed.`,
+                forbidden: `Only ${returnResult.item?.borrower} can return this item.`,
+            };
+            const msg = errorMessages[returnResult.reason ?? 'not_found'];
+            if (fromKeyboard) await ctx.answerCbQuery(msg).catch(() => {});
+            else ctx.reply(msg);
+            return;
         }
 
-        // Create REA events for the return transaction
-        try {
-            const events = this.eventFactory.itemReturned(
-                holonId,
-                ctx.from,
-                currentItem,
-                currentItem.value || 0
-            );
-            await Promise.all(events.map(e => this.eventStore.put(holonId, e)));
-        } catch (error) {
-            console.error('Error creating REA events for return:', error);
-        }
+        const currentItem = returnResult.item!;
+        const isOwner = !!returnResult.isOwner;
 
-        currentItem.borrowed = false;
-        currentItem.borrower = null;
-        currentItem.borrowerId = null;
-        currentItem.returnedAt = new Date();
-        await this.db.put(holonId.toString(), 'library', currentItem);
+        // Core helper internally skips owners + zero-value items and
+        // swallows persistence errors (matches the original inline path).
+        const accountingDeps: AccountingDeps = {
+            db: this.db as any,
+            eventStore: this.eventStore,
+            eventFactory: this.eventFactory,
+        };
+        await coreRecordReturnAccounting(accountingDeps, holonId, ctx.from, currentItem);
 
         if (fromKeyboard) {
             const refundMsg = (!isOwner && currentItem.value > 0) ? ` (${currentItem.value}● refunded)` : '';


### PR DESCRIPTION
## Summary

- Add four MCP tools to `packages/mcp-ui/src/tools/library.ts`: `library_item_get`, `library_borrow_accounting_record`, `library_return_accounting_record`, and `library_detect_item_type` — each a thin wrapper over the existing `@holons/core/library` exports.
- The accounting tools plug no-op REA event store/factory stubs into the core accounting deps so the credit-denominated expense bookkeeping still persists in environments (the MCP server) that have no REA infrastructure.
- Refactor `packages/telegram-ui/src/Library.ts` to delegate `handleBorrowDateSelected` and `returnItem` to `coreBorrowItem` / `coreReturnItem` for fetch + state mutation + persistence, and to `recordBorrowAccounting` / `recordReturnAccounting` for credit/REA bookkeeping. Drops ~100 lines of inline duplicated logic.

## Test plan

- [x] `pnpm -F @holons/core build`
- [x] `pnpm -F @holons/mcp-ui build`
- [x] `pnpm -F @holons/telegram-ui typecheck`
- [x] MCP \`tools/list\` smoke (grep all four new tool names)

Stacked on mcp-ui (PR #50).

Generated with Claude Code