### PR TITLE
web: refactor ItemModal/TaskModal/Star to use core tasks participant helpers (unit 12/12)

### DIFF
--- a/apps/web/src/components/ItemModal.svelte
+++ b/apps/web/src/components/ItemModal.svelte
@@ -5,6 +5,7 @@
     import type { HoloSphere } from "holosphere";
     import { nameMap, resolvedName, resolvedInitials } from '$lib/stores/nameResolver';
     import DisplayName from './shared/DisplayName.svelte';
+    import { removeParticipant as coreRemoveParticipant, toggleParticipant as coreToggleParticipant } from '@holons/core/tasks';
     // Allow either quest or role to be passed
     export let quest: any = undefined;
     export let role: any = undefined;
@@ -154,42 +155,32 @@
     }
 
     async function removeParticipant(participantId: string) {
-        // Update the item directly for immediate UI update
-        item.participants = (item.participants || []).filter((p: any) => p.id !== participantId);
-
-        if (quest) {
-            quest.participants = (quest.participants || []).filter((p: any) => p.id !== participantId);
-        } else if (role) {
-            role.participants = (role.participants || []).filter((p: any) => p.id !== participantId);
-        }
-        const participants = (quest || role).participants;
-        await updateItem({ participants });
+        const target = (quest || role) as any;
+        const base = { ...target, participants: target.participants || [] };
+        const updated = coreRemoveParticipant(base, participantId);
+        if (quest) quest.participants = updated.participants;
+        if (role) role.participants = updated.participants;
+        item.participants = updated.participants;
+        await updateItem({ participants: updated.participants });
     }
 
     async function toggleParticipant(userId: string) {
-        const participants = [...((quest || role).participants || [])];
-        const participantIndex = participants.findIndex((p: any) => p.id === userId);
-
-        if (participantIndex >= 0) {
-            participants.splice(participantIndex, 1);
-            if (quest) quest.participants = participants;
-            if (role) role.participants = participants;
-        } else {
-            const user = userStore[userId];
-            if (user) {
-                const newParticipant = {
-                    id: userId,
-                    first_name: user.first_name,
-                    last_name: user.last_name,
-                    username: user.username
-                };
-                participants.push(newParticipant);
-                if (quest) quest.participants = participants;
-                if (role) role.participants = participants;
-            }
+        const target = (quest || role) as any;
+        const base = { ...target, participants: target.participants || [] };
+        const u = userStore[userId];
+        // If user isn't in the store and isn't already a participant, nothing to add.
+        if (!u && !base.participants.some((p: any) => String(p.id) === String(userId))) {
+            showDropdown = false;
+            return;
         }
-
-        await updateItem({ participants });
+        const candidate = u
+            ? { id: userId, first_name: u.first_name, last_name: u.last_name, username: u.username }
+            : { id: userId };
+        const updated = coreToggleParticipant(base, candidate);
+        if (quest) quest.participants = updated.participants;
+        if (role) role.participants = updated.participants;
+        item.participants = updated.participants;
+        await updateItem({ participants: updated.participants });
         showDropdown = false;
     }
 

--- a/apps/web/src/components/Star.svelte
+++ b/apps/web/src/components/Star.svelte
@@ -12,6 +12,7 @@
 	import { nameMap, resolvedName } from '$lib/stores/nameResolver';
 	import DisplayName from './shared/DisplayName.svelte';
 	import { getColorFromCategory } from '@holons/core/categories';
+	import { toggleParticipant as coreToggleParticipant } from '@holons/core/tasks';
 
 	let holosphere = getContext("holosphere") as HoloSphere;
 
@@ -158,32 +159,26 @@
 		const quest = store[questId];
 		if (!quest) return;
 
-		if (!quest.participants) {
-			quest.participants = [];
-		}
-		if (!quest.appreciation) {
-			quest.appreciation = [];
-		}
-
-		if (!quest.participants) {
-			quest.participants = [];
-		}
-		const participantIndex = quest.participants.findIndex(
-			(p) => p.id === userId
-		);
-
-		if (participantIndex >= 0) {
-			quest.participants.splice(participantIndex, 1);
-		} else {
-			const user = userStore[userId];
-			quest.participants.push({
+		const user = userStore[userId];
+		const candidate = user
+			? {
 				id: userId,
 				username:
 					user.first_name +
 					(user.last_name ? " " + user.last_name : ""),
 				picture: user.picture,
-			});
-		}
+			}
+			: { id: userId };
+
+		const base = {
+			...quest,
+			participants: quest.participants || [],
+			appreciation: quest.appreciation || [],
+		};
+		const updated = coreToggleParticipant(base, candidate);
+
+		quest.participants = updated.participants;
+		quest.appreciation = base.appreciation;
 
 		await holosphere.put(holonID, "quests", quest);
 

--- a/apps/web/src/components/TaskModal.svelte
+++ b/apps/web/src/components/TaskModal.svelte
@@ -25,6 +25,7 @@
     import { nostrPublicKey } from "../lib/stores/nostr";
     import { telegramStore } from "../lib/stores/telegram";
     import { notifyWriteDenied } from "../lib/stores/writeNotifications";
+    import { addParticipant as coreAddParticipant, removeParticipant as coreRemoveParticipant } from "@holons/core/tasks";
 
     export let quest: any;
     export let questId: string;
@@ -315,19 +316,19 @@
     }
 
     async function removeParticipant(participantId: string) {
-        const participants = (quest.participants || []).filter(
-            (p: { id: string }) => p.id !== participantId
-        );
+        const base = { ...quest, participants: quest.participants || [] };
+        const updated = coreRemoveParticipant(base, participantId);
 
-        // Also reset time tracking for the removed participant
+        // Side effect: clear this participant's time-tracking entry. Time tracking
+        // is UI/Telegram-specific state, so it stays here rather than in core.
         const updatedTimeTracking = { ...quest.timeTracking };
         if (updatedTimeTracking[participantId]) {
             delete updatedTimeTracking[participantId];
         }
 
         await updateQuest({
-            participants,
-            timeTracking: updatedTimeTracking
+            participants: updated.participants,
+            timeTracking: updatedTimeTracking,
         });
     }
 
