### PR TITLE
mcp-ui + expenses: fill MCP gaps + refactor UI duplication (unit 1/12)

### DIFF
--- a/apps/web/src/utils/expenseCalculations.ts
+++ b/apps/web/src/utils/expenseCalculations.ts
@@ -1,3 +1,17 @@
+// Thin facade over @holons/core/expenses.
+//
+// We keep this module so existing call sites (`Status.svelte`, `Expenses.svelte`)
+// don't need to change shape: web stores expenses as a Gun-style
+// Record<id, Expense> rather than the Expense[] core works with, and the
+// legacy `unit` field needs to be folded into `currency` before delegating.
+import {
+    computeCreditMatrix,
+    computeUserCurrencyBalance,
+    normalizeCurrency as coreNormalizeCurrency,
+    type Expense as CoreExpense,
+    type User as CoreUser,
+} from '@holons/core/expenses';
+
 interface Expense {
     id: string;
     amount: number;
@@ -16,7 +30,7 @@ interface User {
 }
 
 export function normalizeCurrency(c: string): string {
-    return (c || '').toLowerCase().replace(/s$/, '').replace(/[^a-z]/g, '');
+    return coreNormalizeCurrency(c);
 }
 
 /**
@@ -25,19 +39,20 @@ export function normalizeCurrency(c: string): string {
  * older time-tracking entries (currency: 'hour').
  */
 export function expenseCurrency(e: Expense): string {
-    return normalizeCurrency((e?.currency || e?.unit || '') as string);
+    return coreNormalizeCurrency((e?.currency || e?.unit || '') as string);
 }
 
 /**
- * Normalize `splitWith` to an array. Some upstream call sites (notably
- * holonsbot's hour-tracking before the array-splitWith fix) passed a scalar
- * holonId instead of `[holonId]`; without this shim those entries contribute
- * zero to anyone's balance because the inner loop runs zero times.
+ * Fold the legacy `unit` field into `currency` so core (which only inspects
+ * `currency`) sees the same value `expenseCurrency()` would return.
  */
-function splitWithArray(raw: unknown): Array<string | number> {
-    if (Array.isArray(raw)) return raw as Array<string | number>;
-    if (raw === null || raw === undefined || raw === '') return [];
-    return [raw as string | number];
+function toCoreExpenses(expenses: Record<string, Expense>): CoreExpense[] {
+    return Object.values(expenses)
+        .filter((e): e is Expense => Boolean(e))
+        .map((e) => ({
+            ...(e as unknown as CoreExpense),
+            currency: e.currency || e.unit || '',
+        }));
 }
 
 export function calculateCurrencyBalance(
@@ -47,40 +62,8 @@ export function calculateCurrencyBalance(
     users: User[]
 ): number {
     if (!currency || !userId || users.length === 0) return 0;
-
-    const normalizedCurrency = normalizeCurrency(currency);
-
-    // Find the user index - use string comparison for consistency
-    const userIndex = users.findIndex(user => String(user.id) === String(userId));
-    if (userIndex === -1) return 0;
-
-    // Create credit matrix using the exact same logic as Expenses.svelte
-    const creditMatrix = Array(users.length).fill(0).map(() => Array(users.length).fill(0));
-
-    Object.values(expenses).forEach(expense => {
-        if (!expense) return;
-        if (expenseCurrency(expense) !== normalizedCurrency) return;
-        const splitWithList = splitWithArray((expense as any).splitWith);
-        const amountPerPerson = expense.amount / (splitWithList.length || 1);
-        const payerIndex = users.findIndex(user => String(user.id) === String(expense.paidBy));
-
-        if (payerIndex === -1) return; // Skip if payer not found
-
-        splitWithList.forEach(memberId => {
-            const memberIndex = users.findIndex(user => String(user.id) === String(memberId));
-            if (memberIndex === -1) return; // Skip if member not found
-
-            if (payerIndex !== memberIndex) {
-                // Different people: payer is owed, member owes
-                creditMatrix[payerIndex][memberIndex] += amountPerPerson;
-                creditMatrix[memberIndex][payerIndex] -= amountPerPerson;
-            }
-            // If payerIndex === memberIndex, they paid for themselves, so no credit/debt
-        });
-    });
-
-    // Calculate balance by summing the user's row in the credit matrix
-    return creditMatrix[userIndex].reduce((sum, val) => sum + val, 0);
+    if (!users.some((u) => String(u.id) === String(userId))) return 0;
+    return computeUserCurrencyBalance(toCoreExpenses(expenses), userId, currency);
 }
 
 export function calculateCreditMatrix(
@@ -89,29 +72,7 @@ export function calculateCreditMatrix(
     users: User[]
 ): number[][] {
     if (!currency || users.length === 0) return [];
-
-    const normalizedCurrency = normalizeCurrency(currency);
-    const creditMatrix = Array(users.length).fill(0).map(() => Array(users.length).fill(0));
-
-    Object.values(expenses).forEach(expense => {
-        if (!expense) return;
-        if (expenseCurrency(expense) !== normalizedCurrency) return;
-        const splitWithList = splitWithArray((expense as any).splitWith);
-        const amountPerPerson = expense.amount / (splitWithList.length || 1);
-        const payerIndex = users.findIndex(user => String(user.id) === String(expense.paidBy));
-
-        if (payerIndex === -1) return;
-
-        splitWithList.forEach(memberId => {
-            const memberIndex = users.findIndex(user => String(user.id) === String(memberId));
-            if (memberIndex === -1) return;
-
-            if (payerIndex !== memberIndex) {
-                creditMatrix[payerIndex][memberIndex] += amountPerPerson;
-                creditMatrix[memberIndex][payerIndex] -= amountPerPerson;
-            }
-        });
-    });
-
+    const coreUsers: CoreUser[] = users.map((u) => ({ id: u.id }));
+    const { creditMatrix } = computeCreditMatrix(toCoreExpenses(expenses), coreUsers, currency);
     return creditMatrix;
 }

--- a/packages/mcp-ui/src/tools/expenses.ts
+++ b/packages/mcp-ui/src/tools/expenses.ts
@@ -7,8 +7,13 @@ import { z } from 'zod';
 import {
   addParticipant,
   calculateBalance,
+  coerceSplitWith,
+  computeBalances,
   computeCreditMatrix,
+  computeUserCurrencyBalance,
   createExpense,
+  normalizeCurrency,
+  removeParticipant,
   splitAmongAll,
   toggleParticipant,
   type AgentId,
@@ -211,6 +216,135 @@ export function registerExpensesTools(server: McpServer, deps: ToolDeps): void {
         const exp = parseJson<Expense>(expense, 'expense');
         const next = toggleParticipant(exp, userId as AgentId, holonId as AgentId);
         return ok({ expense: next });
+      } catch (err) {
+        return fail(err);
+      }
+    }
+  );
+
+  // holonId is accepted for forward-compat with the toggle variant; core's
+  // removeParticipant does not currently re-seed an empty splitWith with the
+  // holon sentinel, so we leave that behaviour to the caller.
+  server.registerTool(
+    'expense_remove_participant',
+    {
+      description:
+        'Remove a user from an expense splitWith. Returns a new Expense (no-op if the user was not present).',
+      inputSchema: {
+        expense: z.string().describe('JSON-encoded Expense.'),
+        userId: z.union([z.string(), z.number()]).describe('User id to remove.'),
+        holonId: z
+          .union([z.string(), z.number()])
+          .describe('Holon id (accepted for forward-compat; not used by core.removeParticipant).'),
+      },
+    },
+    async ({ expense, userId }) => {
+      try {
+        const exp = parseJson<Expense>(expense, 'expense');
+        const next = removeParticipant(exp, userId as AgentId);
+        return ok({ expense: next });
+      } catch (err) {
+        return fail(err);
+      }
+    }
+  );
+
+  // Core's computeBalances takes User[]; this tool accepts plain userIds and
+  // synthesizes a minimal User[] so callers without a populated roster can
+  // still compute net positions for an arbitrary id set.
+  server.registerTool(
+    'expense_compute_balances',
+    {
+      description:
+        'Compute per-user net balances + credit matrix for a currency, given a list of user ids.',
+      inputSchema: {
+        expenses: z.string().describe('JSON array of Expense objects.'),
+        userIds: z
+          .array(z.union([z.string(), z.number()]))
+          .describe('User ids participating in the calculation.'),
+        currency: z
+          .string()
+          .optional()
+          .describe('Currency code (normalized internally). Defaults to empty (zeroed result).'),
+      },
+    },
+    async ({ expenses, userIds, currency }) => {
+      try {
+        const list = parseJson<Expense[]>(expenses, 'expenses');
+        if (!Array.isArray(list)) throw new Error('"expenses" must be a JSON array');
+        const users: User[] = (userIds ?? []).map((id) => ({ id: id as AgentId }));
+        const result = computeBalances(list, users, currency ?? '');
+        return ok({ ...result, currency: currency ?? '', expenseCount: list.length });
+      } catch (err) {
+        return fail(err);
+      }
+    }
+  );
+
+  server.registerTool(
+    'expense_user_currency_balance',
+    {
+      description:
+        'Net balance for a single user in one currency. Positive = user is owed; negative = user owes.',
+      inputSchema: {
+        expenses: z.string().describe('JSON array of Expense objects.'),
+        userId: z.union([z.string(), z.number()]).describe('User to score.'),
+        currency: z.string().describe('Currency code (normalized internally).'),
+      },
+    },
+    async ({ expenses, userId, currency }) => {
+      try {
+        const list = parseJson<Expense[]>(expenses, 'expenses');
+        if (!Array.isArray(list)) throw new Error('"expenses" must be a JSON array');
+        const net = computeUserCurrencyBalance(list, userId as AgentId, currency);
+        return ok({ userId, currency, net, expenseCount: list.length });
+      } catch (err) {
+        return fail(err);
+      }
+    }
+  );
+
+  server.registerTool(
+    'expense_normalize_currency',
+    {
+      description:
+        'Normalize a currency code the same way @holons/core does (lowercase, drop trailing s, strip non-letters).',
+      inputSchema: {
+        input: z.string().describe('Raw currency string.'),
+      },
+    },
+    async ({ input }) => {
+      try {
+        return ok({ input, normalized: normalizeCurrency(input) });
+      } catch (err) {
+        return fail(err);
+      }
+    }
+  );
+
+  server.registerTool(
+    'expense_coerce_split_with',
+    {
+      description:
+        'Coerce a legacy splitWith value (scalar / JSON-encoded / array) into an AgentId[] using core rules.',
+      inputSchema: {
+        value: z
+          .string()
+          .describe('JSON-encoded legacy splitWith value (string|number|array|null).'),
+      },
+    },
+    async ({ value }) => {
+      try {
+        // Allow a bare scalar JSON token ("123" or 123) or an array. If JSON
+        // parsing fails, fall back to the raw string.
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(value);
+        } catch {
+          parsed = value;
+        }
+        const coerced = coerceSplitWith(parsed);
+        return ok({ value: parsed, splitWith: coerced });
       } catch (err) {
         return fail(err);
       }

--- a/packages/telegram-ui/src/Expenses.ts
+++ b/packages/telegram-ui/src/Expenses.ts
@@ -8,7 +8,14 @@ import i18next from 'i18next';
 import * as utils from './utilities.js';
 import { createPaddedCaption } from './utilities.js';
 import { REAEventStore, REAEventFactory, REAAggregator } from './domain/rea/index.js';
-import type { Expense } from '@holons/core/expenses';
+import {
+    computeCreditMatrix,
+    computeUserCurrencyBalance,
+    createExpense,
+    toggleParticipant as toggleParticipantCore,
+    type AgentId,
+    type Expense,
+} from '@holons/core/expenses';
 
 // Bot-side aliases for the historical Expenses.js naming. `Expense` in core
 // is the canonical record; `currency` is a normalized string code.
@@ -276,33 +283,20 @@ export default class Expenses {
     };
 
     async addExpense(messageId: number | null, holonId: number | string, amount: number, currency: string, description: string, paidBy: number | string, splitWith: Array<number | string>, picture: string | null = null) {
-        //do health check on currency: remove uppercase, check if it's a valid currency, remove plural
-        if (isNaN(amount) || amount <= 0 ) { // Currency validation moved to 'spent'
-            return false;
-        }
-
-        // amount = parseFloat(amount); // Already float from 'spent'
-
-        // currency is already normalized (lowercase, singular, no special chars) by the caller (`spent` method)
-        // description = description.replace(/^for /, ''); //EN (already done in `spent` if needed, but usually fine here)
-        description = description.replace(/^for /i, ''); // Case-insensitive
-        description = description.replace(/^per /i, '');
-        description = description.replace(/^voor /i, '');
-        description = description.replace(/^für /i, '');
-        description = description.replace(/^por /i, '');
-        description = description.replace(/^pour /i, '');
-
-
-        const expense = {
-            id: messageId,
-            date: Date.now(),
+        // Delegate validation, currency normalization and description-prefix
+        // stripping to @holons/core/expenses.createExpense. Returns null on
+        // non-positive/invalid amounts, matching the previous early-return.
+        const expense = createExpense({
+            id: messageId ?? Date.now(),
+            holonId,
             amount,
             currency,
             description,
             paidBy,
             splitWith,
-            picture: picture || null
-        };
+            picture,
+        });
+        if (!expense) return false;
 
         // Store expense record (for display and backward compatibility)
         await this.db.put(holonId.toString(), 'expenses', expense);
@@ -319,27 +313,14 @@ export default class Expenses {
         return expense;
     }
 
-    // add user to split TODO: BOT ID IS HARDCODED, switch to either holonId or variable bot id
+    // add/remove user to split. Delegates the splitWith state machine
+    // (including the holonId sentinel fallback) to @holons/core/expenses.
     async joinSplit(holonId: number | string, userID: number | string, expenseID: string) {
-        let expense = await this.db.get(holonId.toString(), 'expenses', expenseID)
-
-        if (expense) {
-            if (!expense.splitWith.includes(userID)) { //add user to split
-                expense.splitWith.push(userID);
-                // Remove holonId ("This Holon") if it exists in the array
-                expense.splitWith = expense.splitWith.filter((id: any) => id !== holonId);
-            }
-            else {//remove user from split
-                expense.splitWith = expense.splitWith.filter(function (value: any, _index: number, _arr: any[]) { return value != userID; });
-                if (expense.splitWith.length == 0) {
-                    expense.splitWith.push(holonId);
-                }
-            }
-
-            await this.db.put(holonId.toString(), 'expenses', expense)
-            return expense;
-        }
-        return false;
+        const expense = await this.db.get(holonId.toString(), 'expenses', expenseID);
+        if (!expense) return false;
+        const next = toggleParticipantCore(expense as Expense, userID as AgentId, holonId as AgentId);
+        await this.db.put(holonId.toString(), 'expenses', next);
+        return next;
     }
 
     async removeFromSplit(ctx: any) {
@@ -469,186 +450,28 @@ export default class Expenses {
     }
 
     async calculateCredits(holonId: number | string, currency: string) {
-        console.log(`\n=== CALCULATING CREDITS ===`);
-        console.log(`Holon ID: ${holonId}`);
-        console.log(`Currency: ${currency}`);
-        
-        // Validate and normalize currency input
         if (!currency || typeof currency !== 'string' || currency.length === 0) {
-            console.error('❌ Invalid currency provided to calculateCredits:', currency);
+            console.error('Invalid currency provided to calculateCredits:', currency);
             return { creditMatrix: [], userNames: [] };
         }
-        
-        const requestedCurrencyNormalized = currency.toLowerCase().replace(/s$/, '').replace(/[^a-z]/g, '');
-        console.log(`✅ Normalized currency: ${requestedCurrencyNormalized}`);
 
-        // Fetch data from the database
-        let expenses = await this.db.getAll(holonId.toString(), 'expenses');
-        let users = await this.db.getAll(holonId.toString(), 'users');
-        const currentSettings = await this.settings.getSettings(holonId); 
-        const allowedCurrenciesSetting = currentSettings.currencies || [];
+        const expenses = await this.db.getAll(holonId.toString(), 'expenses');
+        const users = await this.db.getAll(holonId.toString(), 'users');
+        const currentSettings = await this.settings.getSettings(holonId);
+        const allowedCurrenciesSetting: string[] = currentSettings.currencies || [];
 
-        console.log(`📊 Data Summary:`);
-        console.log(`  - Total expenses: ${expenses?.length || 0}`);
-        console.log(`  - Total users: ${users?.length || 0}`);
-        console.log(`  - Allowed currencies: [${allowedCurrenciesSetting.join(', ')}]`);
-
-        // Early exit if no users are found
         if (!users || users.length === 0) {
-            console.log('❌ No users found for credit calculation in chat:', holonId);
-            return { creditMatrix: [], userNames: [] }; // Return empty structure
+            console.log('No users found for credit calculation in chat:', holonId);
+            return { creditMatrix: [], userNames: [] };
         }
 
-        let userArray = users.map(user => user.id);
-        let creditMatrix = Array(userArray.length).fill(0).map(() => Array(userArray.length).fill(0));
-
-        console.log(`\n=== PROCESSING EXPENSES ===`);
-        let processedExpenses = 0;
-        let skippedExpenses = 0;
-
-        // Process each expense to calculate credits
-        expenses.forEach(expense => {
-            // Ensure the expense currency matches the requested currency (case-insensitive)
-            const expenseCurrencyNormalized = expense.currency ? expense.currency.toLowerCase().replace(/s$/, '').replace(/[^a-z]/g, '') : '';
-            
-            console.log(`\nExpense ID: ${expense.id}`);
-            console.log(`  Amount: ${expense.amount} ${expense.currency}`);
-            console.log(`  Description: ${expense.description}`);
-            console.log(`  Paid by: ${expense.paidBy}`);
-            
-            // FIX: Add proper type checking for splitWith
-            let splitWithDisplay = 'none';
-            if (expense.splitWith) {
-                if (Array.isArray(expense.splitWith)) {
-                    splitWithDisplay = expense.splitWith.join(', ');
-                } else if (typeof expense.splitWith === 'string') {
-                    splitWithDisplay = expense.splitWith;
-                } else if (typeof expense.splitWith === 'number') {
-                    splitWithDisplay = expense.splitWith.toString();
-                } else {
-                    splitWithDisplay = JSON.stringify(expense.splitWith);
-                }
-            }
-            console.log(`  Split with: [${splitWithDisplay}]`);
-            console.log(`  Currency match: ${expenseCurrencyNormalized} === ${requestedCurrencyNormalized} ? ${expenseCurrencyNormalized === requestedCurrencyNormalized}`);
-            
-            if (expenseCurrencyNormalized === requestedCurrencyNormalized) {
-                // If allowed currencies are defined in settings, ensure this expense's currency is one of them
-                if (allowedCurrenciesSetting.length > 0 && !allowedCurrenciesSetting.includes(expenseCurrencyNormalized)) {
-                    console.warn(`⚠️ Skipping expense ${expense.id} for credit calculation; its currency '${expense.currency}' (normalized: '${expenseCurrencyNormalized}') is not in the allowed list: [${allowedCurrenciesSetting.join(', ')}]`);
-                    skippedExpenses++;
-                    return; 
-                }
-
-                // FIX: Ensure splitWith is an array, default to empty if not
-                let splitWithArray = [];
-                if (expense.splitWith) {
-                    if (Array.isArray(expense.splitWith)) {
-                        splitWithArray = expense.splitWith;
-                    } else if (typeof expense.splitWith === 'string') {
-                        // Try to parse as JSON or treat as single value
-                        try {
-                            const parsed = JSON.parse(expense.splitWith);
-                            splitWithArray = Array.isArray(parsed) ? parsed : [parsed];
-                        } catch {
-                            splitWithArray = [expense.splitWith];
-                        }
-                    } else if (typeof expense.splitWith === 'number') {
-                        splitWithArray = [expense.splitWith];
-                    } else {
-                        console.warn(`⚠️ Unknown splitWith type for expense ${expense.id}:`, typeof expense.splitWith, expense.splitWith);
-                        splitWithArray = [];
-                    }
-                }
-                
-                const numberOfSplitters = splitWithArray.length > 0 ? splitWithArray.length : 1;
-                const amountPerPerson = expense.amount / numberOfSplitters;
-
-                console.log(`  ✅ Processing expense:`);
-                console.log(`    Number of splitters: ${numberOfSplitters}`);
-                console.log(`    Amount per person: ${amountPerPerson.toFixed(2)}`);
-                console.log(`    SplitWith array: [${splitWithArray.join(', ')}]`);
-
-                const payerIndex = userArray.indexOf(expense.paidBy);
-
-                // Ensure payer is found in the user list
-                if (payerIndex === -1) {
-                    console.warn(`⚠️ Payer ID ${expense.paidBy} not found in user list for expense ${expense.id}`);
-                    skippedExpenses++;
-                    return; // Skip this expense if payer not found
-                }
-
-                console.log(`    Payer index: ${payerIndex}`);
-
-                splitWithArray.forEach((memberId: any) => {
-                    const memberIndex = userArray.indexOf(memberId);
-
-                    // Ensure member is found in the user list
-                    if (memberIndex === -1) {
-                        console.warn(`⚠️ Member ID ${memberId} not found in user list for expense ${expense.id}`);
-                        return; // Skip this member if not found
-                    }
-
-                    console.log(`    Processing member ${memberId} (index: ${memberIndex})`);
-
-                    // Update the credit matrix, avoiding self-credit updates
-                    if (payerIndex !== memberIndex) {
-                        // Ensure the matrix indices are valid before assignment
-                        if (creditMatrix[payerIndex] && creditMatrix[memberIndex]) {
-                           creditMatrix[payerIndex][memberIndex] += amountPerPerson;
-                           creditMatrix[memberIndex][payerIndex] -= amountPerPerson;
-                           console.log(`      ✅ Updated matrix: [${payerIndex}][${memberIndex}] += ${amountPerPerson.toFixed(2)}`);
-                           console.log(`      ✅ Updated matrix: [${memberIndex}][${payerIndex}] -= ${amountPerPerson.toFixed(2)}`);
-                        } else {
-                           console.error(`❌ Invalid indices for credit matrix update: payerIndex=${payerIndex}, memberIndex=${memberIndex}`);
-                        }
-                    } else {
-                        console.log(`      ⏭️ Skipping self-credit update for payer ${expense.paidBy}`);
-                    }
-                });
-                
-                processedExpenses++;
-            } else {
-                console.log(`  ⏭️ Skipping - currency mismatch`);
-                skippedExpenses++;
-            }
-        });
-
-        console.log(`\n=== PROCESSING SUMMARY ===`);
-        console.log(`✅ Processed expenses: ${processedExpenses}`);
-        console.log(`⏭️ Skipped expenses: ${skippedExpenses}`);
-
-        // Get display names for the users involved
-        let userNames = await Promise.all(userArray.map(userId => this.getDisplayName(holonId, userId)));
-        
-        console.log(`\n=== FINAL USER LIST ===`);
-        userNames.forEach((name, index) => {
-            console.log(`  ${index}: ${name} (ID: ${userArray[index]})`);
-        });
-
-        // ADD: Detailed credit matrix analysis
-        console.log(`\n=== CREDIT MATRIX ANALYSIS ===`);
-        console.log(`Matrix format: [Row User] owes [Column User] amount`);
-        for (let i = 0; i < creditMatrix.length; i++) {
-            for (let j = 0; j < creditMatrix[i].length; j++) {
-                if (i !== j && creditMatrix[i][j] !== 0) {
-                    console.log(`  ${userNames[i]} owes ${userNames[j]}: ${creditMatrix[i][j].toFixed(2)}`);
-                }
-            }
-        }
-
-        // ADD: Net balance calculation for each user
-        console.log(`\n=== NET BALANCES ===`);
-        for (let i = 0; i < creditMatrix.length; i++) {
-            let netBalance = 0;
-            for (let j = 0; j < creditMatrix[i].length; j++) {
-                if (i !== j) {
-                    netBalance += creditMatrix[i][j]; // Positive = owes money, Negative = is owed money
-                }
-            }
-            console.log(`  ${userNames[i]}: ${netBalance.toFixed(2)} (${netBalance > 0 ? 'owes' : netBalance < 0 ? 'is owed' : 'balanced'})`);
-        }
-
+        const { creditMatrix, userIds } = computeCreditMatrix(
+            (expenses ?? []) as Expense[],
+            users.map((u: any) => ({ id: u.id })),
+            currency,
+            allowedCurrenciesSetting,
+        );
+        const userNames = await Promise.all(userIds.map((id) => this.getDisplayName(holonId, id)));
         return { creditMatrix, userNames };
     }
 
@@ -686,101 +509,9 @@ export default class Expenses {
     }
 
     async getUserCurrencyBalance(holonId: number | string, userID: number | string, currencyName: string) {
-        console.log(`\n=== GETTING CURRENCY BALANCE ===`);
-        console.log(`Holon ID: ${holonId}, User ID: ${userID}, Currency: ${currencyName}`);
-        
         const expenses = await this.db.getAll(holonId.toString(), 'expenses');
-        let netBalance = 0;
-        const normalizedTargetCurrency = currencyName.toLowerCase().replace(/s$/, '').replace(/[^a-z]/g, '');
-
-        console.log(`Total expenses found: ${expenses?.length || 0}`);
-        console.log(`Normalized target currency: ${normalizedTargetCurrency}`);
-
-        if (!expenses || expenses.length === 0) {
-            console.log(`❌ No expenses found`);
-            return 0;
-        }
-
-        for (const expense of expenses) {
-            const expenseCurrencyNormalized = expense.currency ? expense.currency.toLowerCase().replace(/s$/, '').replace(/[^a-z]/g, '') : '';
-            
-            // FIX: Handle splitWith properly for display
-            let splitWithDisplay = 'none';
-            if (expense.splitWith) {
-                if (Array.isArray(expense.splitWith)) {
-                    splitWithDisplay = expense.splitWith.join(', ');
-                } else if (typeof expense.splitWith === 'string') {
-                    splitWithDisplay = expense.splitWith;
-                } else if (typeof expense.splitWith === 'number') {
-                    splitWithDisplay = expense.splitWith.toString();
-                } else {
-                    splitWithDisplay = JSON.stringify(expense.splitWith);
-                }
-            }
-            
-            console.log(`\nExpense ID: ${expense.id}`);
-            console.log(`  Amount: ${expense.amount} ${expense.currency}`);
-            console.log(`  Paid by: ${expense.paidBy}`);
-            console.log(`  Split with: [${splitWithDisplay}]`);
-            console.log(`  Currency match: ${expenseCurrencyNormalized} === ${normalizedTargetCurrency} ? ${expenseCurrencyNormalized === normalizedTargetCurrency}`);
-
-            if (expenseCurrencyNormalized === normalizedTargetCurrency) {
-                // FIX: Handle splitWith properly for calculation
-                let splitWithArray = [];
-                if (expense.splitWith) {
-                    if (Array.isArray(expense.splitWith)) {
-                        splitWithArray = expense.splitWith;
-                    } else if (typeof expense.splitWith === 'string') {
-                        // Try to parse as JSON or treat as single value
-                        try {
-                            const parsed = JSON.parse(expense.splitWith);
-                            splitWithArray = Array.isArray(parsed) ? parsed : [parsed];
-                        } catch {
-                            splitWithArray = [expense.splitWith];
-                        }
-                    } else if (typeof expense.splitWith === 'number') {
-                        splitWithArray = [expense.splitWith];
-                    } else {
-                        console.warn(`⚠️ Unknown splitWith type for expense ${expense.id}:`, typeof expense.splitWith, expense.splitWith);
-                        splitWithArray = [];
-                    }
-                }
-                
-                const numSplitters = splitWithArray.length > 0 ? splitWithArray.length : 1;
-                const share = expense.amount / numSplitters;
-                // FIX: Handle data type mismatch for includes check
-                let userInSplit = splitWithArray.some((id: any) => id == userID); // Use == for type coercion
-
-                console.log(`  ✅ Processing expense:`);
-                console.log(`    Number of splitters: ${numSplitters}`);
-                console.log(`    Share per person: ${share.toFixed(2)}`);
-                console.log(`    User in split: ${userInSplit}`);
-                console.log(`    User is payer: ${expense.paidBy === userID}`);
-                console.log(`    Data types - expense.paidBy: ${typeof expense.paidBy} (${expense.paidBy}), userID: ${typeof userID} (${userID})`);
-
-                // FIX: Handle data type mismatch for comparison
-                const isPayer = expense.paidBy == userID; // Use == instead of === for type coercion
-                
-                if (isPayer) {
-                    netBalance += expense.amount; // User paid the full amount
-                    console.log(`    +${expense.amount} (paid full amount)`);
-                    if (userInSplit) {
-                        netBalance -= share; // Subtract their own share
-                        console.log(`    -${share.toFixed(2)} (own share)`);
-                    }
-                } else if (userInSplit) {
-                    netBalance -= share; // User is in split but didn't pay, so they owe their share
-                    console.log(`    -${share.toFixed(2)} (owe share)`);
-                }
-                
-                console.log(`    Current net balance: ${netBalance.toFixed(2)}`);
-            } else {
-                console.log(`  ⏭️ Skipping - currency mismatch`);
-            }
-        }
-        
-        console.log(`\nFinal net balance for user ${userID}: ${netBalance.toFixed(2)}`);
-        return netBalance;
+        if (!expenses || expenses.length === 0) return 0;
+        return computeUserCurrencyBalance(expenses as Expense[], userID as AgentId, currencyName);
     }
 
     // Show participant selection interface with checklist-style user selection
@@ -835,34 +566,21 @@ export default class Expenses {
         }
     }
 
-    // Toggle individual participant in expense split
+    // Toggle individual participant in expense split. SplitWith state machine
+    // (including the holonId sentinel fallback) is delegated to core.
     async toggleParticipant(ctx: any, holonId: number | string, messageId: number, expenseID: string, userID: number) {
         try {
             await ctx.answerCbQuery().catch(() => {});
-            
-            let expense = await this.db.get(holonId.toString(), 'expenses', expenseID);
+
+            const expense = await this.db.get(holonId.toString(), 'expenses', expenseID);
             if (!expense) {
                 await ctx.answerCbQuery('Expense not found');
                 return;
             }
 
-            // Toggle participant
-            if (expense.splitWith.includes(userID)) {
-                // Remove user from split
-                expense.splitWith = expense.splitWith.filter((id: any) => id !== userID);
-                // Add holonId ("This Holon") if split becomes empty
-                if (expense.splitWith.length === 0) {
-                    expense.splitWith.push(holonId);
-                }
-            } else {
-                // Add user to split
-                expense.splitWith.push(userID);
-                // Remove holonId ("This Holon") if it exists in the array
-                expense.splitWith = expense.splitWith.filter((id: any) => id !== holonId);
-            }
+            const next = toggleParticipantCore(expense as Expense, userID as AgentId, holonId as AgentId);
+            await this.db.put(holonId.toString(), 'expenses', next);
 
-            await this.db.put(holonId.toString(), 'expenses', expense);
-            
             // Refresh the participant selection view
             await this.showParticipantSelection(ctx, holonId, messageId, expenseID);
 


### PR DESCRIPTION
## Summary

- Adds 5 new MCP tools to `packages/mcp-ui/src/tools/expenses.ts` that fill the remaining gaps over `@holons/core/expenses`: `expense_remove_participant`, `expense_compute_balances`, `expense_user_currency_balance`, `expense_normalize_currency`, `expense_coerce_split_with`.
- Refactors `apps/web/src/utils/expenseCalculations.ts` into a thin facade over `@holons/core/expenses`. Legacy `unit` field is folded into `currency` before delegating so existing call sites in `Status.svelte` and `Expenses.svelte` keep working without code changes.
- Deletes the duplicated credit-matrix / balance / currency-normalization / split-toggle implementations in `packages/telegram-ui/src/Expenses.ts`. `addExpense`, `joinSplit`, `toggleParticipant`, `calculateCredits` and `getUserCurrencyBalance` now delegate to core; public method signatures are preserved.

## Test plan

- [x] `pnpm -F @holons/core build`
- [x] `pnpm -F @holons/mcp-ui build`
- [x] `pnpm -F @holons/telegram-ui typecheck` (clean)
- [x] `pnpm -F harvest-web check` (101 errors — same baseline as `origin/mcp-ui`; none in touched files)
- [x] MCP `tools/list` smoke: all 5 new tools registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)