### PR TITLE
core+web: REA-canonical completion (unit 2/3)

### DIFF
--- a/apps/web/src/components/Status.svelte
+++ b/apps/web/src/components/Status.svelte
@@ -9,6 +9,8 @@
     import PieChart3D from "./PieChart3D.svelte";
     import { calculateCurrencyBalance, expenseCurrency } from "../utils/expenseCalculations";
     import { migrateEquation, type ScoreEquation } from "$lib/scoring/ContributionScoring";
+    import { REAAggregator, ZERO_USER_AGGREGATES, type UserAggregates } from "@holons/core/scoring";
+    import { getEventStore } from "../lib/rea/eventStore";
     import TitleBar from "./shared/TitleBar.svelte";
     import { nameMap, resolvedName, resolveName, resolvedInitials } from '$lib/stores/nameResolver';
     import { HolonsManager } from "../lib/holons/HolonsManager";
@@ -51,6 +53,13 @@
     let currenciesLoaded = false;
     let expensesLoaded = false;
     let currencyBalanceCache: Record<string, number> = {};
+    // REA-derived aggregates keyed by user.id. Falls back to zero while
+    // the per-user query is in flight (table keeps rendering).
+    let aggregatesByUser: Record<string, UserAggregates> = {};
+    function userAggregates(user: User, userKey: string): UserAggregates {
+        const id = String(user.id || userKey);
+        return aggregatesByUser[id] ?? ZERO_USER_AGGREGATES;
+    }
 
     // Contract share state
     let manager: HolonsManager | null = null;
@@ -588,6 +597,30 @@
         subscribeToUsers();
     }
 
+    // Per-user REA aggregates fetched in parallel.
+    async function loadAggregatesForUsers() {
+        if (!holosphere || !holonID) return;
+        const aggregator = new REAAggregator(getEventStore(holosphere));
+        const entries = Object.entries(store);
+        if (entries.length === 0) {
+            aggregatesByUser = {};
+            return;
+        }
+        const next: Record<string, UserAggregates> = {};
+        await Promise.all(entries.map(async ([key, user]) => {
+            const id = String(user.id || key);
+            try {
+                next[id] = await aggregator.getUserAggregates(String(holonID), id);
+            } catch (err) {
+                console.error("[Status.svelte] REA aggregates fetch failed for", id, err);
+                next[id] = ZERO_USER_AGGREGATES;
+            }
+        }));
+        aggregatesByUser = next;
+    }
+
+    $: if (store && holonID) loadAggregatesForUsers();
+
     type BreakdownLine = { label: string; count: number; weight: number; points: number };
 
     // Per-user score breakdown — used both for the score itself and for the