@@ -522,10 +523,11 @@
             id: user.id, // Store the actual user ID
             firstName: user.first_name, // Map to firstName
             lastName: user.last_name,   // Map to lastName
-            username: user.username, 
+            username: user.username,
         };
 
-        const newParticipantsArray = [...(quest.participants || []), newParticipant];
+        const base = { ...quest, participants: quest.participants || [] };
+        const newParticipantsArray = coreAddParticipant(base, newParticipant).participants;
 
         // When updating user data (actions), use the canonical ID that holosphere.get/put expects for users.
         // This might be user.id (the original UUID-like ID) if it exists and is different from username.


### PR DESCRIPTION
## Summary
- Replace inline participants-array manipulation in `ItemModal.svelte`, `TaskModal.svelte`, and `Star.svelte` with the pure helpers added to `@holons/core/tasks` (`addParticipant`, `removeParticipant`, `toggleParticipant`).
- Components keep their existing persistence path and UI-only side effects (time-tracking cleanup on participant removal, "joined" user action write, dropdown reset, occurrence completion).
- Net: fewer lines, single source of truth for participant-array semantics shared with `@holons/mcp-ui` and `packages/telegram-ui`.

Stacks onto PR #50 (`mcp-ui`).

## Test plan
- [x] `pnpm -F @holons/core build` (clean).
- [x] `pnpm -F harvest-web check` — no new errors introduced by these files (pre-existing errors only: `TaskModal.svelte:172` in `getHologramSource`, `Star.svelte:372/375` self-closing tag warnings).
- [x] `pnpm -F harvest-web build` succeeds.
- [ ] Manual: open a task in ItemModal/TaskModal/Star, toggle participant on and off, confirm persistence and dropdown UX.
- [ ] Manual: remove a participant from TaskModal — confirm their time-tracking entry is cleared.