@@ -595,13 +628,15 @@
     function getBreakdown(user: User, userKey: string): { lines: BreakdownLine[]; total: number } {
         const userId = user.id || userKey;
         const lines: BreakdownLine[] = [];
-        const initiatedCount = Array.isArray(user.initiated) ? user.initiated.length : 0;
-        const completedCount = Array.isArray(user.completed) ? user.completed.length : 0;
-        const wantsCount = Array.isArray(user.wants) ? user.wants.length : 0;
-        const offersCount = Array.isArray(user.offers) ? user.offers.length : 0;
-        const sentCount = user.sent || 0;
-        const receivedCount = user.received || 0;
-        const collaborationCount = user.collaboration || 0;
+        // Counts come from REA aggregates, not the flat user.\* arrays.
+        const agg = userAggregates(user, userKey);
+        const initiatedCount = agg.initiated;
+        const completedCount = agg.completed;
+        const wantsCount = agg.wants;
+        const offersCount = agg.offers;
+        const sentCount = agg.sent;
+        const receivedCount = agg.received;
+        const collaborationCount = agg.collaboration;
 
         const flat: Array<[string, number, number]> = [
             ['Tasks initiated', initiatedCount, equation.initiated],
@@ -663,15 +698,15 @@
         const score = scoreByKey[userId] ?? 0;
         const percentage = totalScore > 0 ? (score / totalScore) * 100 : 0;
 
-        // Build the breakdown object
+        const agg = userAggregates(user, userId);
         const breakdown = {
-            initiated: (user.initiated && Array.isArray(user.initiated)) ? user.initiated.length : 0,
-            completed: (user.completed && Array.isArray(user.completed)) ? user.completed.length : 0,
-            sent: user.sent || 0,
-            received: user.received || 0,
-            collaboration: user.collaboration || 0,
-            wants: (user.wants && Array.isArray(user.wants)) ? user.wants.length : 0,
-            offers: (user.offers && Array.isArray(user.offers)) ? user.offers.length : 0,
+            initiated: agg.initiated,
+            completed: agg.completed,
+            sent: agg.sent,
+            received: agg.received,
+            collaboration: agg.collaboration,
+            wants: agg.wants,
+            offers: agg.offers,
             currencies: {} as Record<string, number>
         };
 
@@ -869,12 +904,12 @@
                                         </td>
                                         <td class="p-2 text-center">
                                             <span class="text-xs text-blue-300">
-                                                {(user.initiated && Array.isArray(user.initiated)) ? user.initiated.length : 0}
+                                                {userAggregates(user, userId).initiated}
                                             </span>
                                         </td>
                                         <td class="p-2 text-center">
                                             <span class="text-xs text-green-300">
-                                                {(user.completed && Array.isArray(user.completed)) ? user.completed.length : 0}
+                                                {userAggregates(user, userId).completed}
                                             </span>
                                         </td>
                                         <td class="p-2 text-center">

--- a/apps/web/src/components/TaskModal.svelte
+++ b/apps/web/src/components/TaskModal.svelte
@@ -10,8 +10,6 @@
     import { formatDate } from "../utils/date";
     import { resolveImage } from "../utils/imageServer";
     import {
-        calculateTaskCompletionScores,
-        getActionScore,
         type ScoreEquation,
         DEFAULT_EQUATION
     } from "../lib/scoring/ContributionScoring";
@@ -29,7 +27,14 @@
         CHECKLIST_TYPES,
         createChecklistObject,
     } from "@holons/core/checklists";
-    import { addParticipant as coreAddParticipant, removeParticipant as coreRemoveParticipant } from "@holons/core/tasks";
+    import {
+        addParticipant as coreAddParticipant,
+        removeParticipant as coreRemoveParticipant,
+        applyTaskCompletion,
+        planTaskCompletion,
+        executeCompletionPlan,
+    } from "@holons/core/tasks";
+    import { getEventStore } from "../lib/rea/eventStore";
 
     export let quest: any;
     export let questId: string;
@@ -373,136 +378,39 @@
             quest.status === "completed" ? "ongoing" : "completed";
 
         if (newStatus === "completed") {
-            // Use the participants already on the quest — adding/removing
-            // participants happens in the participants section above.
-            const selectedParticipants = (quest.participants || []) as any[];
-            const selectedParticipantIds = selectedParticipants.map((p: any) => p.id);
+            // Completer = current logged-in user, falling back to initiator.
+            const telegramUser = telegramStore.getState().user;
+            const pubKey = $nostrPublicKey;
+            const completerId =
+                (telegramUser && String(telegramUser.id))
+                || pubKey
+                || (quest.initiator?.id ? String(quest.initiator.id) : '');
 
-            // Calculate scores using the same computation as Holonsbot
-            const completionScores = calculateTaskCompletionScores(
-                quest.initiator?.id || null,
-                selectedParticipantIds,
-                quest.timeTracking || {},
-                equation
-            );
-
-            // Track initiator action with equation-based scoring
-            if (quest.initiator) {
-                const initiatorData = await holosphere.get(
-                    holonId,
-                    "users",
-                    quest.initiator.id,
-                );
-                if (initiatorData) {
-                    const initiatorScore = completionScores.get(quest.initiator.id);
-                    const initiatedPoints = getActionScore('initiated', 1, equation).points;
-
-                    await holosphere.put(holonId, "users", {
-                        ...initiatorData,
-                        initiated: [
-                            ...(Array.isArray(initiatorData.initiated) ? initiatorData.initiated : []),
-                            quest.title,
-                        ],
-                        actions: [
-                            ...(Array.isArray(initiatorData.actions) ? initiatorData.actions : []),
-                            {
-                                type: "initiated",
-                                action: quest.title,
-                                amount: initiatedPoints, // Use equation weight
-                                questId: questId,
-                                timestamp: new Date(),
-                            },
-                        ],
-                    });
-                }
+            // isAdmin=true mirrors web pre-unify behaviour — the modal already
+            // gates this UI on having access.
+            const result = applyTaskCompletion(quest, completerId, { isAdmin: true });
+            if (!result.ok) {
+                console.warn('[TaskModal] applyTaskCompletion blocked:', result.reason);
+                return;
             }
 
-            // Track participant completions with equation-based scoring
-            for (const participant of selectedParticipants) {
-                const userData = await holosphere.get(
-                    holonId,
-                    "users",
-                    participant.id,
-                );
-                if (!userData) {
-                    console.error(`User data not found for participant ID: ${participant.id}`);
-                    continue;
+            const plan = planTaskCompletion(result.task, equation, {
+                holonId,
+                now: Date.now(),
+            });
+            const eventStore = getEventStore(holosphere);
+
+            try {
+                await executeCompletionPlan(holosphere as any, eventStore, holonId, plan);
+            } catch (error: any) {
+                if (error?.name === 'AuthorizationError') {
+                    notifyWriteDenied('Unable to save - no write permission for this holon');
+                    return;
                 }
-
-                const participantScore = completionScores.get(participant.id);
-                const completedPoints = getActionScore('completed', 1, equation).points;
-                const hoursTracked = (quest.timeTracking?.[participant.id] || 0) as number;
-
-                // Build updated user data
-                const updatedUser: any = {
-                    ...userData,
-                    completed: [...(Array.isArray(userData.completed) ? userData.completed : []), quest.title],
-                    actions: [
-                        ...(Array.isArray(userData.actions) ? userData.actions : []),
-                        {
-                            type: "completed",
-                            action: quest.title,
-                            amount: completedPoints, // Use equation weight
-                            questId: questId,
-                            timestamp: new Date(),
-                        },
-                    ],
-                };
-
-                // If they tracked hours, update hours and collaboration (same as Holonsbot)
-                if (hoursTracked > 0) {
-                    const hoursPoints = getActionScore('hours', hoursTracked, equation).points;
-                    const collabPoints = equation.collaboration; // 1 per time log event
-
-                    updatedUser.hours = (userData.hours || 0) + hoursTracked;
-                    updatedUser.collaboration = (userData.collaboration || 0) + 1;
-                    updatedUser.actions.push({
-                        type: "collaborated",
-                        action: quest.title,
-                        amount: hoursPoints + collabPoints, // Combined hours + collaboration score
-                        hours: hoursTracked,
-                        questId: questId,
-                        timestamp: new Date(),
-                    });
-                }
-
-                await holosphere.put(holonId, "users", updatedUser);
+                console.error('[TaskModal] executeCompletionPlan failed:', error);
             }
 
-            // Create expense entries for all time tracked
-            if (quest.timeTracking) {
-                for (const [userID, hours] of Object.entries(quest.timeTracking)) {
-                    const hoursAsNumber = hours as number;
-                    if (hoursAsNumber > 0) {
-                        // Create expense entry for the time logged, using chatID for splitWith
-                        try {
-                            const messageID = `${questId}_time_${userID}_${Date.now()}`; // Unique ID for this expense
-                            await holosphere.put(holonId, "expenses", {
-                                id: messageID,
-                                chatID: holonId,
-                                amount: hoursAsNumber, // Total hours logged
-                                // 'hour' is just another currency in the ledger.
-                                currency: 'hour',
-                                description: quest.title,
-                                paidBy: userID,
-                                splitWith: [holonId], // Split with the current holon (chatID)
-                                date: Date.now(),
-                                timestamp: new Date().toISOString(),
-                                fromTimeTracking: true, // Flag to identify expenses from time tracking
-                                questId: questId
-                            });
-                        } catch (error: any) {
-                            if (error?.name === 'AuthorizationError') {
-                                notifyWriteDenied('Unable to save - no write permission for this holon');
-                            } else {
-                                console.error(`Error adding time tracking expense for user ${userID}:`, error);
-                            }
-                        }
-                    }
-                }
-            }
-
-            await updateQuest({ status: newStatus, completed_at: new Date().toISOString() });
+            quest = result.task;
             dispatch("taskCompleted", { questId });
             dispatch("close");
         } else {

--- a/apps/web/src/components/Tasks.svelte
+++ b/apps/web/src/components/Tasks.svelte
@@ -25,12 +25,16 @@
 	import ToggleChip from "./shared/ToggleChip.svelte";
 	import { CheckSquare, Calendar as CalendarIcon, Plus, List, Grid, Columns } from 'svelte-feathers';
 	import {
-		calculateTaskCompletionScores,
-		getActionScore,
 		type ScoreEquation,
 		DEFAULT_EQUATION,
 		loadEquation
 	} from "../lib/scoring/ContributionScoring";
+	import {
+		applyTaskCompletion,
+		planTaskCompletion,
+		executeCompletionPlan
+	} from "@holons/core/tasks";
+	import { getEventStore } from "../lib/rea/eventStore";
 	import { getColorFromCategory } from "@holons/core/categories";
 	import {
 		getCachedEquation,
@@ -1052,126 +1056,29 @@
 				equation = await loadEquation(holosphere, holonID);
 			}
 
-			// Calculate scores
-			const participantIds = (quest.participants || []).map((p: any) => p.id);
-			const completionScores = calculateTaskCompletionScores(
-				quest.initiator?.id || null,
-				participantIds,
-				quest.timeTracking || {},
-				equation
-			);
+			// Completer = current logged-in user, falling back to initiator.
+			const telegramUser = telegramStore.getState().user;
+			const pubKey = $nostrPublicKey;
+			const completerId =
+				(telegramUser && String(telegramUser.id))
+				|| pubKey
+				|| (quest.initiator?.id ? String(quest.initiator.id) : '');
 
-			// Track initiator action
-			if (quest.initiator) {
-				const initiatorData = await holosphere.get(holonID, 'users', quest.initiator.id);
-				if (initiatorData) {
-					const initiatedPoints = getActionScore('initiated', 1, equation).points;
-					await holosphere.put(holonID, 'users', {
-						...initiatorData,
-						initiated: [
-							...(Array.isArray(initiatorData.initiated) ? initiatorData.initiated : []),
-							quest.title,
-						],
-						actions: [
-							...(Array.isArray(initiatorData.actions) ? initiatorData.actions : []),
-							{
-								type: 'initiated',
-								action: quest.title,
-								amount: initiatedPoints,
-								questId: key,
-								timestamp: new Date(),
-							},
-						],
-					});
-				}
+			const result = applyTaskCompletion(quest as any, completerId, { isAdmin: true });
+			if (!result.ok) {
+				console.warn('[Tasks] applyTaskCompletion blocked:', result.reason);
+				return;
 			}
 
-			// Track participant completions
-			if (quest.participants) {
-				for (const participant of quest.participants) {
-					const userData = await holosphere.get(holonID, 'users', participant.id);
-					if (!userData) continue;
+			const plan = planTaskCompletion(result.task, equation, {
+				holonId: holonID,
+				now: Date.now(),
+			});
+			const eventStore = getEventStore(holosphere);
 
-					const completedPoints = getActionScore('completed', 1, equation).points;
-					const hoursTracked = (quest.timeTracking?.[participant.id] || 0) as number;
+			await executeCompletionPlan(holosphere as any, eventStore, holonID, plan);
 
-					const updatedUser: any = {
-						...userData,
-						completed: [...(Array.isArray(userData.completed) ? userData.completed : []), quest.title],
-						actions: [
-							...(Array.isArray(userData.actions) ? userData.actions : []),
-							{
-								type: 'completed',
-								action: quest.title,
-								amount: completedPoints,
-								questId: key,
-								timestamp: new Date(),
-							},
-						],
-					};
-
-					// Track hours if any
-					if (hoursTracked > 0) {
-						const hoursPoints = getActionScore('hours', hoursTracked, equation).points;
-						const collabPoints = equation.collaboration;
-
-						updatedUser.hours = (userData.hours || 0) + hoursTracked;
-						updatedUser.collaboration = (userData.collaboration || 0) + 1;
-						updatedUser.actions.push({
-							type: 'collaborated',
-							action: quest.title,
-							amount: hoursPoints + collabPoints,
-							hours: hoursTracked,
-							questId: key,
-							timestamp: new Date(),
-						});
-					}
-
-					await holosphere.put(holonID, 'users', updatedUser);
-				}
-			}
-
-			// Create expense entries for time tracked
-			if (quest.timeTracking) {
-				for (const [userID, hours] of Object.entries(quest.timeTracking)) {
-					const hoursNum = hours as number;
-					if (hoursNum > 0) {
-						try {
-							const messageID = `${key}_time_${userID}_${Date.now()}`;
-							await holosphere.put(holonID, 'expenses', {
-								id: messageID,
-								chatID: holonID,
-								amount: hoursNum,
-								// 'hour' is just another currency in the ledger.
-								currency: 'hour',
-								description: quest.title,
-								paidBy: userID,
-								splitWith: [holonID],
-								date: Date.now(),
-								timestamp: new Date().toISOString(),
-								fromTimeTracking: true,
-								questId: key
-							});
-						} catch (error: any) {
-							if (error?.name === 'AuthorizationError') {
-								notifyWriteDenied('Unable to save - no write permission for this holon');
-							} else {
-								console.error(`Error adding time tracking expense for user ${userID}:`, error);
-							}
-						}
-					}
-				}
-			}
-
-			// Update quest status
-			const completedQuest = {
-				...quest,
-				id: key,
-				status: 'completed' as const,
-				completed_at: new Date().toISOString()
-			};
-
-			await holosphere.put(holonID, 'quests', completedQuest);
+			const completedQuest = { ...result.task, id: key } as Quest;
 			store = { ...store, [key]: completedQuest };
 
 			// Show celebration
@@ -1230,7 +1137,6 @@
 
 						// Ensure required arrays are initialized
 						if (!quest.participants) quest.participants = [];
-						if (!quest.appreciation) quest.appreciation = [];
 
 						// Preserve hologram metadata
 						const processedQuest: Quest = {
@@ -1267,7 +1173,6 @@
 
 						// Ensure required arrays are initialized
 						if (!quest.participants) quest.participants = [];
-						if (!quest.appreciation) quest.appreciation = [];
 
 						newStore[key] = quest as Quest;
 					}
@@ -1300,7 +1205,6 @@
 							}
 
 							if (!quest.participants) quest.participants = [];
-							if (!quest.appreciation) quest.appreciation = [];
 
 							newStore[key] = quest as Quest;
 						}
@@ -1372,7 +1276,6 @@
 
 						// Ensure required arrays are initialized
 						if (!quest.participants) quest.participants = [];
-						if (!quest.appreciation) quest.appreciation = [];
 
 						newStore[key] = quest as Quest;
 					}
@@ -1383,7 +1286,6 @@
 					if (quest && quest.id && !quest._deleted) {
 						// Ensure required arrays are initialized
 						if (!quest.participants) quest.participants = [];
-						if (!quest.appreciation) quest.appreciation = [];
 
 						newStore[key] = quest as Quest;
 					}
@@ -1492,7 +1394,6 @@
 				if (!isDeleted) {
 					// Ensure required arrays are initialized
 					if (!newquest.participants) newquest.participants = [];
-					if (!newquest.appreciation) newquest.appreciation = [];
 					// Atomic update: spread current store and add/update this quest
 					store = { ...store, [questKey]: newquest };
 				} else {

--- a/apps/web/src/components/User.svelte
+++ b/apps/web/src/components/User.svelte
@@ -4,6 +4,8 @@
     import type { HoloSphere } from "holosphere";
     import { nameMap, resolvedName, resolvedInitials } from '$lib/stores/nameResolver';
     import DisplayName from './shared/DisplayName.svelte';
+    import { REAAggregator, ZERO_USER_AGGREGATES, type UserAggregates } from "@holons/core/scoring";
+    import { getEventStore } from "../lib/rea/eventStore";
 
     export let userId: string;
     export let holonId: string;
@@ -38,6 +40,7 @@
     let loading = true;
     let activeTab = 'overview';
     let selectedActionType = 'all';
+    let aggregates: UserAggregates = { ...ZERO_USER_AGGREGATES };
 
     onMount(async () => {
         if (userData) {
@@ -47,6 +50,7 @@
             await loadUserData();
         }
         // Name resolution is now automatic via resolvedName()
+        await loadAggregates();
     });
 
     async function loadUserData() {
@@ -67,6 +71,16 @@
         }
     }
 
+    async function loadAggregates() {
+        if (!holosphere || !holonId || !userId) return;
+        try {
+            const aggregator = new REAAggregator(getEventStore(holosphere));
+            aggregates = await aggregator.getUserAggregates(String(holonId), String(userId));
+        } catch (error) {
+            console.error("[User.svelte] Error loading REA aggregates:", error);
+        }
+    }
+
     function closeModal() {
         dispatch('close');
     }
@@ -83,12 +97,12 @@
 
 
     $: stats = user ? [
-        { label: 'Tasks Initiated', value: user.initiated?.length || 0, color: 'text-blue-400' },
-        { label: 'Tasks Completed', value: user.completed?.length || 0, color: 'text-green-400' },
-        { label: 'Messages Sent', value: user.sent || 0, color: 'text-purple-400' },
-        { label: 'Appreciation Received', value: user.received || 0, color: 'text-orange-400' },
-        { label: 'Hours Contributed', value: user.hours || 0, color: 'text-yellow-400' },
-        { label: 'Collaboration Score', value: user.collaboration?.length || 0, color: 'text-pink-400' }
+        { label: 'Tasks Initiated', value: aggregates.initiated, color: 'text-blue-400' },
+        { label: 'Tasks Completed', value: aggregates.completed, color: 'text-green-400' },
+        { label: 'Appreciation Sent', value: aggregates.sent, color: 'text-purple-400' },
+        { label: 'Appreciation Received', value: aggregates.received, color: 'text-orange-400' },
+        { label: 'Hours Contributed', value: aggregates.hours, color: 'text-yellow-400' },
+        { label: 'Collaboration Score', value: aggregates.collaboration, color: 'text-pink-400' }
     ] : [];
 
     // Get unique action types from user data

--- a/apps/web/src/components/flow/FlowManagement.svelte
+++ b/apps/web/src/components/flow/FlowManagement.svelte
@@ -9,11 +9,12 @@
   import { awaitName } from '$lib/stores/nameResolver';
   import {
     loadEquation,
-    toAggregates,
     calculateUserScore as calculateScore,
     type ScoreEquation,
     DEFAULT_EQUATION
   } from '../../lib/scoring/ContributionScoring';
+  import { REAAggregator, ZERO_USER_AGGREGATES, type UserAggregates } from '@holons/core/scoring';
+  import { getEventStore } from '../../lib/rea/eventStore';
 
   import FlowHeader from './FlowHeader.svelte';
   import FlowControls from './FlowControls.svelte';
@@ -73,6 +74,11 @@
     offers?: string[];
   }
   let holosphereUsers: HolosphereUser[] = [];
+  // REA-derived aggregates per user; zero-filled while requests are in flight.
+  let aggregatesByUser: Record<string, UserAggregates> = {};
+  function userAggregates(user: HolosphereUser): UserAggregates {
+    return aggregatesByUser[String(user.id)] ?? ZERO_USER_AGGREGATES;
+  }
   // Use shared equation type with same defaults as Holonsbot
   let equation: ScoreEquation = { ...DEFAULT_EQUATION };
 
@@ -323,6 +329,7 @@
 
       // Load equation from settings (using shared service - same as Holonsbot)
       equation = await loadEquation(holosphere, holonId);
+      await loadAggregatesForUsers();
 
       // Calculate interior members from users
       calculateInteriorMembers();
@@ -331,6 +338,25 @@
     }
   }
 
+
+  async function loadAggregatesForUsers() {
+    if (!holosphere || !holonId || holosphereUsers.length === 0) {
+      aggregatesByUser = {};
+      return;
+    }
+    const aggregator = new REAAggregator(getEventStore(holosphere));
+    const next: Record<string, UserAggregates> = {};
+    await Promise.all(holosphereUsers.map(async (user) => {
+      const id = String(user.id);
+      try {
+        next[id] = await aggregator.getUserAggregates(String(holonId), id);
+      } catch (err) {
+        console.error('[FlowMgmt] REA aggregates fetch failed for', id, err);
+        next[id] = ZERO_USER_AGGREGATES;
+      }
+    }));
+    aggregatesByUser = next;
+  }
   // Load interior members from smart contract (with balances)
   async function loadInteriorMembersFromContract() {
     if (!manager || !existingBundle?.address) return;
@@ -348,16 +374,7 @@
             score: cm.sharePercent || 0,
             percentage: cm.sharePercent || 0,
             color: COLOR_PALETTE[i % COLOR_PALETTE.length],
-            breakdown: holosphereUser ? {
-              initiated: holosphereUser.initiated?.length || 0,
-              completed: holosphereUser.completed?.length || 0,
-              sent: holosphereUser.sent || 0,
-              received: holosphereUser.received || 0,
-              hours: holosphereUser.hours || 0,
-              collaboration: holosphereUser.collaboration || 0,
-              wants: holosphereUser.wants?.length || 0,
-              offers: holosphereUser.offers?.length || 0,
-            } : undefined
+            breakdown: holosphereUser ? { ...userAggregates(holosphereUser) } : undefined,
           };
         });
         console.log('[FlowMgmt] Loaded interior members from contract:', interiorMembers.length);
@@ -368,16 +385,15 @@
     }
   }
 
-  // Use shared scoring service (same calculation as Holonsbot).
-  // Hours used to be a top-level equation weight; it now lives under
-  // equation.currencies.hour. Until Flow ingests the expense ledger we
-  // approximate the hour balance from user.hours so the score keeps the
-  // same shape as before.
+  // Use shared scoring service (same calculation as Holonsbot). Aggregates
+  // now come from the REA event stream (loaded by loadAggregatesForUsers)
+  // so the score matches the values shown in Status.svelte and User.svelte.
   function calculateUserScore(user: HolosphereUser): number {
-    const aggregates = toAggregates(user);
-    const currencyBalances = { hour: user.hours || 0 };
+    const aggregates = userAggregates(user);
+    const currencyBalances = { hour: aggregates.hours };
     return calculateScore(aggregates, equation, currencyBalances);
   }
+
 
   function calculateInteriorMembers() {
     const usersWithScores = holosphereUsers.map((user, i) => ({
@@ -386,17 +402,7 @@
       score: calculateUserScore(user),
       percentage: 0,
       color: COLOR_PALETTE[i % COLOR_PALETTE.length],
-      breakdown: {
-        initiated: user.initiated?.length || 0,
-        completed: user.completed?.length || 0,
-        sent: user.sent || 0,
-        received: user.received || 0,
-        // Mirrors equation.currencies.hour weighting; kept here for the UI tooltip.
-        hours: user.hours || 0,
-        collaboration: user.collaboration || 0,
-        wants: user.wants?.length || 0,
-        offers: user.offers?.length || 0,
-      }
+      breakdown: { ...userAggregates(user) },
     }));
 
     const totalScore = usersWithScores.reduce((sum, u) => sum + u.score, 0);

--- a/apps/web/src/lib/rea/eventStore.ts
+++ b/apps/web/src/lib/rea/eventStore.ts
@@ -1,0 +1,19 @@
+// Memoized REAEventStore so multiple components share one instance per
+// holosphere handle. Stateless beyond the db reference, but reusing one
+// store keeps GC pressure low and centralizes the wiring.
+
+import { REAEventStore } from '@holons/core/rea';
+
+let cached: { holosphere: unknown; store: REAEventStore } | null = null;
+
+/**
+ * Return a memoized REAEventStore for the given holosphere instance. Reuses
+ * the cached store when called with the same holosphere reference; otherwise
+ * builds a new one (and updates the cache).
+ */
+export function getEventStore(holosphere: any): REAEventStore {
+    if (cached && cached.holosphere === holosphere) return cached.store;
+    const store = new REAEventStore(holosphere);
+    cached = { holosphere, store };
+    return store;
+}

--- a/packages/core/src/rea/event-factory.ts
+++ b/packages/core/src/rea/event-factory.ts
@@ -1,0 +1,480 @@
+/**
+ * REA Event Factory — TS port of telegram-ui's REAEventFactory.
+ *
+ * Static factory class producing properly structured Resource-Event-Agent
+ * events: quests, appreciation, expenses, time logs, items, offers/wants,
+ * credits. Output matches the original JS factory so existing stored events
+ * keep aggregating correctly.
+ */
+
+import type { REAEvent } from './event-store.js';
+
+/** Loose user shape accepted by the factory (id required, name fields optional). */
+interface UserLike {
+  id: string | number;
+  username?: string;
+  first_name?: string;
+  [key: string]: any;
+}
+
+/** Agent object produced by the factory. */
+interface Agent {
+  id: string;
+  type: 'user' | 'holon' | 'external';
+  name?: string;
+}
+
+/** Loose expense shape used by `expenseEvents`. */
+interface ExpenseLike {
+  id: string | number;
+  amount: number;
+  currency: string;
+  description: string;
+  paidBy: string | number;
+  splitWith: Array<string | number>;
+  date?: number;
+  [key: string]: any;
+}
+
+/** Library item shape used by `itemBorrowed`/`itemReturned`. */
+interface LibraryItemLike {
+  id: string | number;
+  createdBy?: string | number;
+  [key: string]: any;
+}
+
+/**
+ * Factory class for creating properly structured REA events.
+ * All methods are static and pure (apart from `Date.now()` and the id nonce).
+ */
+export class REAEventFactory {
+  /** Generate a unique event id: `${holonId}_${ts}_${rand}`. */
+  static generateId(holonId: string | number): string {
+    const timestamp = Date.now();
+    const nonce = Math.random().toString(36).substring(2, 9);
+    return `${holonId}_${timestamp}_${nonce}`;
+  }
+
+  /** Build a user Agent from a user-like object. */
+  static createUserAgent(user: UserLike): Agent {
+    return {
+      id: String(user.id),
+      type: 'user',
+      name: user.username || user.first_name || String(user.id),
+    };
+  }
+
+  /** Build a holon Agent. */
+  static createHolonAgent(holonId: string | number, name: string | null = null): Agent {
+    return {
+      id: String(holonId),
+      type: 'holon',
+      name: name || String(holonId),
+    };
+  }
+
+  /** Build an external Agent (used as the receiver for expense:paid). */
+  static createExternalAgent(description: string): Agent {
+    return {
+      id: 'external',
+      type: 'external',
+      name: description,
+    };
+  }
+
+  // ==================== Quest Events ====================
+
+  /** Quest initiated event. */
+  static questInitiated(
+    holonId: string | number,
+    initiator: UserLike,
+    quest: { id: string | number; title: string },
+  ): REAEvent {
+    return {
+      id: this.generateId(holonId),
+      timestamp: Date.now(),
+      resource: {
+        type: 'appreciation',
+        quantity: 1,
+        unit: 'initiative',
+      },
+      provider: this.createUserAgent(initiator),
+      receiver: this.createHolonAgent(holonId),
+      context: {
+        holonId: String(holonId),
+        questId: String(quest.id),
+        note: quest.title,
+      },
+      eventType: 'quest:initiated',
+      status: 'confirmed',
+    };
+  }
+
+  /** Quest completed event. */
+  static questCompleted(
+    holonId: string | number,
+    participant: UserLike,
+    quest: { id: string | number; title: string },
+  ): REAEvent {
+    return {
+      id: this.generateId(holonId),
+      timestamp: Date.now(),
+      resource: {
+        type: 'appreciation',
+        quantity: 1,
+        unit: 'completion',
+      },
+      provider: this.createUserAgent(participant),
+      receiver: this.createHolonAgent(holonId),
+      context: {
+        holonId: String(holonId),
+        questId: String(quest.id),
+        note: quest.title,
+      },
+      eventType: 'quest:completed',
+      status: 'confirmed',
+    };
+  }
+
+  /** Time logged event. */
+  static timeLogged(
+    holonId: string | number,
+    user: UserLike,
+    hours: number,
+    questId: string | number | null = null,
+    note: string | null = null,
+  ): REAEvent {
+    return {
+      id: this.generateId(holonId),
+      timestamp: Date.now(),
+      resource: {
+        type: 'time',
+        quantity: hours,
+        unit: 'hours',
+      },
+      provider: this.createUserAgent(user),
+      receiver: this.createHolonAgent(holonId),
+      context: {
+        holonId: String(holonId),
+        questId: questId ? String(questId) : null,
+        note,
+      },
+      eventType: 'quest:time_logged',
+      status: 'confirmed',
+    };
+  }
+
+  // ==================== Appreciation Events ====================
+
+  /**
+   * Dual-event appreciation exchange: returns `[sent, received]`.
+   * `sent` is from the sender's perspective; `received` is the receiver's.
+   */
+  static appreciationExchange(
+    holonId: string | number,
+    sender: UserLike,
+    receiver: UserLike,
+    amount: number,
+    reason: string,
+    questId: string | number | null = null,
+  ): REAEvent[] {
+    const baseId = this.generateId(holonId);
+    const timestamp = Date.now();
+    const senderAgent = this.createUserAgent(sender);
+    const receiverAgent = this.createUserAgent(receiver);
+
+    return [
+      {
+        id: `${baseId}_sent`,
+        timestamp,
+        resource: { type: 'appreciation', quantity: amount, unit: 'kudos' },
+        provider: senderAgent,
+        receiver: receiverAgent,
+        context: {
+          holonId: String(holonId),
+          questId: questId ? String(questId) : null,
+          note: reason,
+        },
+        eventType: 'appreciation:sent',
+        status: 'confirmed',
+      },
+      {
+        id: `${baseId}_received`,
+        timestamp,
+        resource: { type: 'appreciation', quantity: amount, unit: 'kudos' },
+        provider: senderAgent,
+        receiver: receiverAgent,
+        context: {
+          holonId: String(holonId),
+          questId: questId ? String(questId) : null,
+          note: reason,
+        },
+        eventType: 'appreciation:received',
+        status: 'confirmed',
+      },
+    ];
+  }
+
+  // ==================== Expense Events ====================
+
+  /** Expense events: one `expense:paid` plus one `expense:share` per non-payer. */
+  static expenseEvents(holonId: string | number, expense: ExpenseLike): REAEvent[] {
+    const events: REAEvent[] = [];
+    const baseId = this.generateId(holonId);
+    const timestamp = expense.date || Date.now();
+    const shareAmount = expense.amount / expense.splitWith.length;
+
+    events.push({
+      id: `${baseId}_paid`,
+      timestamp,
+      resource: {
+        type: 'money',
+        quantity: expense.amount,
+        unit: expense.currency.toLowerCase(),
+      },
+      provider: { id: String(expense.paidBy), type: 'user' },
+      receiver: this.createExternalAgent(expense.description),
+      context: {
+        holonId: String(holonId),
+        expenseId: String(expense.id),
+        note: expense.description,
+      },
+      eventType: 'expense:paid',
+      status: 'confirmed',
+    });
+
+    expense.splitWith.forEach((userId, index) => {
+      if (String(userId) !== String(expense.paidBy)) {
+        events.push({
+          id: `${baseId}_share_${index}`,
+          timestamp,
+          resource: {
+            type: 'money',
+            quantity: shareAmount,
+            unit: expense.currency.toLowerCase(),
+          },
+          provider: { id: String(expense.paidBy), type: 'user' },
+          receiver: { id: String(userId), type: 'user' },
+          context: {
+            holonId: String(holonId),
+            expenseId: String(expense.id),
+            note: expense.description,
+          },
+          eventType: 'expense:share',
+          status: 'confirmed',
+        });
+      }
+    });
+
+    return events;
+  }
+
+  /** Direct transfer event (user -> user). */
+  static directTransfer(
+    holonId: string | number,
+    sender: UserLike,
+    receiver: UserLike,
+    amount: number,
+    currency: string,
+    note: string | null = null,
+  ): REAEvent {
+    return {
+      id: this.generateId(holonId),
+      timestamp: Date.now(),
+      resource: {
+        type: 'money',
+        quantity: amount,
+        unit: currency.toLowerCase(),
+      },
+      provider: this.createUserAgent(sender),
+      receiver: this.createUserAgent(receiver),
+      context: { holonId: String(holonId), note },
+      eventType: 'transfer:direct',
+      status: 'confirmed',
+    };
+  }
+
+  // ==================== Library/Item Events ====================
+
+  /** Item borrowed events: borrow + optional fee + optional deposit. */
+  static itemBorrowed(
+    holonId: string | number,
+    borrower: UserLike,
+    item: LibraryItemLike,
+    credits: number,
+    deposit: number,
+  ): REAEvent[] {
+    const baseId = this.generateId(holonId);
+    const timestamp = Date.now();
+    const events: REAEvent[] = [];
+
+    events.push({
+      id: `${baseId}_borrow`,
+      timestamp,
+      resource: {
+        type: 'item',
+        quantity: 1,
+        unit: String(item.id),
+        resourceId: item.id,
+      },
+      provider: { id: String(item.createdBy), type: 'user' },
+      receiver: this.createUserAgent(borrower),
+      context: { holonId: String(holonId), itemId: item.id },
+      eventType: 'item:borrowed',
+      status: 'confirmed',
+    });
+
+    if (credits > 0) {
+      events.push({
+        id: `${baseId}_fee`,
+        timestamp,
+        resource: { type: 'credit', quantity: credits, unit: 'credits' },
+        provider: this.createUserAgent(borrower),
+        receiver: { id: String(item.createdBy), type: 'user' },
+        context: { holonId: String(holonId), itemId: item.id },
+        eventType: 'item:fee_paid',
+        status: 'confirmed',
+      });
+    }
+
+    if (deposit > 0) {
+      events.push({
+        id: `${baseId}_deposit`,
+        timestamp,
+        resource: { type: 'credit', quantity: deposit, unit: 'credits' },
+        provider: this.createUserAgent(borrower),
+        receiver: this.createHolonAgent(holonId),
+        context: { holonId: String(holonId), itemId: item.id },
+        eventType: 'item:deposit_held',
+        status: 'pending',
+      });
+    }
+
+    return events;
+  }
+
+  /** Item returned events: return + optional deposit return. */
+  static itemReturned(
+    holonId: string | number,
+    borrower: UserLike,
+    item: LibraryItemLike,
+    depositAmount: number,
+  ): REAEvent[] {
+    const baseId = this.generateId(holonId);
+    const timestamp = Date.now();
+    const events: REAEvent[] = [];
+
+    events.push({
+      id: `${baseId}_return`,
+      timestamp,
+      resource: {
+        type: 'item',
+        quantity: 1,
+        unit: String(item.id),
+        resourceId: item.id,
+      },
+      provider: this.createUserAgent(borrower),
+      receiver: { id: String(item.createdBy), type: 'user' },
+      context: { holonId: String(holonId), itemId: item.id },
+      eventType: 'item:returned',
+      status: 'confirmed',
+    });
+
+    if (depositAmount > 0) {
+      events.push({
+        id: `${baseId}_deposit_return`,
+        timestamp,
+        resource: { type: 'credit', quantity: depositAmount, unit: 'credits' },
+        provider: this.createHolonAgent(holonId),
+        receiver: this.createUserAgent(borrower),
+        context: { holonId: String(holonId), itemId: item.id },
+        eventType: 'item:deposit_returned',
+        status: 'confirmed',
+      });
+    }
+
+    return events;
+  }
+
+  // ==================== Offer/Want Events ====================
+
+  /** Offer declared event. */
+  static offerDeclared(
+    holonId: string | number,
+    user: UserLike,
+    offer: string,
+  ): REAEvent {
+    return {
+      id: this.generateId(holonId),
+      timestamp: Date.now(),
+      resource: { type: 'appreciation', quantity: 1, unit: 'offer' },
+      provider: this.createUserAgent(user),
+      receiver: this.createHolonAgent(holonId),
+      context: { holonId: String(holonId), note: offer },
+      eventType: 'offer:declared',
+      status: 'confirmed',
+    };
+  }
+
+  /** Want declared event. */
+  static wantDeclared(
+    holonId: string | number,
+    user: UserLike,
+    want: string,
+  ): REAEvent {
+    return {
+      id: this.generateId(holonId),
+      timestamp: Date.now(),
+      resource: { type: 'appreciation', quantity: 1, unit: 'want' },
+      provider: this.createUserAgent(user),
+      receiver: this.createHolonAgent(holonId),
+      context: { holonId: String(holonId), note: want },
+      eventType: 'want:declared',
+      status: 'confirmed',
+    };
+  }
+
+  // ==================== Credit Events ====================
+
+  /** Credit issued event (mutual-credit systems). */
+  static creditIssued(
+    holonId: string | number,
+    issuer: UserLike,
+    recipient: UserLike,
+    amount: number,
+    note: string | null = null,
+  ): REAEvent {
+    return {
+      id: this.generateId(holonId),
+      timestamp: Date.now(),
+      resource: { type: 'credit', quantity: amount, unit: 'credits' },
+      provider: this.createUserAgent(issuer),
+      receiver: this.createUserAgent(recipient),
+      context: { holonId: String(holonId), note },
+      eventType: 'credit:issued',
+      status: 'confirmed',
+    };
+  }
+
+  /** Credit transfer event (user -> user). */
+  static creditTransfer(
+    holonId: string | number,
+    sender: UserLike,
+    recipient: UserLike,
+    amount: number,
+    note: string | null = null,
+  ): REAEvent {
+    return {
+      id: this.generateId(holonId),
+      timestamp: Date.now(),
+      resource: { type: 'credit', quantity: amount, unit: 'credits' },
+      provider: this.createUserAgent(sender),
+      receiver: this.createUserAgent(recipient),
+      context: { holonId: String(holonId), note },
+      eventType: 'credit:transfer',
+      status: 'confirmed',
+    };
+  }
+}
+
+export default REAEventFactory;

--- a/packages/core/src/rea/event-store.ts
+++ b/packages/core/src/rea/event-store.ts
@@ -1,0 +1,227 @@
+/**
+ * REA Event Store — TS port of telegram-ui's REAEventStore.
+ *
+ * Stores and retrieves Resource-Event-Agent events via a HoloSphere-like
+ * backend. Events are persisted at `(holonId, 'rea_events')` and queried
+ * with an in-memory filter pass (matching the telegram-ui semantics).
+ *
+ * UI-agnostic: any backend implementing the minimal HoloSphere surface
+ * (`put`/`get`/`getAll`) can plug in.
+ */
+
+import type { REAEventStoreLike } from '../scoring/aggregator.js';
+import type { HoloSphereLike } from '../tasks/types.js';
+
+/** Resource-Event-Agent event. Loose by design — UIs add fields freely. */
+export interface REAEvent {
+  id: string;
+  timestamp: number;
+  resource?: {
+    type?: string;
+    quantity?: number;
+    unit?: string;
+    resourceId?: string | number;
+    [key: string]: any;
+  };
+  provider?: { id?: string | number; type?: string; name?: string; [key: string]: any };
+  receiver?: { id?: string | number; type?: string; name?: string; [key: string]: any };
+  context?: {
+    holonId?: string;
+    questId?: string | null;
+    itemId?: string | number;
+    expenseId?: string;
+    note?: string | null;
+    [key: string]: any;
+  };
+  eventType?: string;
+  status?: string;
+  [key: string]: any;
+}
+
+/** Optional filters accepted by `query()`. */
+export interface EventQueryFilters {
+  resourceType?: string;
+  eventType?: string;
+  agentId?: string | number;
+  fromDate?: number;
+  toDate?: number;
+  status?: string;
+  [key: string]: any;
+}
+
+/** HoloSphere surface used by the event store (adds optional get/getAll
+ *  to the base put-only HoloSphereLike). */
+interface EventDB extends HoloSphereLike {
+  put(holonId: string | number, bucket: string, value: any): Promise<unknown>;
+  get?(holonId: string | number, bucket: string, key?: string): Promise<any>;
+  getAll?(holonId: string | number, bucket: string): Promise<any[]>;
+}
+
+/**
+ * REA Event Store: persistent storage and retrieval of REA events.
+ *
+ * Behavior matches `packages/telegram-ui/src/domain/rea/REAEventStore.js`
+ * (same bucket name, same query semantics).
+ */
+export class REAEventStore implements REAEventStoreLike {
+  db: EventDB;
+
+  constructor(db: HoloSphereLike) {
+    this.db = db as EventDB;
+  }
+
+  /** Store a new REA event. Returns the event. */
+  async put(holonId: string | number, event: REAEvent): Promise<REAEvent> {
+    if (!event.id) {
+      throw new Error('REA event must have an id');
+    }
+    await this.db.put(String(holonId), 'rea_events', event);
+    return event;
+  }
+
+  /** Store multiple REA events. */
+  async putMany(holonId: string | number, events: REAEvent[]): Promise<REAEvent[]> {
+    const results = await Promise.all(events.map((event) => this.put(holonId, event)));
+    return results;
+  }
+
+  /** Get a specific event by id. */
+  async get(holonId: string | number, eventId: string): Promise<REAEvent | null> {
+    if (!this.db.get) return null;
+    return (await this.db.get(String(holonId), 'rea_events', eventId)) as REAEvent | null;
+  }
+
+  /** Get all events for a holon. */
+  async getAll(holonId: string | number): Promise<REAEvent[]> {
+    if (!this.db.getAll) return [];
+    const events = await this.db.getAll(String(holonId), 'rea_events');
+    return (events as REAEvent[]) || [];
+  }
+
+  /** Query events with filters (in-memory filter pass). */
+  async query(
+    holonId: string | number,
+    filters: EventQueryFilters = {},
+  ): Promise<REAEvent[]> {
+    const events = await this.getAll(holonId);
+
+    return events.filter((event) => {
+      if (filters.resourceType && event.resource?.type !== filters.resourceType) {
+        return false;
+      }
+      if (filters.eventType && event.eventType !== filters.eventType) {
+        return false;
+      }
+      if (filters.agentId) {
+        const agentId = String(filters.agentId);
+        const providerId = String(event.provider?.id);
+        const receiverId = String(event.receiver?.id);
+        if (providerId !== agentId && receiverId !== agentId) {
+          return false;
+        }
+      }
+      if (filters.fromDate && event.timestamp < filters.fromDate) {
+        return false;
+      }
+      if (filters.toDate && event.timestamp > filters.toDate) {
+        return false;
+      }
+      if (filters.status && event.status !== filters.status) {
+        return false;
+      }
+      return true;
+    });
+  }
+
+  /** Get events where agent is the provider. */
+  async getProviderEvents(
+    holonId: string | number,
+    agentId: string | number,
+    resourceType: string | null = null,
+  ): Promise<REAEvent[]> {
+    const events = await this.query(holonId, resourceType ? { resourceType } : {});
+    return events.filter((e) => String(e.provider?.id) === String(agentId));
+  }
+
+  /** Get events where agent is the receiver. */
+  async getReceiverEvents(
+    holonId: string | number,
+    agentId: string | number,
+    resourceType: string | null = null,
+  ): Promise<REAEvent[]> {
+    const events = await this.query(holonId, resourceType ? { resourceType } : {});
+    return events.filter((e) => String(e.receiver?.id) === String(agentId));
+  }
+
+  /** Get events by event type. */
+  async getByEventType(
+    holonId: string | number,
+    eventType: string,
+  ): Promise<REAEvent[]> {
+    return this.query(holonId, { eventType });
+  }
+
+  /** Get events for a specific quest. */
+  async getQuestEvents(
+    holonId: string | number,
+    questId: string | number,
+  ): Promise<REAEvent[]> {
+    const events = await this.getAll(holonId);
+    return events.filter((e) => String(e.context?.questId) === String(questId));
+  }
+
+  /** Get events for a specific library item. */
+  async getItemEvents(
+    holonId: string | number,
+    itemId: string | number,
+  ): Promise<REAEvent[]> {
+    const events = await this.getAll(holonId);
+    return events.filter(
+      (e) =>
+        String(e.context?.itemId) === String(itemId) ||
+        String(e.resource?.resourceId) === String(itemId),
+    );
+  }
+
+  /** Update an event's status. */
+  async updateStatus(
+    holonId: string | number,
+    eventId: string,
+    status: string,
+  ): Promise<REAEvent | null> {
+    const event = await this.get(holonId, eventId);
+    if (!event) return null;
+    event.status = status;
+    await this.put(holonId, event);
+    return event;
+  }
+
+  /** Count events matching filters. */
+  async count(
+    holonId: string | number,
+    filters: EventQueryFilters = {},
+  ): Promise<number> {
+    const events = await this.query(holonId, filters);
+    return events.length;
+  }
+
+  /** Sum resource quantities for matching events. */
+  async sumQuantity(
+    holonId: string | number,
+    filters: EventQueryFilters = {},
+  ): Promise<number> {
+    const events = await this.query(holonId, filters);
+    return events.reduce((sum, e) => sum + (e.resource?.quantity || 0), 0);
+  }
+
+  /** Get events in a time range. */
+  async getInTimeRange(
+    holonId: string | number,
+    fromDate: number,
+    toDate: number,
+  ): Promise<REAEvent[]> {
+    return this.query(holonId, { fromDate, toDate });
+  }
+}
+
+export default REAEventStore;

--- a/packages/core/src/rea/index.ts
+++ b/packages/core/src/rea/index.ts
@@ -1,0 +1,3 @@
+export { REAEventStore } from './event-store.js';
+export { REAEventFactory } from './event-factory.js';
+export type { REAEvent, EventQueryFilters } from './event-store.js';

--- a/packages/core/src/scoring/aggregator.ts
+++ b/packages/core/src/scoring/aggregator.ts
@@ -33,6 +33,18 @@ export interface UserAggregates {
   offers: number;
 }
 
+/** All-zero UserAggregates — useful default while REA queries are in flight. */
+export const ZERO_USER_AGGREGATES: UserAggregates = {
+  initiated: 0,
+  completed: 0,
+  sent: 0,
+  received: 0,
+  hours: 0,
+  collaboration: 0,
+  wants: 0,
+  offers: 0,
+};
+
 /**
  * Convert raw user data (from web stores or REA events) into the canonical
  * UserAggregates shape. Handles both array-based (Dashboard) and count-based

--- a/packages/core/src/scoring/index.ts
+++ b/packages/core/src/scoring/index.ts
@@ -19,6 +19,7 @@ export {
 export {
   REAAggregator,
   toAggregates,
+  ZERO_USER_AGGREGATES,
   type REAEventStoreLike,
   type UserAggregates,
 } from './aggregator.js';

--- a/packages/core/src/tasks/completion-execute.ts
+++ b/packages/core/src/tasks/completion-execute.ts
@@ -1,0 +1,122 @@
+// Executor for a CompletionPlan: persists the task update, REA events, and
+// time-tracking expense docs against the holosphere + REA event store.
+//
+// All persistence calls are best-effort: per-action errors are collected
+// rather than thrown so one failed write does not abort the rest of the
+// plan. The summary outcome lets callers report partial-success states.
+
+import type { CompletionPlan } from './completion-plan.js';
+import type { HoloSphereLike } from './types.js';
+import { REAEventFactory } from '../rea/event-factory.js';
+import { saveTaskToHolon } from './persistence.js';
+
+export interface ExecuteCompletionOptions {
+  /** Default true. Set false to skip REA event writes (e.g. dry-run UI). */
+  recordEvents?: boolean;
+  /** Default true. Set false to skip hour-currency expense writes. */
+  recordExpenses?: boolean;
+}
+
+export interface ExecuteOutcome {
+  taskSaved: boolean;
+  savedActions: number;
+  savedExpenses: number;
+  errors: { kind: 'task' | 'action' | 'expense'; message: string }[];
+}
+
+/** Minimal event-store surface needed to record REA events. */
+interface EventStoreLike {
+  put(holonId: string | number, event: unknown): Promise<unknown>;
+}
+
+export async function executeCompletionPlan(
+  store: HoloSphereLike,
+  eventStore: EventStoreLike,
+  holonId: string | number,
+  plan: CompletionPlan,
+  options: ExecuteCompletionOptions = {},
+): Promise<ExecuteOutcome> {
+  const outcome: ExecuteOutcome = {
+    taskSaved: false,
+    savedActions: 0,
+    savedExpenses: 0,
+    errors: [],
+  };
+
+  outcome.taskSaved = await saveTaskToHolon(store, holonId, plan.task);
+  if (!outcome.taskSaved) {
+    outcome.errors.push({ kind: 'task', message: 'saveTaskToHolon returned false' });
+  }
+
+  if (options.recordEvents !== false) {
+    for (const action of plan.actions) {
+      try {
+        const built = buildEvent(action, holonId);
+        if (!built) continue;
+        // Some factory methods return an array (e.g. appreciationExchange
+        // produces a sent + received pair); flatten so every event is stored.
+        const events = Array.isArray(built) ? built : [built];
+        for (const event of events) {
+          await eventStore.put(holonId, event);
+          outcome.savedActions++;
+        }
+      } catch (err) {
+        outcome.errors.push({
+          kind: 'action',
+          message: (err as Error).message ?? String(err),
+        });
+      }
+    }
+  }
+
+  if (options.recordExpenses !== false) {
+    for (const expense of plan.expenses) {
+      try {
+        await store.put(holonId, 'expenses', expense);
+        outcome.savedExpenses++;
+      } catch (err) {
+        outcome.errors.push({
+          kind: 'expense',
+          message: (err as Error).message ?? String(err),
+        });
+      }
+    }
+  }
+
+  return outcome;
+}
+
+function buildEvent(action: any, holonId: string | number): unknown {
+  switch (action.type) {
+    case 'questInitiated':
+      return REAEventFactory.questInitiated(holonId, action.user, {
+        id: action.taskId,
+        title: action.taskTitle,
+      });
+    case 'questCompleted':
+      return REAEventFactory.questCompleted(holonId, action.user, {
+        id: action.taskId,
+        title: action.taskTitle,
+      });
+    case 'appreciationExchange':
+      // Factory returns [sent, received] — caller flattens.
+      return REAEventFactory.appreciationExchange(
+        holonId,
+        action.user,
+        action.receiver,
+        action.amount,
+        action.taskTitle,
+        action.taskId,
+      );
+    case 'timeLogged':
+      return REAEventFactory.timeLogged(
+        holonId,
+        action.user,
+        Number(action.hours ?? 0),
+        action.taskId,
+        action.taskTitle,
+      );
+    default:
+      return null;
+  }
+}

--- a/packages/core/src/tasks/completion-plan.ts
+++ b/packages/core/src/tasks/completion-plan.ts
@@ -1,0 +1,120 @@
+// Pure planner for task/event completion side-effects.
+// Returns the data needed to record REA events + expense docs.
+// Consumers (bot, web, MCP) call executeCompletionPlan to persist.
+
+import type { Quest, QuestParticipant } from './types.js';
+import type { ScoreEquation } from '../scoring/index.js';
+import { getActionScore } from '../scoring/index.js';
+
+export interface PlannedAction {
+  user: QuestParticipant;
+  type: 'questInitiated' | 'questCompleted' | 'appreciationExchange' | 'timeLogged';
+  taskTitle: string;
+  taskId: string | number;
+  amount: number;
+  hours?: number;
+  receiver?: QuestParticipant;
+}
+
+export interface PlannedExpense {
+  id: string;
+  amount: number;
+  currency: 'hour';
+  description: string;
+  paidBy: string | number;
+  splitWith: (string | number)[];
+  date: number;
+  fromTimeTracking: true;
+  questId: string | number;
+}
+
+export interface CompletionPlan {
+  task: Quest;
+  actions: PlannedAction[];
+  expenses: PlannedExpense[];
+  releasedHolograms: unknown[];
+}
+
+function isSelfPair(a: QuestParticipant, b: QuestParticipant): boolean {
+  return String(a?.id ?? '') === String(b?.id ?? '');
+}
+
+export function planTaskCompletion(
+  task: Quest,
+  equation: ScoreEquation,
+  options: { now?: number; holonId?: string | number } = {},
+): CompletionPlan {
+  const actions: PlannedAction[] = [];
+  const expenses: PlannedExpense[] = [];
+  const now = options.now ?? Date.now();
+
+  const initiatedAmount = getActionScore('initiated', 1, equation).points;
+  const completedAmount = getActionScore('completed', 1, equation).points;
+  const sentAmount = getActionScore('sent', 1, equation).points;
+
+  if (task.initiator) {
+    actions.push({
+      user: task.initiator as QuestParticipant,
+      type: 'questInitiated',
+      taskTitle: task.title,
+      taskId: task.id ?? '',
+      amount: initiatedAmount,
+    });
+  }
+
+  for (const participant of task.participants ?? []) {
+    actions.push({
+      user: participant,
+      type: 'questCompleted',
+      taskTitle: task.title,
+      taskId: task.id ?? '',
+      amount: completedAmount,
+    });
+  }
+
+  for (const sender of task.appreciation ?? []) {
+    for (const recipient of task.participants ?? []) {
+      if (isSelfPair(sender, recipient)) continue;
+      actions.push({
+        user: sender,
+        type: 'appreciationExchange',
+        taskTitle: task.title,
+        taskId: task.id ?? '',
+        amount: sentAmount,
+        receiver: recipient,
+      });
+    }
+  }
+
+  const timeTracking = (task as any).timeTracking ?? {};
+  for (const [userId, rawHours] of Object.entries(timeTracking)) {
+    const hours = Number(rawHours);
+    if (!hours || hours <= 0) continue;
+    const hoursAmount = getActionScore('hours', hours, equation).points;
+    actions.push({
+      user: { id: userId } as QuestParticipant,
+      type: 'timeLogged',
+      taskTitle: task.title,
+      taskId: task.id ?? '',
+      amount: hoursAmount,
+      hours,
+    });
+    if (options.holonId != null) {
+      expenses.push({
+        id: `${task.id ?? 'task'}_time_${userId}_${now}`,
+        amount: hours,
+        currency: 'hour',
+        description: task.title,
+        paidBy: userId,
+        splitWith: [options.holonId],
+        date: now,
+        fromTimeTracking: true,
+        questId: task.id ?? '',
+      });
+    }
+  }
+
+  const releasedHolograms = ((task as any).activeHolograms ?? []) as unknown[];
+
+  return { task, actions, expenses, releasedHolograms };
+}

--- a/packages/core/src/tasks/completion.ts
+++ b/packages/core/src/tasks/completion.ts
@@ -1,0 +1,59 @@
+// Pure task-completion transform shared by all UIs and the MCP server.
+//
+// What this owns:
+//   - Permission check (initiator OR participant OR caller-supplied isAdmin).
+//   - Status guard (cannot complete a 'stopped' quest).
+//   - Stamping `status: 'completed'` + `completed_at` + clearing `activeHolograms`.
+//
+// What this DOES NOT own (UI/persistence layers do their own):
+//   - REA action events for initiator/participants/appreciation — handled by
+//     the companion `completion-plan.ts` + `completion-execute.ts` helpers.
+//   - Time-tracking -> expense docs (same — see completion-plan).
+//   - Telegram message editing, reminder cancellation, federation propagation.
+
+import type { Quest } from './types.js';
+
+export interface CompleteTaskOptions {
+  /** ISO timestamp for `completed_at`. Defaults to new Date().toISOString(). */
+  now?: string;
+  /** Set true to bypass initiator/participant check (e.g. when caller has
+   *  resolved holon-admin rights elsewhere). */
+  isAdmin?: boolean;
+}
+
+export type CompleteTaskResult =
+  | { ok: true; task: Quest; releasedHolograms: unknown[] }
+  | { ok: false; reason: 'already-completed' | 'stopped' | 'forbidden' };
+
+function isParticipant(task: Quest, userId: string | number): boolean {
+  return task.participants.some((p) => p?.id != null && String(p.id) === String(userId));
+}
+
+function isInitiator(task: Quest, userId: string | number): boolean {
+  const id = task.initiator?.id;
+  return id != null && String(id) === String(userId);
+}
+
+export function applyTaskCompletion(
+  task: Quest,
+  completerId: string | number,
+  options: CompleteTaskOptions = {},
+): CompleteTaskResult {
+  if (task.status === 'completed') return { ok: false, reason: 'already-completed' };
+  if (task.status === 'stopped') return { ok: false, reason: 'stopped' };
+
+  const allowed = options.isAdmin === true
+    || isInitiator(task, completerId)
+    || isParticipant(task, completerId);
+  if (!allowed) return { ok: false, reason: 'forbidden' };
+
+  const releasedHolograms = (task as any).activeHolograms ?? [];
+  const updated: Quest = {
+    ...task,
+    status: 'completed',
+    completed_at: options.now ?? new Date().toISOString(),
+    activeHolograms: [],
+  } as Quest;
+
+  return { ok: true, task: updated, releasedHolograms };
+}

--- a/packages/core/src/tasks/index.ts
+++ b/packages/core/src/tasks/index.ts
@@ -5,3 +5,6 @@ export * from './types.js';
 export * from './creation.js';
 export * from './persistence.js';
 export * from './participants.js';
+export * from './completion.js';
+export * from './completion-plan.js';
+export * from './completion-execute.js';


### PR DESCRIPTION
## Summary

Web side of the 3-part unification pass. All task/event completion
side-effects now flow through a single `@holons/core` API
(`applyTaskCompletion` → `planTaskCompletion` →
`executeCompletionPlan`) instead of the 130-line inline per-user
`holosphere.put` blocks that were duplicated between
`TaskModal.completeQuest` and `Tasks.completeTaskWithAccounting`.

REA events are the canonical storage format: `Status.svelte`,
`User.svelte`, and `FlowManagement.svelte` now read their score counts
from `REAAggregator.getUserAggregates` (via a memoized `REAEventStore`)
rather than from the flat `user.initiated.length / user.hours /
user.collaboration` arrays.

## What's new in `@holons/core`

- `@holons/core/rea`:
  - `REAEventStore` — TS port of `telegram-ui/src/domain/rea/REAEventStore.js`
  - `REAEventFactory` — TS port of `REAEventFactory.js` (all factory methods preserved)
- `@holons/core/tasks` additions:
  - `applyTaskCompletion` — permission/status guard + the
    `status=completed` / `completed_at` / `releasedHolograms=[]` transform
  - `planTaskCompletion` — derives the REA action records (initiator
    + each participant + appreciation duality + time-logged) and the
    hour-currency expense docs from a quest
  - `executeCompletionPlan` — persists task + REA events + expenses,
    flattening the `(sent, received)` pair from
    `REAEventFactory.appreciationExchange`
- `ZERO_USER_AGGREGATES` exported from `scoring/aggregator.ts` so
  consumers stop redeclaring the same all-zero literal.

## Web changes

- **TaskModal.svelte**: `completeQuest()` rewritten — 130 lines of
  inline writes + 30-line expense loop replaced by one
  plan/execute call. Web now records appreciation sent/received
  events automatically.
- **Tasks.svelte**: `completeTaskWithAccounting()` refactored the same
  way. Defensive `if (!quest.appreciation) quest.appreciation = []`
  init blocks removed (REA storage no longer reads those).
- **Status.svelte**: per-user breakdown + 3D pie tooltips + table
  columns read from `aggregatesByUser` (REA-derived).
- **User.svelte**: stats grid reads from `REAAggregator`-loaded
  `aggregates`.
- **FlowManagement.svelte**: `calculateUserScore` and the contract /
  calculated interior-member breakdowns read from `userAggregates(user)`.
- **lib/rea/eventStore.ts**: memoized `REAEventStore` factory so the
  four components share one instance per `holosphere` handle.

## Test plan

- [x] `pnpm -F @holons/core build` — clean
- [x] `pnpm -F @holons/mcp-ui build` — clean
- [x] `pnpm -F harvest-web check` — 0 errors, 0 warnings (matches the
  pre-change `origin/sharedlogic` baseline)
- [ ] Open a task in TaskModal, mark complete with a participant + time
  tracking; verify a `quest:completed` event lands at
  `holonId/rea_events` and an hour-currency expense lands at
  `holonId/expenses`
- [ ] Open `Status.svelte` for the same holon and confirm the
  Tasks Initiated / Tasks Completed / Hours / Collaboration columns
  reflect the new event
- [ ] Open `User.svelte` for the same user; confirm the stats grid
  shows the new counts
- [ ] Same in `FlowManagement.svelte` — interior member percentages
  update

## Notes

- `apps/web`'s `HoloSphere.put` types as `(string, ...)` while core's
  `HoloSphereLike` accepts `(string | number, ...)`; both `Tasks.svelte`
  and `TaskModal.svelte` cast `holosphere as any` at the call site
  rather than tightening the core type.
- This is unit 2 of 3; the foundation files
  (`packages/core/src/rea/*`, `packages/core/src/tasks/completion*.ts`)
  are byte-identical across units 1, 2, and 3 so the merges compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)