### PR TITLE
Add @holons/discord-ui: Discord slash-command bot (Phases 1–2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 	"scripts": {
 		"dev": "pnpm -F harvest-web dev",
 		"dev:bot": "pnpm -F @holons/telegram-ui dev",
+		"dev:discord": "pnpm -F @holons/discord-ui dev",
 		"build": "pnpm -r --if-present build",
 		"typecheck": "pnpm -r --if-present typecheck",
 		"test": "pnpm -r --if-present test",

--- a/packages/core/src/commands/types.ts
+++ b/packages/core/src/commands/types.ts
@@ -18,7 +18,7 @@ export interface CommandContext {
 	/** Holon/community scope for the command, when relevant. */
 	holonId?: string;
 	/** UI surface that originated the command. */
-	source?: 'web' | 'telegram' | 'text' | 'ai' | string;
+	source?: 'web' | 'telegram' | 'discord' | 'text' | 'ai' | string;
 	/** Optional holosphere instance (or any storage/transport handle). */
 	holosphere?: unknown;
 	/** Optional structured logger; defaults to a no-op when omitted. */

--- a/packages/discord-ui/.env.example
+++ b/packages/discord-ui/.env.example
@@ -1,0 +1,15 @@
+# Discord bot credentials (from https://discord.com/developers/applications)
+DISCORD_TOKEN=
+# Application (client) id — required to register slash commands.
+DISCORD_APP_ID=
+# Optional: register commands instantly to a single dev guild instead of
+# globally (global registration can take up to an hour to propagate).
+DISCORD_GUILD_ID=
+
+# Holosphere identity. If unset, a key is generated and stored under
+# ~/.config/holosphere/keys so the bot keeps the same identity across restarts.
+HOLOSPHERE_PRIVATE_KEY=
+APPNAME=Holons
+
+# error | warn | info | debug
+LOG_LEVEL=info

--- a/packages/discord-ui/.gitignore
+++ b/packages/discord-ui/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+logs/
+coverage/
+.env
+*.log
+.DS_Store

--- a/packages/discord-ui/.prettierrc.json
+++ b/packages/discord-ui/.prettierrc.json
@@ -1,0 +1,12 @@
+{
+  "semi": true,
+  "trailingComma": "es5",
+  "singleQuote": true,
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "bracketSpacing": true,
+  "bracketSameLine": false,
+  "arrowParens": "avoid",
+  "endOfLine": "lf"
+}

--- a/packages/discord-ui/README.md
+++ b/packages/discord-ui/README.md
@@ -1,0 +1,79 @@
+# @holons/discord-ui
+
+Discord UI for Holons. A slash-command bot that turns a Discord server into a
+Holons community ("holon"), delegating all business logic to
+[`@holons/core`](../core). It is the Discord counterpart to
+[`@holons/telegram-ui`](../telegram-ui).
+
+## Status
+
+**Phase 1 — runtime foundation + first vertical slice.** This package ships the
+bot runtime (gateway client, slash-command registration, an interaction router,
+embed/button UI helpers, guild→holon binding, and a `@holons/core` context
+adapter) plus a working slice of features. More telegram-parity features are
+being ported in subsequent phases (see the table below).
+
+## Architecture
+
+```
+index.ts            → boot: create holosphere + client, register, login
+core/DiscordBot.ts  → lifecycle orchestration
+core/ServiceContainer.ts → DI container (ported from telegram-ui)
+runtime/client.ts        → discord.js Client (Guilds intent)
+runtime/registerCommands → REST slash-command registration
+runtime/router.ts        → single interactionCreate dispatcher
+context.ts               → builds a @holons/core CommandContext per interaction
+ui/customId.ts           → encode/parse component customIds (feature:action:args)
+ui/format.ts             → pure, testable embed/list formatters
+ui/DiscordUI.ts          → EmbedBuilder / ButtonBuilder helpers
+ui/holonBinding.ts       → guild → holon mapping (persisted in holosphere)
+features/                → one module per feature (slash cmds + handlers)
+```
+
+Each **feature** owns one or more top-level slash commands and the
+buttons/selects/modals they spawn. Adding a feature to `features/index.ts` wires
+it into both registration and routing.
+
+### Telegram → Discord mapping
+
+| Telegram (telegraf)        | Discord (discord.js)                         |
+| -------------------------- | -------------------------------------------- |
+| `bot.command('x')`         | slash command (`SlashCommandBuilder`)        |
+| `ctx.reply()`              | `interaction.reply()` (embeds)               |
+| inline keyboard buttons    | `ButtonBuilder` + `ActionRowBuilder`         |
+| inline keyboard menus      | `StringSelectMenuBuilder`                    |
+| scenes / wizards           | modals + component collectors                |
+| editable "hologram" msg    | stored message id + `message.edit()`         |
+| per-chat → holon           | per-guild → holon (`/holon bind`)            |
+
+## Commands (current)
+
+- `/holon bind <id>` · `/holon current` — bind the server to a holon.
+- `/task` · `/event` · `/offer` · `/request` — create quests; join/leave and
+  complete via buttons.
+- `/quests` — list quests in the holon.
+- `/shopping add <item>` · `/shopping list` — shared shopping list with toggle
+  and "remove checked" buttons.
+
+## Development
+
+```bash
+# from the monorepo root
+pnpm install
+pnpm -F @holons/discord-ui typecheck
+pnpm -F @holons/discord-ui test
+
+# run the bot (needs a .env — see .env.example)
+pnpm dev:discord
+# (re)register slash commands out of band
+pnpm -F @holons/discord-ui register
+```
+
+Set `DISCORD_TOKEN`, `DISCORD_APP_ID`, and (for instant dev updates)
+`DISCORD_GUILD_ID` in `.env`. See [`.env.example`](./.env.example).
+
+## Roadmap (telegram parity)
+
+Quests (time logging, checklists, scheduling, appreciation) → Checklists/Tags →
+Expenses/REA → Roles/Users/Onboarding → Scheduler/Reminders → Federation →
+Library → Settings → the long tail (announcements, RSVP, rounds, booking, …).

--- a/packages/discord-ui/README.md
+++ b/packages/discord-ui/README.md
@@ -7,11 +7,11 @@ Holons community ("holon"), delegating all business logic to
 
 ## Status
 
-**Phase 2 — membership, expenses, checklists + quest appreciation.** Builds on
-the Phase 1 runtime (gateway client, slash-command registration, interaction
-router, embed/button UI helpers, guild→holon binding, `@holons/core` context
-adapter). More telegram-parity features are being ported in subsequent phases
-(see the roadmap below).
+**Phase 3 — contribution scores, quest detail/filter, read-only settings.**
+Builds on the Phase 1 runtime (gateway client, slash-command registration,
+interaction router, embed/button UI helpers, guild→holon binding, `@holons/core`
+context adapter) and the Phase 2 features. More telegram-parity features are
+being ported in subsequent phases (see the roadmap below).
 
 ## Architecture
 
@@ -59,6 +59,10 @@ it into both registration and routing.
 - `/expense <amount> <description> [currency] [split]` — record a shared cost.
 - `/balances [currency]` — who owes whom (credit-matrix balances).
 - `/checklist create|add|show|list` — checklists with per-item toggle buttons.
+- `/quests [type]` — list quests (optionally filtered); each line shows its id.
+- `/quest <id>` — reopen one quest as an interactive card.
+- `/scores` — contribution leaderboard (REA + value equation, via core scoring).
+- `/settings` — read-only holon configuration overview.
 
 ## Development
 
@@ -82,6 +86,9 @@ Set `DISCORD_TOKEN`, `DISCORD_APP_ID`, and (for instant dev updates)
 - ✅ **Phase 1** — runtime + quests/shopping vertical slice.
 - ✅ **Phase 2** — membership (`/join` `/leave` `/members`), expenses/REA
   (`/expense` `/balances`), checklists (`/checklist`), quest appreciation.
+- ✅ **Phase 3** — contribution scores (`/scores`), quest detail/filter
+  (`/quest`, `/quests type:`), read-only settings (`/settings`).
 - ⬜ Quests deeper (time logging, on-quest checklists, scheduling/recurring).
-- ⬜ Tags, Roles/Onboarding, Scheduler/Reminders, Federation, Library, Settings.
+- ⬜ Tags, Roles/Onboarding, Scheduler/Reminders, Federation, Library,
+  editable Settings.
 - ⬜ Long tail: announcements, RSVP, rounds/rotation, booking, capital game.

--- a/packages/discord-ui/README.md
+++ b/packages/discord-ui/README.md
@@ -7,11 +7,11 @@ Holons community ("holon"), delegating all business logic to
 
 ## Status
 
-**Phase 1 — runtime foundation + first vertical slice.** This package ships the
-bot runtime (gateway client, slash-command registration, an interaction router,
-embed/button UI helpers, guild→holon binding, and a `@holons/core` context
-adapter) plus a working slice of features. More telegram-parity features are
-being ported in subsequent phases (see the table below).
+**Phase 2 — membership, expenses, checklists + quest appreciation.** Builds on
+the Phase 1 runtime (gateway client, slash-command registration, interaction
+router, embed/button UI helpers, guild→holon binding, `@holons/core` context
+adapter). More telegram-parity features are being ported in subsequent phases
+(see the roadmap below).
 
 ## Architecture
 
@@ -49,11 +49,16 @@ it into both registration and routing.
 ## Commands (current)
 
 - `/holon bind <id>` · `/holon current` — bind the server to a holon.
+- `/join` · `/leave` · `/members` — holon membership (a member is a profile in
+  the `users` lens, feeding expenses and scoring).
 - `/task` · `/event` · `/offer` · `/request` — create quests; join/leave and
-  complete via buttons.
+  complete via buttons, **appreciate** contributors once completed.
 - `/quests` — list quests in the holon.
 - `/shopping add <item>` · `/shopping list` — shared shopping list with toggle
   and "remove checked" buttons.
+- `/expense <amount> <description> [currency] [split]` — record a shared cost.
+- `/balances [currency]` — who owes whom (credit-matrix balances).
+- `/checklist create|add|show|list` — checklists with per-item toggle buttons.
 
 ## Development
 
@@ -74,6 +79,9 @@ Set `DISCORD_TOKEN`, `DISCORD_APP_ID`, and (for instant dev updates)
 
 ## Roadmap (telegram parity)
 
-Quests (time logging, checklists, scheduling, appreciation) → Checklists/Tags →
-Expenses/REA → Roles/Users/Onboarding → Scheduler/Reminders → Federation →
-Library → Settings → the long tail (announcements, RSVP, rounds, booking, …).
+- ✅ **Phase 1** — runtime + quests/shopping vertical slice.
+- ✅ **Phase 2** — membership (`/join` `/leave` `/members`), expenses/REA
+  (`/expense` `/balances`), checklists (`/checklist`), quest appreciation.
+- ⬜ Quests deeper (time logging, on-quest checklists, scheduling/recurring).
+- ⬜ Tags, Roles/Onboarding, Scheduler/Reminders, Federation, Library, Settings.
+- ⬜ Long tail: announcements, RSVP, rounds/rotation, booking, capital game.

--- a/packages/discord-ui/README.md
+++ b/packages/discord-ui/README.md
@@ -7,11 +7,11 @@ Holons community ("holon"), delegating all business logic to
 
 ## Status
 
-**Phase 3 — contribution scores, quest detail/filter, read-only settings.**
-Builds on the Phase 1 runtime (gateway client, slash-command registration,
-interaction router, embed/button UI helpers, guild→holon binding, `@holons/core`
-context adapter) and the Phase 2 features. More telegram-parity features are
-being ported in subsequent phases (see the roadmap below).
+**Phase 4 — deeper quests: dependencies + on-quest checklists.** Builds on the
+Phase 1 runtime (gateway client, slash-command registration, interaction
+router, embed/button UI helpers, guild→holon binding, `@holons/core` context
+adapter) and the Phase 2–3 features. More telegram-parity features are being
+ported in subsequent phases (see the roadmap below).
 
 ## Architecture
 
@@ -60,7 +60,9 @@ it into both registration and routing.
 - `/balances [currency]` — who owes whom (credit-matrix balances).
 - `/checklist create|add|show|list` — checklists with per-item toggle buttons.
 - `/quests [type]` — list quests (optionally filtered); each line shows its id.
-- `/quest <id>` — reopen one quest as an interactive card.
+- `/quest show <id>` — reopen one quest as an interactive card.
+- `/quest depend <id> <on>` — add a cycle-guarded dependency between quests.
+- `/quest checklist <id> [items]` — show/create a checklist attached to a quest.
 - `/scores` — contribution leaderboard (REA + value equation, via core scoring).
 - `/settings` — read-only holon configuration overview.
 
@@ -88,7 +90,8 @@ Set `DISCORD_TOKEN`, `DISCORD_APP_ID`, and (for instant dev updates)
   (`/expense` `/balances`), checklists (`/checklist`), quest appreciation.
 - ✅ **Phase 3** — contribution scores (`/scores`), quest detail/filter
   (`/quest`, `/quests type:`), read-only settings (`/settings`).
-- ⬜ Quests deeper (time logging, on-quest checklists, scheduling/recurring).
-- ⬜ Tags, Roles/Onboarding, Scheduler/Reminders, Federation, Library,
-  editable Settings.
+- ✅ **Phase 4** — quest dependencies (`/quest depend`, cycle-guarded) and
+  on-quest checklists (`/quest checklist`), surfaced in the quest embed.
+- ⬜ Quests deeper still (time logging, scheduling/recurring reminders).
+- ⬜ Tags, Roles/Onboarding, Scheduler, Federation, Library, editable Settings.
 - ⬜ Long tail: announcements, RSVP, rounds/rotation, booking, capital game.

--- a/packages/discord-ui/eslint.config.js
+++ b/packages/discord-ui/eslint.config.js
@@ -1,0 +1,63 @@
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import prettier from 'eslint-plugin-prettier';
+import prettierConfig from 'eslint-config-prettier';
+
+export default tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: {
+        console: 'readonly',
+        process: 'readonly',
+        Buffer: 'readonly',
+        URL: 'readonly',
+        fetch: 'readonly',
+        setTimeout: 'readonly',
+        setInterval: 'readonly',
+        clearTimeout: 'readonly',
+        clearInterval: 'readonly',
+      },
+    },
+    plugins: { prettier },
+    rules: {
+      ...prettierConfig.rules,
+      'prettier/prettier': 'error',
+      'no-console': 'warn',
+      'no-empty': ['error', { allowEmptyCatch: true }],
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          args: 'none',
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrors: 'none',
+        },
+      ],
+      '@typescript-eslint/no-explicit-any': 'off',
+      'no-var': 'error',
+      'prefer-const': 'error',
+      'no-duplicate-imports': 'error',
+    },
+  },
+  {
+    files: ['**/*.test.ts'],
+    languageOptions: {
+      globals: {
+        describe: 'readonly',
+        it: 'readonly',
+        test: 'readonly',
+        expect: 'readonly',
+        beforeEach: 'readonly',
+        afterEach: 'readonly',
+      },
+    },
+    rules: { 'no-console': 'off' },
+  },
+  {
+    ignores: ['node_modules/**', 'dist/**', 'logs/**', 'coverage/**'],
+  }
+);

--- a/packages/discord-ui/package.json
+++ b/packages/discord-ui/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@holons/discord-ui",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Discord UI for Holons. Slash-command bot that calls into @holons/core for business logic.",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "dev": "tsx watch src/index.ts",
+    "register": "tsx src/runtime/registerCommands.ts",
+    "build": "tsc -p .",
+    "typecheck": "tsc -p . --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
+  },
+  "author": "Roberto Valenti",
+  "license": "AGPL-3.0-or-later",
+  "dependencies": {
+    "@holons/core": "workspace:*",
+    "discord.js": "^14.16.3",
+    "dotenv": "^17.2.3",
+    "holosphere": "1.3.0-alpha7",
+    "nostr-tools": "^2.17.2",
+    "winston": "^3.17.0"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.39.4",
+    "@types/node": "^22.19.17",
+    "eslint": "^9.35.0",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-prettier": "^5.5.4",
+    "prettier": "^3.6.2",
+    "tsx": "^4.21.0",
+    "typescript": "^5.7.3",
+    "typescript-eslint": "^8.20.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/discord-ui/src/context.test.ts
+++ b/packages/discord-ui/src/context.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { buildInvocationContext } from './context.js';
+import type { HoloStore, HolonBindingStore } from './types.js';
+
+const noopStore: HoloStore = {
+  get: async () => null,
+  getAll: async () => [],
+  put: async () => undefined,
+};
+
+function bindingsWith(map: Record<string, string>): HolonBindingStore {
+  return {
+    get: async guildId => map[guildId] ?? null,
+    set: async () => undefined,
+  };
+}
+
+describe('buildInvocationContext', () => {
+  it('resolves the bound holon for a guild', async () => {
+    const ctx = await buildInvocationContext({
+      holosphere: noopStore,
+      bindings: bindingsWith({ g1: 'holon-42' }),
+      guildId: 'g1',
+    });
+    expect(ctx.holonId).toBe('holon-42');
+  });
+
+  it('has a null holon when the guild is unbound', async () => {
+    const ctx = await buildInvocationContext({
+      holosphere: noopStore,
+      bindings: bindingsWith({}),
+      guildId: 'unknown',
+    });
+    expect(ctx.holonId).toBeNull();
+  });
+
+  it('builds a discord-sourced core CommandContext for the user', async () => {
+    const ctx = await buildInvocationContext({
+      holosphere: noopStore,
+      bindings: bindingsWith({ g1: 'holon-42' }),
+      guildId: 'g1',
+    });
+    const core = ctx.core({ id: 'u9', username: 'alice' });
+    expect(core.source).toBe('discord');
+    expect(core.userId).toBe('u9');
+    expect(core.userName).toBe('alice');
+    expect(core.holonId).toBe('holon-42');
+    expect(core.holosphere).toBe(noopStore);
+  });
+});

--- a/packages/discord-ui/src/context.ts
+++ b/packages/discord-ui/src/context.ts
@@ -1,0 +1,45 @@
+/**
+ * Builds the per-interaction `InvocationContext` handed to feature handlers.
+ * Resolves the originating guild's bound holon and exposes a `core()` factory
+ * that produces a `@holons/core` CommandContext for the acting user.
+ */
+import type { CommandContext } from '@holons/core/commands';
+import type {
+  DiscordUser,
+  HoloStore,
+  HolonBindingStore,
+  InvocationContext,
+} from './types.js';
+import { config } from './utils/config.js';
+import { log } from './utils/logger.js';
+
+export interface BuildContextOptions {
+  holosphere: HoloStore;
+  bindings: HolonBindingStore;
+  /** Originating guild id, or null for DMs / non-guild interactions. */
+  guildId: string | null;
+}
+
+export async function buildInvocationContext(
+  opts: BuildContextOptions
+): Promise<InvocationContext> {
+  const { holosphere, bindings, guildId } = opts;
+  const holonId = guildId ? await bindings.get(guildId) : null;
+
+  return {
+    holosphere,
+    holonId,
+    appName: config.appName,
+    bindings,
+    core(user: DiscordUser): CommandContext {
+      return {
+        source: 'discord',
+        userId: user.id,
+        userName: user.username,
+        holonId: holonId ?? undefined,
+        holosphere,
+        logger: log,
+      };
+    },
+  };
+}

--- a/packages/discord-ui/src/core/DiscordBot.ts
+++ b/packages/discord-ui/src/core/DiscordBot.ts
@@ -1,0 +1,65 @@
+/**
+ * Top-level Discord bot lifecycle: build holosphere + client, wire the router,
+ * register slash commands, and log in. Mirrors telegram-ui's `HolonsBotCore`
+ * but for Discord (and far lighter — feature wiring is static via the registry).
+ */
+import { Events } from 'discord.js';
+import createHoloSphere from '../createHoloSphere.js';
+import { createClient } from '../runtime/client.js';
+import { registerCommands } from '../runtime/registerCommands.js';
+import { attachRouter } from '../runtime/router.js';
+import type { HoloStore } from '../types.js';
+import { HolosphereHolonBindings } from '../ui/holonBinding.js';
+import { config } from '../utils/config.js';
+import { errorMessage } from '../utils/errorHandler.js';
+import { log } from '../utils/logger.js';
+
+export class DiscordBot {
+  private readonly client = createClient();
+  private readonly holosphere = createHoloSphere(
+    config.appName
+  ) as unknown as HoloStore;
+  private started = false;
+
+  async init(): Promise<void> {
+    if (this.started) return;
+    if (!config.token) {
+      throw new Error(
+        'DISCORD_TOKEN is not set — cannot start the Discord bot'
+      );
+    }
+
+    const bindings = new HolosphereHolonBindings(this.holosphere);
+    attachRouter(this.client, { holosphere: this.holosphere, bindings });
+
+    this.client.once(Events.ClientReady, readyClient => {
+      log.info('Discord bot ready', { user: readyClient.user.tag });
+    });
+
+    if (config.appId) {
+      try {
+        await registerCommands();
+      } catch (err) {
+        // Non-fatal: the bot still runs against previously-registered commands.
+        log.warn('Slash command registration failed', {
+          error: errorMessage(err),
+        });
+      }
+    } else {
+      log.warn('DISCORD_APP_ID not set — skipping slash command registration');
+    }
+
+    await this.client.login(config.token);
+    this.started = true;
+    log.info('Discord bot initialization completed');
+  }
+
+  async shutdown(): Promise<void> {
+    if (!this.started) return;
+    log.info('Shutting down Discord bot');
+    await this.client.destroy();
+    this.started = false;
+  }
+}
+
+export default DiscordBot;

--- a/packages/discord-ui/src/core/ServiceContainer.ts
+++ b/packages/discord-ui/src/core/ServiceContainer.ts
@@ -1,0 +1,145 @@
+/**
+ * Dependency-injection container for Discord-UI services. Ported from
+ * telegram-ui's `core/ServiceContainer.ts` (same lifecycle/dependency model)
+ * so feature services can be wired the same way in both bots.
+ */
+import { log } from '../utils/logger.js';
+
+export type ServiceFactory<T = unknown> = (
+  deps: Record<string, unknown>,
+  container: ServiceContainer
+) => T | Promise<T>;
+
+export interface ServiceRegistrationOptions {
+  /** Cache the produced instance as a singleton. Defaults to `true`. */
+  singleton?: boolean;
+  /** Names of services that must resolve before this factory runs. */
+  dependencies?: string[];
+}
+
+interface ServiceDefinition {
+  factory: ServiceFactory;
+  singleton: boolean;
+  dependencies: string[];
+}
+
+export interface Shutdownable {
+  shutdown(): Promise<void> | void;
+}
+
+export type DependencyGraph = Record<
+  string,
+  { dependencies: string[]; singleton: boolean; initialized: boolean }
+>;
+
+export class ServiceContainer {
+  public factories: Map<string, ServiceDefinition> = new Map();
+  public singletons: Map<string, unknown> = new Map();
+  public initialized: Set<string> = new Set();
+  private resolving: Set<string> = new Set();
+
+  register<T = unknown>(
+    name: string,
+    factory: ServiceFactory<T>,
+    options: ServiceRegistrationOptions = {}
+  ): void {
+    this.factories.set(name, {
+      factory: factory as ServiceFactory,
+      singleton: options.singleton !== false,
+      dependencies: options.dependencies || [],
+    });
+    log.debug('Service registered', {
+      name,
+      dependencies: options.dependencies,
+    });
+  }
+
+  async get<T = unknown>(name: string): Promise<T> {
+    if (this.singletons.has(name)) return this.singletons.get(name) as T;
+
+    const def = this.factories.get(name);
+    if (!def) throw new Error(`Service '${name}' not found`);
+
+    if (this.resolving.has(name)) {
+      throw new Error(`Circular dependency detected for service '${name}'`);
+    }
+    this.resolving.add(name);
+
+    try {
+      const deps: Record<string, unknown> = {};
+      for (const dep of def.dependencies) deps[dep] = await this.get(dep);
+
+      const instance = await def.factory(deps, this);
+      if (def.singleton) this.singletons.set(name, instance);
+      this.initialized.add(name);
+      log.debug('Service initialized', { name });
+      return instance as T;
+    } finally {
+      this.resolving.delete(name);
+    }
+  }
+
+  has(name: string): boolean {
+    return this.factories.has(name);
+  }
+
+  getServiceNames(): string[] {
+    return Array.from(this.factories.keys());
+  }
+
+  async initializeAll(): Promise<void> {
+    const names = this.getServiceNames();
+    log.info('Initializing all services', { count: names.length });
+    for (const name of names) await this.get(name);
+  }
+
+  validateDependencies(): void {
+    const errors: string[] = [];
+    for (const [name, def] of this.factories) {
+      for (const dep of def.dependencies) {
+        if (!this.has(dep)) {
+          errors.push(
+            `Service '${name}' depends on unregistered service '${dep}'`
+          );
+        }
+      }
+    }
+    if (errors.length > 0) {
+      throw new Error(`Dependency validation failed:\n${errors.join('\n')}`);
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    const promises: Promise<unknown>[] = [];
+    for (const [name, instance] of this.singletons) {
+      const candidate = instance as Partial<Shutdownable> | null | undefined;
+      if (candidate && typeof candidate.shutdown === 'function') {
+        promises.push(
+          Promise.resolve(candidate.shutdown()).catch((error: unknown) => {
+            log.error('Error shutting down service', {
+              name,
+              error: String(error),
+            });
+          })
+        );
+      }
+    }
+    await Promise.all(promises);
+    this.singletons.clear();
+    this.initialized.clear();
+  }
+
+  getDependencyGraph(): DependencyGraph {
+    const graph: DependencyGraph = {};
+    for (const [name, def] of this.factories) {
+      graph[name] = {
+        dependencies: def.dependencies,
+        singleton: def.singleton,
+        initialized: this.initialized.has(name),
+      };
+    }
+    return graph;
+  }
+}
+
+export default ServiceContainer;

--- a/packages/discord-ui/src/createHoloSphere.ts
+++ b/packages/discord-ui/src/createHoloSphere.ts
@@ -1,0 +1,45 @@
+/**
+ * Builds the bot's HoloSphere instance. Thin Node wrapper around
+ * `@holons/core/holosphere` that resolves a persistent private key
+ * (env -> stored -> generated), mirroring telegram-ui's `createHoloSphere.js`.
+ */
+import { createHoloSphere as coreCreateHoloSphere } from '@holons/core/holosphere';
+import { generateSecretKey } from 'nostr-tools';
+import { getOrCreateKey } from './utils/keyStorage.js';
+
+function generatePrivateKey(): string {
+  return Buffer.from(generateSecretKey()).toString('hex');
+}
+
+export interface CreateHoloSphereOptions {
+  privateKey?: string;
+  backend?: string;
+  logLevel?: string;
+}
+
+/**
+ * Create a configured HoloSphere instance.
+ *
+ * Private key priority:
+ *   1. `options.privateKey`
+ *   2. `process.env.HOLOSPHERE_PRIVATE_KEY`
+ *   3. stored key (or a freshly generated + persisted one)
+ */
+export function createHoloSphere(
+  appName = process.env.APPNAME || 'Holons',
+  options: CreateHoloSphereOptions = {}
+) {
+  const privateKey =
+    options.privateKey ||
+    process.env.HOLOSPHERE_PRIVATE_KEY ||
+    getOrCreateKey(appName, generatePrivateKey);
+
+  return coreCreateHoloSphere({
+    appName,
+    privateKey,
+    backend: options.backend || 'nostr',
+    logLevel: options.logLevel || 'INFO',
+  });
+}
+
+export default createHoloSphere;

--- a/packages/discord-ui/src/features/checklists.ts
+++ b/packages/discord-ui/src/features/checklists.ts
@@ -1,0 +1,244 @@
+/**
+ * Checklists feature. `/checklist create|add|show|list` with per-item toggle
+ * buttons. CRUD lives in `@holons/core/checklists` (store-based operations);
+ * this module supplies the holosphere store and renders the result.
+ */
+import {
+  MessageFlags,
+  SlashCommandBuilder,
+  type ChatInputCommandInteraction,
+  type MessageComponentInteraction,
+} from 'discord.js';
+import {
+  addItemsToChecklist,
+  createChecklist,
+  getAllChecklists,
+  getChecklist,
+  toggleItem,
+  type ChecklistStore,
+} from '@holons/core/checklists';
+import type { Feature, InvocationContext } from '../types.js';
+import type { ParsedCustomId } from '../ui/customId.js';
+import { checklistComponents, checklistEmbed } from '../ui/DiscordUI.js';
+import { checklistSummaryLine } from '../ui/format.js';
+
+const FEATURE_ID = 'checklists';
+
+function store(ctx: InvocationContext): ChecklistStore {
+  return ctx.holosphere as unknown as ChecklistStore;
+}
+
+/** Names must avoid `_` (core) and `:` (our customId separator). */
+function invalidName(name: string): boolean {
+  return !name || name.includes('_') || name.includes(':');
+}
+
+async function needHolon(
+  interaction: ChatInputCommandInteraction
+): Promise<void> {
+  await interaction.reply({
+    content:
+      'This server is not bound to a holon yet. Ask an admin to run `/holon bind`.',
+    flags: MessageFlags.Ephemeral,
+  });
+}
+
+export const checklistsFeature: Feature = {
+  id: FEATURE_ID,
+  commands: [
+    new SlashCommandBuilder()
+      .setName('checklist')
+      .setDescription('Create and manage checklists')
+      .addSubcommand(sub =>
+        sub
+          .setName('create')
+          .setDescription('Create a new checklist')
+          .addStringOption(opt =>
+            opt
+              .setName('name')
+              .setDescription('Checklist name')
+              .setRequired(true)
+          )
+          .addStringOption(opt =>
+            opt
+              .setName('items')
+              .setDescription('Comma-separated items')
+              .setRequired(false)
+          )
+      )
+      .addSubcommand(sub =>
+        sub
+          .setName('add')
+          .setDescription('Add items to a checklist')
+          .addStringOption(opt =>
+            opt
+              .setName('name')
+              .setDescription('Checklist name')
+              .setRequired(true)
+          )
+          .addStringOption(opt =>
+            opt
+              .setName('items')
+              .setDescription('Comma-separated items')
+              .setRequired(true)
+          )
+      )
+      .addSubcommand(sub =>
+        sub
+          .setName('show')
+          .setDescription('Show a checklist')
+          .addStringOption(opt =>
+            opt
+              .setName('name')
+              .setDescription('Checklist name')
+              .setRequired(true)
+          )
+      )
+      .addSubcommand(sub =>
+        sub.setName('list').setDescription('List all checklists')
+      ),
+  ],
+
+  async handleCommand(
+    interaction: ChatInputCommandInteraction,
+    ctx: InvocationContext
+  ): Promise<void> {
+    if (!ctx.holonId) {
+      await needHolon(interaction);
+      return;
+    }
+    const holonId = ctx.holonId;
+    const sub = interaction.options.getSubcommand();
+
+    if (sub === 'list') {
+      const all = await getAllChecklists(store(ctx), holonId);
+      if (all.length === 0) {
+        await interaction.reply({
+          content: 'No checklists yet. Create one with `/checklist create`.',
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+      await interaction.reply({
+        content: `**Checklists** (${all.length})\n\n${all
+          .map(checklistSummaryLine)
+          .join('\n')}`,
+      });
+      return;
+    }
+
+    const name = interaction.options.getString('name', true).trim();
+
+    if (sub === 'create') {
+      if (invalidName(name)) {
+        await interaction.reply({
+          content: 'Checklist names cannot contain `_` or `:`.',
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+      const result = await createChecklist(store(ctx), holonId, name, {
+        creator: interaction.user.id,
+      });
+      if (!result.ok) {
+        await interaction.reply({
+          content:
+            result.reason === 'exists'
+              ? `A checklist named \`${name}\` already exists.`
+              : 'Invalid checklist name.',
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+      const items = interaction.options.getString('items');
+      let checklist = result.checklist;
+      if (items) {
+        const added = await addItemsToChecklist(
+          store(ctx),
+          holonId,
+          name,
+          items
+        );
+        if (added.ok) checklist = added.checklist;
+      }
+      await interaction.reply({
+        embeds: [checklistEmbed(checklist)],
+        components: checklistComponents(FEATURE_ID, checklist),
+      });
+      return;
+    }
+
+    if (sub === 'add') {
+      const items = interaction.options.getString('items', true);
+      const result = await addItemsToChecklist(
+        store(ctx),
+        holonId,
+        name,
+        items
+      );
+      if (!result.ok) {
+        await interaction.reply({
+          content:
+            result.reason === 'not_found'
+              ? `No checklist named \`${name}\`. Create it with \`/checklist create\`.`
+              : 'No valid items to add.',
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+      await interaction.reply({
+        embeds: [checklistEmbed(result.checklist)],
+        components: checklistComponents(FEATURE_ID, result.checklist),
+      });
+      return;
+    }
+
+    // show
+    const checklist = await getChecklist(store(ctx), holonId, name);
+    if (!checklist) {
+      await interaction.reply({
+        content: `No checklist named \`${name}\`.`,
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+    await interaction.reply({
+      embeds: [checklistEmbed(checklist)],
+      components: checklistComponents(FEATURE_ID, checklist),
+    });
+  },
+
+  async handleComponent(
+    interaction: MessageComponentInteraction,
+    parsed: ParsedCustomId,
+    ctx: InvocationContext
+  ): Promise<void> {
+    if (!ctx.holonId) {
+      await interaction.reply({
+        content: 'This server is no longer bound to a holon.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+    if (parsed.action !== 'toggle') return;
+
+    const [name, indexRaw] = parsed.args;
+    const checklist = await toggleItem(
+      store(ctx),
+      ctx.holonId,
+      name,
+      Number(indexRaw)
+    );
+    if (!checklist) {
+      await interaction.reply({
+        content: 'That checklist item no longer exists.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+    await interaction.update({
+      embeds: [checklistEmbed(checklist)],
+      components: checklistComponents(FEATURE_ID, checklist),
+    });
+  },
+};

--- a/packages/discord-ui/src/features/expenses.ts
+++ b/packages/discord-ui/src/features/expenses.ts
@@ -1,0 +1,216 @@
+/**
+ * Expenses feature. `/expense` records a shared cost; `/balances` shows who
+ * owes whom. All accounting (expense creation, currency normalisation, the
+ * credit-matrix balance computation) lives in `@holons/core/expenses`.
+ */
+import {
+  MessageFlags,
+  EmbedBuilder,
+  SlashCommandBuilder,
+  type ChatInputCommandInteraction,
+} from 'discord.js';
+import {
+  computeBalances,
+  createExpense,
+  normalizeCurrency,
+  type Expense,
+} from '@holons/core/expenses';
+import {
+  ensureUserProfile,
+  getUsers,
+  type UserDB,
+  type UserProfile,
+} from '@holons/core/users';
+import type { Feature, InvocationContext } from '../types.js';
+import { ACCENT } from '../ui/DiscordUI.js';
+import { balancesView, formatAmount, memberName } from '../ui/format.js';
+import { userLike } from './users.js';
+
+const FEATURE_ID = 'expenses';
+const EXPENSES_BUCKET = 'expenses';
+
+function generateExpenseId(): string {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2, 5);
+}
+
+function nameResolver(users: UserProfile[]): (id: string | number) => string {
+  const byId = new Map(users.map(u => [String(u.id), memberName(u)]));
+  return id => byId.get(String(id)) ?? String(id);
+}
+
+async function needHolon(
+  interaction: ChatInputCommandInteraction
+): Promise<void> {
+  await interaction.reply({
+    content:
+      'This server is not bound to a holon yet. Ask an admin to run `/holon bind`.',
+    flags: MessageFlags.Ephemeral,
+  });
+}
+
+export const expensesFeature: Feature = {
+  id: FEATURE_ID,
+  commands: [
+    new SlashCommandBuilder()
+      .setName('expense')
+      .setDescription('Record a shared expense')
+      .addNumberOption(opt =>
+        opt.setName('amount').setDescription('Amount paid').setRequired(true)
+      )
+      .addStringOption(opt =>
+        opt
+          .setName('description')
+          .setDescription('What it was for')
+          .setRequired(true)
+      )
+      .addStringOption(opt =>
+        opt
+          .setName('currency')
+          .setDescription('Currency code (default EUR)')
+          .setRequired(false)
+      )
+      .addStringOption(opt =>
+        opt
+          .setName('split')
+          .setDescription('Who shares the cost (default: everyone)')
+          .setRequired(false)
+          .addChoices(
+            { name: 'everyone', value: 'everyone' },
+            { name: 'just me', value: 'me' }
+          )
+      ),
+    new SlashCommandBuilder()
+      .setName('balances')
+      .setDescription('Show who owes whom in this holon')
+      .addStringOption(opt =>
+        opt
+          .setName('currency')
+          .setDescription('Limit to one currency')
+          .setRequired(false)
+      ),
+  ],
+
+  async handleCommand(
+    interaction: ChatInputCommandInteraction,
+    ctx: InvocationContext
+  ): Promise<void> {
+    if (!ctx.holonId) {
+      await needHolon(interaction);
+      return;
+    }
+
+    if (interaction.commandName === 'expense') {
+      await recordExpense(interaction, ctx, ctx.holonId);
+      return;
+    }
+    await showBalances(interaction, ctx, ctx.holonId);
+  },
+};
+
+async function recordExpense(
+  interaction: ChatInputCommandInteraction,
+  ctx: InvocationContext,
+  holonId: string
+): Promise<void> {
+  const db = ctx.holosphere as unknown as UserDB;
+  // Make sure the payer is a member so they appear in balances.
+  await ensureUserProfile(db, userLike(interaction.user), holonId);
+
+  const amount = interaction.options.getNumber('amount', true);
+  const description = interaction.options.getString('description', true);
+  const currency = interaction.options.getString('currency') ?? 'EUR';
+  const split = interaction.options.getString('split') ?? 'everyone';
+  const paidBy = interaction.user.id;
+
+  let splitWith: Array<string | number>;
+  if (split === 'me') {
+    splitWith = [paidBy];
+  } else {
+    const members = await getUsers(db, holonId);
+    splitWith = members.length > 0 ? members.map(m => m.id) : [holonId];
+  }
+
+  const expense = createExpense({
+    id: generateExpenseId(),
+    holonId,
+    amount,
+    currency,
+    description,
+    paidBy,
+    splitWith,
+  });
+
+  if (!expense) {
+    await interaction.reply({
+      content: 'Amount must be a positive number.',
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  await ctx.holosphere.put(holonId, EXPENSES_BUCKET, expense);
+
+  const cur = normalizeCurrency(expense.currency).toUpperCase();
+  const shares = expense.splitWith.length;
+  const embed = new EmbedBuilder()
+    .setColor(ACCENT)
+    .setTitle('💸 Expense recorded')
+    .setDescription(`**${expense.description}**`)
+    .addFields(
+      {
+        name: 'Amount',
+        value: `${formatAmount(expense.amount)} ${cur}`,
+        inline: true,
+      },
+      {
+        name: 'Paid by',
+        value: interaction.user.username,
+        inline: true,
+      },
+      {
+        name: 'Split between',
+        value: `${shares} ${shares === 1 ? 'person' : 'people'}`,
+        inline: true,
+      }
+    );
+  await interaction.reply({ embeds: [embed] });
+}
+
+async function showBalances(
+  interaction: ChatInputCommandInteraction,
+  ctx: InvocationContext,
+  holonId: string
+): Promise<void> {
+  const db = ctx.holosphere as unknown as UserDB;
+  const expenses = ((await ctx.holosphere.getAll(holonId, EXPENSES_BUCKET)) ??
+    []) as Expense[];
+  const users = await getUsers(db, holonId);
+
+  if (expenses.length === 0) {
+    await interaction.reply({
+      content: 'No expenses recorded yet. Add one with `/expense`.',
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const nameFor = nameResolver(users);
+  const requested = interaction.options.getString('currency');
+  const currencies = requested
+    ? [normalizeCurrency(requested)]
+    : [...new Set(expenses.map(e => normalizeCurrency(e.currency)))];
+
+  const sections = currencies.map(currency => {
+    const result = computeBalances(expenses, users, currency);
+    return `__${currency.toUpperCase()}__\n${balancesView(result, currency, nameFor)}`;
+  });
+
+  await interaction.reply({
+    embeds: [
+      new EmbedBuilder()
+        .setColor(ACCENT)
+        .setTitle('⚖️ Balances')
+        .setDescription(sections.join('\n\n')),
+    ],
+  });
+}

--- a/packages/discord-ui/src/features/holon.ts
+++ b/packages/discord-ui/src/features/holon.ts
@@ -1,0 +1,69 @@
+/**
+ * `/holon` — bind a Discord server to a Holons holon (community). Every other
+ * command operates on the bound holon, so this is the first thing an admin
+ * runs in a new server.
+ */
+import {
+  MessageFlags,
+  SlashCommandBuilder,
+  type ChatInputCommandInteraction,
+} from 'discord.js';
+import type { Feature, InvocationContext } from '../types.js';
+
+export const holonFeature: Feature = {
+  id: 'holon',
+  commands: [
+    new SlashCommandBuilder()
+      .setName('holon')
+      .setDescription('Manage which Holons community this server is bound to')
+      .addSubcommand(sub =>
+        sub
+          .setName('bind')
+          .setDescription('Bind this server to a holon id')
+          .addStringOption(opt =>
+            opt
+              .setName('id')
+              .setDescription('The holon (community) id')
+              .setRequired(true)
+          )
+      )
+      .addSubcommand(sub =>
+        sub
+          .setName('current')
+          .setDescription('Show the holon this server is bound to')
+      ),
+  ],
+
+  async handleCommand(
+    interaction: ChatInputCommandInteraction,
+    ctx: InvocationContext
+  ): Promise<void> {
+    if (!interaction.guildId) {
+      await interaction.reply({
+        content: 'This command can only be used in a server.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const sub = interaction.options.getSubcommand();
+
+    if (sub === 'bind') {
+      const holonId = interaction.options.getString('id', true).trim();
+      await ctx.bindings.set(interaction.guildId, holonId);
+      await interaction.reply({
+        content: `✅ This server is now bound to holon \`${holonId}\`.`,
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    // sub === 'current'
+    await interaction.reply({
+      content: ctx.holonId
+        ? `This server is bound to holon \`${ctx.holonId}\`.`
+        : 'This server is not bound to any holon yet. Use `/holon bind`.',
+      flags: MessageFlags.Ephemeral,
+    });
+  },
+};

--- a/packages/discord-ui/src/features/index.ts
+++ b/packages/discord-ui/src/features/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Feature registry. Adding a feature here wires its slash commands into
+ * registration and its handlers into the router — no other changes needed.
+ */
+import type { Feature } from '../types.js';
+import { holonFeature } from './holon.js';
+import { questsFeature } from './quests.js';
+import { shoppingFeature } from './shopping.js';
+
+export const features: Feature[] = [
+  holonFeature,
+  questsFeature,
+  shoppingFeature,
+];
+
+/** Map of slash command name -> owning feature. */
+export function commandIndex(list: Feature[] = features): Map<string, Feature> {
+  const index = new Map<string, Feature>();
+  for (const feature of list) {
+    for (const command of feature.commands) index.set(command.name, feature);
+  }
+  return index;
+}
+
+/** Map of customId namespace (feature id) -> owning feature. */
+export function featureIndex(list: Feature[] = features): Map<string, Feature> {
+  const index = new Map<string, Feature>();
+  for (const feature of list) index.set(feature.id, feature);
+  return index;
+}

--- a/packages/discord-ui/src/features/index.ts
+++ b/packages/discord-ui/src/features/index.ts
@@ -7,6 +7,8 @@ import { checklistsFeature } from './checklists.js';
 import { expensesFeature } from './expenses.js';
 import { holonFeature } from './holon.js';
 import { questsFeature } from './quests.js';
+import { scoresFeature } from './scores.js';
+import { settingsFeature } from './settings.js';
 import { shoppingFeature } from './shopping.js';
 import { usersFeature } from './users.js';
 
@@ -17,6 +19,8 @@ export const features: Feature[] = [
   shoppingFeature,
   expensesFeature,
   checklistsFeature,
+  scoresFeature,
+  settingsFeature,
 ];
 
 /** Map of slash command name -> owning feature. */

--- a/packages/discord-ui/src/features/index.ts
+++ b/packages/discord-ui/src/features/index.ts
@@ -3,14 +3,20 @@
  * registration and its handlers into the router — no other changes needed.
  */
 import type { Feature } from '../types.js';
+import { checklistsFeature } from './checklists.js';
+import { expensesFeature } from './expenses.js';
 import { holonFeature } from './holon.js';
 import { questsFeature } from './quests.js';
 import { shoppingFeature } from './shopping.js';
+import { usersFeature } from './users.js';
 
 export const features: Feature[] = [
   holonFeature,
+  usersFeature,
   questsFeature,
   shoppingFeature,
+  expensesFeature,
+  checklistsFeature,
 ];
 
 /** Map of slash command name -> owning feature. */

--- a/packages/discord-ui/src/features/quests.ts
+++ b/packages/discord-ui/src/features/quests.ts
@@ -19,12 +19,24 @@ import {
   saveTaskToHolon,
   toggleAppreciation,
   toggleParticipant,
+  wouldCreateDependencyCycle,
   type Quest,
   type QuestInitiator,
 } from '@holons/core/tasks';
+import {
+  createChecklist,
+  getChecklist,
+  addItemsToChecklist,
+  type ChecklistStore,
+} from '@holons/core/checklists';
 import type { DiscordUser, Feature, InvocationContext } from '../types.js';
 import type { ParsedCustomId } from '../ui/customId.js';
-import { questComponents, questEmbed } from '../ui/DiscordUI.js';
+import {
+  checklistComponents,
+  checklistEmbed,
+  questComponents,
+  questEmbed,
+} from '../ui/DiscordUI.js';
 import { questSummaryLine } from '../ui/format.js';
 
 const FEATURE_ID = 'quests';
@@ -104,9 +116,45 @@ export const questsFeature: Feature = {
       ),
     new SlashCommandBuilder()
       .setName('quest')
-      .setDescription('Show one quest as an interactive card')
-      .addStringOption(opt =>
-        opt.setName('id').setDescription('Quest id').setRequired(true)
+      .setDescription('Work with a single quest')
+      .addSubcommand(sub =>
+        sub
+          .setName('show')
+          .setDescription('Show one quest as an interactive card')
+          .addStringOption(opt =>
+            opt.setName('id').setDescription('Quest id').setRequired(true)
+          )
+      )
+      .addSubcommand(sub =>
+        sub
+          .setName('depend')
+          .setDescription('Make one quest depend on another')
+          .addStringOption(opt =>
+            opt
+              .setName('id')
+              .setDescription('The quest that depends')
+              .setRequired(true)
+          )
+          .addStringOption(opt =>
+            opt
+              .setName('on')
+              .setDescription('The quest it must come after')
+              .setRequired(true)
+          )
+      )
+      .addSubcommand(sub =>
+        sub
+          .setName('checklist')
+          .setDescription('Show or create a checklist attached to a quest')
+          .addStringOption(opt =>
+            opt.setName('id').setDescription('Quest id').setRequired(true)
+          )
+          .addStringOption(opt =>
+            opt
+              .setName('items')
+              .setDescription('Comma-separated items to add')
+              .setRequired(false)
+          )
       ),
   ],
 
@@ -125,7 +173,14 @@ export const questsFeature: Feature = {
     }
 
     if (interaction.commandName === 'quest') {
-      await showQuest(interaction, ctx, ctx.holonId);
+      const sub = interaction.options.getSubcommand();
+      if (sub === 'depend') {
+        await dependQuest(interaction, ctx, ctx.holonId);
+      } else if (sub === 'checklist') {
+        await questChecklist(interaction, ctx, ctx.holonId);
+      } else {
+        await showQuest(interaction, ctx, ctx.holonId);
+      }
       return;
     }
 
@@ -280,7 +335,7 @@ async function listQuests(
   const heading = typeFilter ? `**Quests · ${typeFilter}**` : '**Quests**';
 
   await interaction.reply({
-    content: `${heading} (${active.length})\n\n${lines.join('\n')}${more}\n\n_Open one with_ \`/quest id:<id>\``,
+    content: `${heading} (${active.length})\n\n${lines.join('\n')}${more}\n\n_Open one with_ \`/quest show id:<id>\``,
   });
 }
 
@@ -307,5 +362,122 @@ async function showQuest(
   await interaction.reply({
     embeds: [questEmbed(quest)],
     components: questComponents(FEATURE_ID, quest),
+  });
+}
+
+/**
+ * `/quest depend` — record that `id` must come after `on`. Rejected if it
+ * would close a cycle (the dependency graph must stay a DAG), using the core
+ * `wouldCreateDependencyCycle` guard against the full quest set.
+ */
+async function dependQuest(
+  interaction: ChatInputCommandInteraction,
+  ctx: InvocationContext,
+  holonId: string
+): Promise<void> {
+  const fromId = interaction.options.getString('id', true).trim();
+  const onId = interaction.options.getString('on', true).trim();
+
+  if (fromId === onId) {
+    await interaction.reply({
+      content: 'A quest cannot depend on itself.',
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const all = ((await ctx.holosphere.getAll(holonId, QUESTS_BUCKET)) ??
+    []) as Quest[];
+  const quest = all.find(q => String(q.id) === fromId && !q._deleted);
+  const dep = all.find(q => String(q.id) === onId && !q._deleted);
+  if (!quest || !dep) {
+    await interaction.reply({
+      content: `Unknown quest id: \`${!quest ? fromId : onId}\`.`,
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  if (wouldCreateDependencyCycle(all, fromId, onId)) {
+    await interaction.reply({
+      content: '⛔ That would create a dependency cycle.',
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const deps = ((quest.dependencies as string[] | undefined) ?? []).map(String);
+  if (deps.includes(onId)) {
+    await interaction.reply({
+      content: `\`${quest.title}\` already depends on \`${dep.title}\`.`,
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+  quest.dependencies = [...deps, onId];
+  await saveTaskToHolon(ctx.holosphere, holonId, quest);
+
+  await interaction.reply({
+    embeds: [questEmbed(quest)],
+    components: questComponents(FEATURE_ID, quest),
+  });
+}
+
+/**
+ * `/quest checklist` — show (or lazily create) a checklist attached to a
+ * quest. The checklist id is the quest id (base36, colon/underscore-free), so
+ * it links cleanly and its toggle buttons route to the checklists feature.
+ */
+async function questChecklist(
+  interaction: ChatInputCommandInteraction,
+  ctx: InvocationContext,
+  holonId: string
+): Promise<void> {
+  const questId = interaction.options.getString('id', true).trim();
+  const quest = (await ctx.holosphere.get(
+    holonId,
+    QUESTS_BUCKET,
+    questId
+  )) as Quest | null;
+  if (!quest || quest._deleted) {
+    await interaction.reply({
+      content: `No quest with id \`${questId}\`.`,
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const store = ctx.holosphere as unknown as ChecklistStore;
+  const name = String(quest.id);
+  let checklist = await getChecklist(store, holonId, name);
+
+  if (!checklist) {
+    const created = await createChecklist(store, holonId, name, {
+      type: 'quest',
+      questId: name,
+      parentTitle: quest.title,
+      creator: interaction.user.id,
+    });
+    if (!created.ok) {
+      await interaction.reply({
+        content: 'Could not create a checklist for this quest.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+    checklist = created.checklist;
+    quest.checklistId = name;
+    await saveTaskToHolon(ctx.holosphere, holonId, quest);
+  }
+
+  const items = interaction.options.getString('items');
+  if (items) {
+    const added = await addItemsToChecklist(store, holonId, name, items);
+    if (added.ok) checklist = added.checklist;
+  }
+
+  await interaction.reply({
+    embeds: [checklistEmbed(checklist)],
+    components: checklistComponents('checklists', checklist),
   });
 }

--- a/packages/discord-ui/src/features/quests.ts
+++ b/packages/discord-ui/src/features/quests.ts
@@ -1,0 +1,246 @@
+/**
+ * Quests/tasks feature. Slash commands create quests of each type; buttons on
+ * the resulting message let members join/leave and mark the quest complete.
+ *
+ * All domain logic (record creation, participant toggling, completion rules,
+ * persistence) lives in `@holons/core/tasks` — this module only translates
+ * Discord interactions into those calls and renders the result.
+ */
+import {
+  MessageFlags,
+  SlashCommandBuilder,
+  type ChatInputCommandInteraction,
+  type MessageComponentInteraction,
+} from 'discord.js';
+import {
+  applyTaskCompletion,
+  createMarketItem,
+  createTask,
+  saveTaskToHolon,
+  toggleParticipant,
+  type Quest,
+  type QuestInitiator,
+} from '@holons/core/tasks';
+import type { DiscordUser, Feature, InvocationContext } from '../types.js';
+import type { ParsedCustomId } from '../ui/customId.js';
+import { questComponents, questEmbed } from '../ui/DiscordUI.js';
+import { questSummaryLine } from '../ui/format.js';
+
+const FEATURE_ID = 'quests';
+const QUESTS_BUCKET = 'quests';
+
+/** Quest ids must avoid ':' (customId separator) and '_' (legacy parsing). */
+function generateQuestId(): string {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2, 5);
+}
+
+function userFrom(interaction: {
+  user: { id: string; username: string };
+}): DiscordUser {
+  return { id: interaction.user.id, username: interaction.user.username };
+}
+
+function initiatorFrom(user: DiscordUser): QuestInitiator {
+  return { id: user.id, username: user.username, firstName: user.username };
+}
+
+async function replyNeedHolon(
+  interaction: ChatInputCommandInteraction
+): Promise<void> {
+  await interaction.reply({
+    content:
+      'This server is not bound to a holon yet. Ask an admin to run `/holon bind`.',
+    flags: MessageFlags.Ephemeral,
+  });
+}
+
+function buildCreateCommand(
+  name: string,
+  description: string,
+  withLocation: boolean
+): SlashCommandBuilder {
+  const builder = new SlashCommandBuilder()
+    .setName(name)
+    .setDescription(description)
+    .addStringOption(opt =>
+      opt.setName('title').setDescription('Short title').setRequired(true)
+    )
+    .addStringOption(opt =>
+      opt
+        .setName('description')
+        .setDescription('More detail')
+        .setRequired(false)
+    );
+  if (withLocation) {
+    builder.addStringOption(opt =>
+      opt.setName('location').setDescription('Where').setRequired(false)
+    );
+  }
+  return builder as SlashCommandBuilder;
+}
+
+export const questsFeature: Feature = {
+  id: FEATURE_ID,
+  commands: [
+    buildCreateCommand('task', 'Create a task the community can pick up', true),
+    buildCreateCommand('event', 'Create a scheduled event', true),
+    buildCreateCommand('offer', 'Offer a resource or skill', false),
+    buildCreateCommand('request', 'Request help from the community', false),
+    new SlashCommandBuilder()
+      .setName('quests')
+      .setDescription('List quests in this holon'),
+  ],
+
+  async handleCommand(
+    interaction: ChatInputCommandInteraction,
+    ctx: InvocationContext
+  ): Promise<void> {
+    if (!ctx.holonId) {
+      await replyNeedHolon(interaction);
+      return;
+    }
+
+    if (interaction.commandName === 'quests') {
+      await listQuests(interaction, ctx, ctx.holonId);
+      return;
+    }
+
+    await createQuest(interaction, ctx, ctx.holonId, interaction.commandName);
+  },
+
+  async handleComponent(
+    interaction: MessageComponentInteraction,
+    parsed: ParsedCustomId,
+    ctx: InvocationContext
+  ): Promise<void> {
+    if (!ctx.holonId) {
+      await interaction.reply({
+        content: 'This server is no longer bound to a holon.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+    const [questId] = parsed.args;
+    const quest = (await ctx.holosphere.get(
+      ctx.holonId,
+      QUESTS_BUCKET,
+      questId
+    )) as Quest | null;
+
+    if (!quest) {
+      await interaction.reply({
+        content: 'That quest no longer exists.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const user = userFrom(interaction);
+
+    if (parsed.action === 'toggle') {
+      const updated = toggleParticipant(quest, initiatorFrom(user));
+      await saveTaskToHolon(ctx.holosphere, ctx.holonId, updated);
+      await interaction.update({
+        embeds: [questEmbed(updated)],
+        components: questComponents(FEATURE_ID, updated),
+      });
+      return;
+    }
+
+    if (parsed.action === 'complete') {
+      const result = applyTaskCompletion(quest, user.id);
+      if (!result.ok) {
+        await interaction.reply({
+          content:
+            result.reason === 'forbidden'
+              ? 'Only the initiator or a participant can complete this quest.'
+              : `Cannot complete this quest (${result.reason}).`,
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+      await saveTaskToHolon(ctx.holosphere, ctx.holonId, result.task);
+      await interaction.update({
+        embeds: [questEmbed(result.task)],
+        components: questComponents(FEATURE_ID, result.task),
+      });
+    }
+  },
+};
+
+async function createQuest(
+  interaction: ChatInputCommandInteraction,
+  ctx: InvocationContext,
+  holonId: string,
+  type: string
+): Promise<void> {
+  const title = interaction.options.getString('title', true);
+  const description = interaction.options.getString('description') ?? undefined;
+  const location = interaction.options.getString('location') ?? undefined;
+  const user = userFrom(interaction);
+
+  let quest: Quest;
+  if (type === 'offer' || type === 'request') {
+    quest = createMarketItem({
+      holonId,
+      initiator: initiatorFrom(user),
+      kind: type,
+      title,
+      description,
+    });
+  } else {
+    quest = createTask({
+      holonId,
+      initiator: initiatorFrom(user),
+      title,
+      type,
+    });
+    if (description) quest.description = description;
+    if (location) quest.location = location;
+  }
+  quest.id = generateQuestId();
+
+  await saveTaskToHolon(ctx.holosphere, holonId, quest);
+  await interaction.reply({
+    embeds: [questEmbed(quest)],
+    components: questComponents(FEATURE_ID, quest),
+  });
+}
+
+async function listQuests(
+  interaction: ChatInputCommandInteraction,
+  ctx: InvocationContext,
+  holonId: string
+): Promise<void> {
+  const all = ((await ctx.holosphere.getAll(holonId, QUESTS_BUCKET)) ??
+    []) as Quest[];
+  const active = all
+    .filter(q => q && !q._deleted)
+    .sort((a, b) => {
+      // Ongoing before completed, then newest first.
+      const ac = a.status === 'completed' ? 1 : 0;
+      const bc = b.status === 'completed' ? 1 : 0;
+      if (ac !== bc) return ac - bc;
+      return String(b.created ?? '').localeCompare(String(a.created ?? ''));
+    });
+
+  if (active.length === 0) {
+    await interaction.reply({
+      content:
+        'No quests yet. Create one with `/task`, `/event`, `/offer` or `/request`.',
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const shown = active.slice(0, 25);
+  const lines = shown.map(questSummaryLine);
+  const more =
+    active.length > shown.length
+      ? `\n\n…and ${active.length - shown.length} more.`
+      : '';
+
+  await interaction.reply({
+    content: `**Quests** (${active.length})\n\n${lines.join('\n')}${more}`,
+  });
+}

--- a/packages/discord-ui/src/features/quests.ts
+++ b/packages/discord-ui/src/features/quests.ts
@@ -89,7 +89,25 @@ export const questsFeature: Feature = {
     buildCreateCommand('request', 'Request help from the community', false),
     new SlashCommandBuilder()
       .setName('quests')
-      .setDescription('List quests in this holon'),
+      .setDescription('List quests in this holon')
+      .addStringOption(opt =>
+        opt
+          .setName('type')
+          .setDescription('Only show one kind')
+          .setRequired(false)
+          .addChoices(
+            { name: 'task', value: 'task' },
+            { name: 'event', value: 'event' },
+            { name: 'offer', value: 'offer' },
+            { name: 'request', value: 'request' }
+          )
+      ),
+    new SlashCommandBuilder()
+      .setName('quest')
+      .setDescription('Show one quest as an interactive card')
+      .addStringOption(opt =>
+        opt.setName('id').setDescription('Quest id').setRequired(true)
+      ),
   ],
 
   async handleCommand(
@@ -103,6 +121,11 @@ export const questsFeature: Feature = {
 
     if (interaction.commandName === 'quests') {
       await listQuests(interaction, ctx, ctx.holonId);
+      return;
+    }
+
+    if (interaction.commandName === 'quest') {
+      await showQuest(interaction, ctx, ctx.holonId);
       return;
     }
 
@@ -223,10 +246,12 @@ async function listQuests(
   ctx: InvocationContext,
   holonId: string
 ): Promise<void> {
+  const typeFilter = interaction.options.getString('type');
   const all = ((await ctx.holosphere.getAll(holonId, QUESTS_BUCKET)) ??
     []) as Quest[];
   const active = all
     .filter(q => q && !q._deleted)
+    .filter(q => !typeFilter || (q.type ?? 'task') === typeFilter)
     .sort((a, b) => {
       // Ongoing before completed, then newest first.
       const ac = a.status === 'completed' ? 1 : 0;
@@ -237,21 +262,50 @@ async function listQuests(
 
   if (active.length === 0) {
     await interaction.reply({
-      content:
-        'No quests yet. Create one with `/task`, `/event`, `/offer` or `/request`.',
+      content: typeFilter
+        ? `No ${typeFilter} quests yet.`
+        : 'No quests yet. Create one with `/task`, `/event`, `/offer` or `/request`.',
       flags: MessageFlags.Ephemeral,
     });
     return;
   }
 
   const shown = active.slice(0, 25);
-  const lines = shown.map(questSummaryLine);
+  // Append the id so members can reopen the interactive card via `/quest`.
+  const lines = shown.map(q => `${questSummaryLine(q)}  \`${q.id}\``);
   const more =
     active.length > shown.length
       ? `\n\n…and ${active.length - shown.length} more.`
       : '';
+  const heading = typeFilter ? `**Quests · ${typeFilter}**` : '**Quests**';
 
   await interaction.reply({
-    content: `**Quests** (${active.length})\n\n${lines.join('\n')}${more}`,
+    content: `${heading} (${active.length})\n\n${lines.join('\n')}${more}\n\n_Open one with_ \`/quest id:<id>\``,
+  });
+}
+
+async function showQuest(
+  interaction: ChatInputCommandInteraction,
+  ctx: InvocationContext,
+  holonId: string
+): Promise<void> {
+  const questId = interaction.options.getString('id', true).trim();
+  const quest = (await ctx.holosphere.get(
+    holonId,
+    QUESTS_BUCKET,
+    questId
+  )) as Quest | null;
+
+  if (!quest || quest._deleted) {
+    await interaction.reply({
+      content: `No quest with id \`${questId}\`.`,
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  await interaction.reply({
+    embeds: [questEmbed(quest)],
+    components: questComponents(FEATURE_ID, quest),
   });
 }

--- a/packages/discord-ui/src/features/quests.ts
+++ b/packages/discord-ui/src/features/quests.ts
@@ -17,6 +17,7 @@ import {
   createMarketItem,
   createTask,
   saveTaskToHolon,
+  toggleAppreciation,
   toggleParticipant,
   type Quest,
   type QuestInitiator,
@@ -139,6 +140,16 @@ export const questsFeature: Feature = {
 
     if (parsed.action === 'toggle') {
       const updated = toggleParticipant(quest, initiatorFrom(user));
+      await saveTaskToHolon(ctx.holosphere, ctx.holonId, updated);
+      await interaction.update({
+        embeds: [questEmbed(updated)],
+        components: questComponents(FEATURE_ID, updated),
+      });
+      return;
+    }
+
+    if (parsed.action === 'appreciate') {
+      const updated = toggleAppreciation(quest, initiatorFrom(user));
       await saveTaskToHolon(ctx.holosphere, ctx.holonId, updated);
       await interaction.update({
         embeds: [questEmbed(updated)],

--- a/packages/discord-ui/src/features/registry.test.ts
+++ b/packages/discord-ui/src/features/registry.test.ts
@@ -13,6 +13,11 @@ describe('feature registry', () => {
     expect(index.get('quests')?.id).toBe('quests');
     expect(index.get('shopping')?.id).toBe('shopping');
     expect(index.get('holon')?.id).toBe('holon');
+    expect(index.get('join')?.id).toBe('members');
+    expect(index.get('members')?.id).toBe('members');
+    expect(index.get('expense')?.id).toBe('expenses');
+    expect(index.get('balances')?.id).toBe('expenses');
+    expect(index.get('checklist')?.id).toBe('checklists');
   });
 
   it('maps every feature id to its feature', () => {

--- a/packages/discord-ui/src/features/registry.test.ts
+++ b/packages/discord-ui/src/features/registry.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { features, commandIndex, featureIndex } from './index.js';
+
+describe('feature registry', () => {
+  it('registers unique slash command names', () => {
+    const names = features.flatMap(f => f.commands.map(c => c.name));
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('maps every command name to its owning feature', () => {
+    const index = commandIndex();
+    expect(index.get('task')?.id).toBe('quests');
+    expect(index.get('quests')?.id).toBe('quests');
+    expect(index.get('shopping')?.id).toBe('shopping');
+    expect(index.get('holon')?.id).toBe('holon');
+  });
+
+  it('maps every feature id to its feature', () => {
+    const index = featureIndex();
+    for (const feature of features) {
+      expect(index.get(feature.id)).toBe(feature);
+    }
+  });
+
+  it('produces valid command JSON for registration', () => {
+    for (const feature of features) {
+      for (const command of feature.commands) {
+        const json = command.toJSON() as { name: string; description: string };
+        expect(json.name).toMatch(/^[-_\p{L}\p{N}]{1,32}$/u);
+        expect(typeof json.description).toBe('string');
+      }
+    }
+  });
+});

--- a/packages/discord-ui/src/features/registry.test.ts
+++ b/packages/discord-ui/src/features/registry.test.ts
@@ -18,6 +18,9 @@ describe('feature registry', () => {
     expect(index.get('expense')?.id).toBe('expenses');
     expect(index.get('balances')?.id).toBe('expenses');
     expect(index.get('checklist')?.id).toBe('checklists');
+    expect(index.get('quest')?.id).toBe('quests');
+    expect(index.get('scores')?.id).toBe('scores');
+    expect(index.get('settings')?.id).toBe('settings');
   });
 
   it('maps every feature id to its feature', () => {

--- a/packages/discord-ui/src/features/scores.ts
+++ b/packages/discord-ui/src/features/scores.ts
@@ -1,0 +1,92 @@
+/**
+ * Scores feature. `/scores` shows a contribution leaderboard for the holon.
+ *
+ * The whole scoring pipeline is core: an REA event store + aggregator feed
+ * `computeHolonUserScores`, weighted by the holon's value equation. This module
+ * only wires holosphere into those and renders the ranking.
+ */
+import {
+  EmbedBuilder,
+  SlashCommandBuilder,
+  MessageFlags,
+  type ChatInputCommandInteraction,
+} from 'discord.js';
+import { REAEventStore } from '@holons/core/rea';
+import {
+  REAAggregator,
+  computeHolonUserScores,
+  loadEquation,
+} from '@holons/core/scoring';
+import { getUsers, type UserDB, type UserProfile } from '@holons/core/users';
+import type { Feature, InvocationContext } from '../types.js';
+import { ACCENT } from '../ui/DiscordUI.js';
+import {
+  leaderboardView,
+  memberName,
+  type LeaderboardEntry,
+} from '../ui/format.js';
+
+const FEATURE_ID = 'scores';
+
+export const scoresFeature: Feature = {
+  id: FEATURE_ID,
+  commands: [
+    new SlashCommandBuilder()
+      .setName('scores')
+      .setDescription('Contribution leaderboard for this holon'),
+  ],
+
+  async handleCommand(
+    interaction: ChatInputCommandInteraction,
+    ctx: InvocationContext
+  ): Promise<void> {
+    if (!ctx.holonId) {
+      await interaction.reply({
+        content:
+          'This server is not bound to a holon yet. Ask an admin to run `/holon bind`.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+    const holonId = ctx.holonId;
+    const db = ctx.holosphere as unknown as UserDB;
+
+    const users = await getUsers(db, holonId);
+    if (users.length === 0) {
+      await interaction.reply({
+        content: 'No members yet. Use `/join` to register, then contribute.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    // Scoring can touch many holosphere reads — acknowledge first.
+    await interaction.deferReply();
+
+    const eventStore = new REAEventStore(ctx.holosphere as never);
+    const aggregator = new REAAggregator(eventStore);
+    const equation = await loadEquation(ctx.holosphere, holonId);
+    const scored = await computeHolonUserScores(
+      aggregator,
+      holonId,
+      users,
+      equation
+    );
+
+    const nameById = new Map(
+      users.map((u: UserProfile) => [String(u.id), memberName(u)])
+    );
+    const entries: LeaderboardEntry[] = scored.map(s => ({
+      name: nameById.get(String(s.userId)) ?? String(s.userId),
+      score: s.score,
+      percentage: s.percentage,
+    }));
+
+    const embed = new EmbedBuilder()
+      .setColor(ACCENT)
+      .setTitle('🏆 Contribution leaderboard')
+      .setDescription(leaderboardView(entries));
+
+    await interaction.editReply({ embeds: [embed] });
+  },
+};

--- a/packages/discord-ui/src/features/settings.ts
+++ b/packages/discord-ui/src/features/settings.ts
@@ -1,0 +1,74 @@
+/**
+ * Settings feature (read-only). `/settings` shows the holon's configuration
+ * loaded via `@holons/core/settings`. Editing settings (lenses, federation,
+ * flow management) is deferred to a later phase — see the package roadmap.
+ */
+import {
+  EmbedBuilder,
+  SlashCommandBuilder,
+  MessageFlags,
+  type ChatInputCommandInteraction,
+} from 'discord.js';
+import { loadSettings } from '@holons/core/settings';
+import type { Feature, InvocationContext } from '../types.js';
+import { ACCENT } from '../ui/DiscordUI.js';
+
+const FEATURE_ID = 'settings';
+
+export const settingsFeature: Feature = {
+  id: FEATURE_ID,
+  commands: [
+    new SlashCommandBuilder()
+      .setName('settings')
+      .setDescription('Show this holon’s settings'),
+  ],
+
+  async handleCommand(
+    interaction: ChatInputCommandInteraction,
+    ctx: InvocationContext
+  ): Promise<void> {
+    if (!ctx.holonId) {
+      await interaction.reply({
+        content:
+          'This server is not bound to a holon yet. Ask an admin to run `/holon bind`.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const settings = await loadSettings(ctx.holosphere as never, ctx.holonId);
+    if (!settings) {
+      await interaction.reply({
+        content: `Holon \`${ctx.holonId}\` has no settings configured yet.`,
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const federation = Array.isArray(settings.federation)
+      ? settings.federation.length
+      : 0;
+    const embed = new EmbedBuilder()
+      .setColor(ACCENT)
+      .setTitle(`⚙️ Settings — ${settings.name ?? ctx.holonId}`)
+      .addFields(
+        { name: 'Holon id', value: `\`${ctx.holonId}\``, inline: true },
+        { name: 'Timezone', value: settings.timezone || '—', inline: true },
+        { name: 'Language', value: settings.language || '—', inline: true },
+        { name: 'Theme', value: settings.theme || '—', inline: true },
+        {
+          name: 'Max tasks',
+          value: settings.maxTasks != null ? String(settings.maxTasks) : '—',
+          inline: true,
+        },
+        {
+          name: 'Federated holons',
+          value: String(federation),
+          inline: true,
+        }
+      )
+      .setFooter({ text: 'Read-only — editing comes in a later release.' });
+
+    await interaction.reply({ embeds: [embed] });
+  },
+};

--- a/packages/discord-ui/src/features/shopping.ts
+++ b/packages/discord-ui/src/features/shopping.ts
@@ -1,0 +1,141 @@
+/**
+ * Shopping-list feature. `/shopping add` / `/shopping list` plus per-item
+ * toggle buttons and a "Remove checked" button.
+ *
+ * CRUD lives in `@holons/core/shopping` (pure functions over the checklist
+ * document); this module loads/saves the document and renders it.
+ */
+import {
+  MessageFlags,
+  SlashCommandBuilder,
+  type ChatInputCommandInteraction,
+  type MessageComponentInteraction,
+} from 'discord.js';
+import {
+  CHECKLISTS_COLLECTION,
+  SHOPPING_KEY,
+  addItem,
+  normalizeChecklist,
+  removeChecked,
+  toggleItem,
+  type ShoppingChecklist,
+} from '@holons/core/shopping';
+import type { Feature, InvocationContext } from '../types.js';
+import type { ParsedCustomId } from '../ui/customId.js';
+import { shoppingComponents, shoppingEmbed } from '../ui/DiscordUI.js';
+
+const FEATURE_ID = 'shopping';
+
+async function loadList(
+  ctx: InvocationContext,
+  holonId: string
+): Promise<ShoppingChecklist | null> {
+  const raw = await ctx.holosphere.get(
+    holonId,
+    CHECKLISTS_COLLECTION,
+    SHOPPING_KEY
+  );
+  return normalizeChecklist(raw);
+}
+
+async function saveList(
+  ctx: InvocationContext,
+  holonId: string,
+  list: ShoppingChecklist
+): Promise<void> {
+  await ctx.holosphere.put(holonId, CHECKLISTS_COLLECTION, list);
+}
+
+export const shoppingFeature: Feature = {
+  id: FEATURE_ID,
+  commands: [
+    new SlashCommandBuilder()
+      .setName('shopping')
+      .setDescription('Manage the shared shopping list')
+      .addSubcommand(sub =>
+        sub
+          .setName('add')
+          .setDescription('Add an item to the shopping list')
+          .addStringOption(opt =>
+            opt.setName('item').setDescription('Item to add').setRequired(true)
+          )
+      )
+      .addSubcommand(sub =>
+        sub.setName('list').setDescription('Show the shopping list')
+      ),
+  ],
+
+  async handleCommand(
+    interaction: ChatInputCommandInteraction,
+    ctx: InvocationContext
+  ): Promise<void> {
+    if (!ctx.holonId) {
+      await interaction.reply({
+        content:
+          'This server is not bound to a holon yet. Ask an admin to run `/holon bind`.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+    const holonId = ctx.holonId;
+    const sub = interaction.options.getSubcommand();
+
+    if (sub === 'add') {
+      const text = interaction.options.getString('item', true);
+      const current = await loadList(ctx, holonId);
+      const updated = addItem(current, text, {
+        createdBy: interaction.user.id,
+      });
+      await saveList(ctx, holonId, updated);
+      await interaction.reply({
+        embeds: [shoppingEmbed(updated)],
+        components: shoppingComponents(FEATURE_ID, updated),
+      });
+      return;
+    }
+
+    // sub === 'list'
+    const list = await loadList(ctx, holonId);
+    await interaction.reply({
+      embeds: [shoppingEmbed(list)],
+      components: shoppingComponents(FEATURE_ID, list),
+    });
+  },
+
+  async handleComponent(
+    interaction: MessageComponentInteraction,
+    parsed: ParsedCustomId,
+    ctx: InvocationContext
+  ): Promise<void> {
+    if (!ctx.holonId) {
+      await interaction.reply({
+        content: 'This server is no longer bound to a holon.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+    const holonId = ctx.holonId;
+    const current = await loadList(ctx, holonId);
+
+    let updated: ShoppingChecklist | null = current;
+    if (parsed.action === 'toggle') {
+      updated = toggleItem(current, parsed.args[0]);
+    } else if (parsed.action === 'clearChecked') {
+      updated = removeChecked(current);
+    }
+
+    if (!updated) {
+      await interaction.reply({
+        content: 'The shopping list is empty.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    await saveList(ctx, holonId, updated);
+    await interaction.update({
+      embeds: [shoppingEmbed(updated)],
+      components: shoppingComponents(FEATURE_ID, updated),
+    });
+  },
+};

--- a/packages/discord-ui/src/features/users.ts
+++ b/packages/discord-ui/src/features/users.ts
@@ -1,0 +1,103 @@
+/**
+ * Membership feature. `/join` registers the caller as a member of the bound
+ * holon, `/leave` removes them, `/members` lists everyone.
+ *
+ * A "member" is just a user profile under the holon's `users` lens — the same
+ * model the Telegram bot uses — so membership here feeds expenses, scoring and
+ * everything else that reads `users`.
+ */
+import {
+  MessageFlags,
+  SlashCommandBuilder,
+  type ChatInputCommandInteraction,
+} from 'discord.js';
+import {
+  getUsers,
+  joinHolon,
+  leaveHolon,
+  type TelegramUserLike,
+  type UserDB,
+} from '@holons/core/users';
+import type { Feature, InvocationContext } from '../types.js';
+import { memberListView } from '../ui/format.js';
+
+const FEATURE_ID = 'members';
+
+/** Map a Discord interaction user onto the core's user shape. */
+export function userLike(user: {
+  id: string;
+  username: string;
+  globalName?: string | null;
+}): TelegramUserLike {
+  return {
+    id: user.id,
+    username: user.username,
+    first_name: user.globalName ?? user.username,
+  };
+}
+
+async function needHolon(
+  interaction: ChatInputCommandInteraction
+): Promise<void> {
+  await interaction.reply({
+    content:
+      'This server is not bound to a holon yet. Ask an admin to run `/holon bind`.',
+    flags: MessageFlags.Ephemeral,
+  });
+}
+
+export const usersFeature: Feature = {
+  id: FEATURE_ID,
+  commands: [
+    new SlashCommandBuilder()
+      .setName('join')
+      .setDescription('Join this holon as a member'),
+    new SlashCommandBuilder()
+      .setName('leave')
+      .setDescription('Leave this holon'),
+    new SlashCommandBuilder()
+      .setName('members')
+      .setDescription('List members of this holon'),
+  ],
+
+  async handleCommand(
+    interaction: ChatInputCommandInteraction,
+    ctx: InvocationContext
+  ): Promise<void> {
+    if (!ctx.holonId) {
+      await needHolon(interaction);
+      return;
+    }
+    const db = ctx.holosphere as unknown as UserDB;
+
+    if (interaction.commandName === 'join') {
+      const result = await joinHolon(
+        db,
+        userLike(interaction.user),
+        ctx.holonId
+      );
+      await interaction.reply({
+        content: result.profile
+          ? '✅ You are now a member of this holon.'
+          : 'Could not register you as a member.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (interaction.commandName === 'leave') {
+      await leaveHolon(db, interaction.user.id, ctx.holonId);
+      await interaction.reply({
+        content: '👋 You have left this holon.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    // members
+    const members = await getUsers(db, ctx.holonId);
+    await interaction.reply({
+      content: `**Members** (${members.length})\n\n${memberListView(members)}`,
+    });
+  },
+};

--- a/packages/discord-ui/src/index.ts
+++ b/packages/discord-ui/src/index.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+/**
+ * Entry point for the Holons Discord bot.
+ */
+import './utils/config.js'; // load .env before anything reads process.env
+import { DiscordBot } from './core/DiscordBot.js';
+import { setupGlobalErrorHandlers } from './utils/errorHandler.js';
+import { log } from './utils/logger.js';
+
+async function start(): Promise<void> {
+  setupGlobalErrorHandlers();
+  log.info('Starting Holons Discord bot');
+
+  const bot = new DiscordBot();
+  await bot.init();
+
+  const shutdown = async (signal: string): Promise<void> => {
+    log.info(`Received ${signal}, shutting down gracefully`);
+    await bot.shutdown();
+    process.exit(0);
+  };
+  process.on('SIGINT', () => void shutdown('SIGINT'));
+  process.on('SIGTERM', () => void shutdown('SIGTERM'));
+}
+
+start().catch(err => {
+  log.error('Failed to start Discord bot', {
+    error: err instanceof Error ? err.message : String(err),
+    stack: err instanceof Error ? err.stack : undefined,
+  });
+  process.exit(1);
+});

--- a/packages/discord-ui/src/runtime/client.ts
+++ b/packages/discord-ui/src/runtime/client.ts
@@ -1,0 +1,9 @@
+/**
+ * The discord.js gateway client. Slash commands and component interactions
+ * only need the `Guilds` intent — we don't read message content.
+ */
+import { Client, GatewayIntentBits } from 'discord.js';
+
+export function createClient(): Client {
+  return new Client({ intents: [GatewayIntentBits.Guilds] });
+}

--- a/packages/discord-ui/src/runtime/registerCommands.ts
+++ b/packages/discord-ui/src/runtime/registerCommands.ts
@@ -1,0 +1,61 @@
+/**
+ * Registers the features' slash commands with Discord via the REST API.
+ *
+ * Importable as `registerCommands()` (called on startup) and runnable directly
+ * (`pnpm -F @holons/discord-ui register`) to (re)sync commands out of band.
+ *
+ * If `DISCORD_GUILD_ID` is set, commands register to that single guild and
+ * appear instantly — ideal for development. Otherwise they register globally,
+ * which can take up to an hour to propagate.
+ */
+import { fileURLToPath } from 'node:url';
+import { REST, Routes } from 'discord.js';
+import { features } from '../features/index.js';
+import { config } from '../utils/config.js';
+import { log } from '../utils/logger.js';
+
+export function collectCommandJSON(): unknown[] {
+  return features.flatMap(feature =>
+    feature.commands.map(command => command.toJSON())
+  );
+}
+
+export interface RegisterOptions {
+  token?: string;
+  appId?: string;
+  guildId?: string;
+}
+
+export async function registerCommands(
+  opts: RegisterOptions = {}
+): Promise<void> {
+  const token = opts.token ?? config.token;
+  const appId = opts.appId ?? config.appId;
+  const guildId = opts.guildId ?? config.guildId;
+
+  if (!token || !appId) {
+    throw new Error(
+      'DISCORD_TOKEN and DISCORD_APP_ID are required to register slash commands'
+    );
+  }
+
+  const body = collectCommandJSON();
+  const rest = new REST({ version: '10' }).setToken(token);
+  const route = guildId
+    ? Routes.applicationGuildCommands(appId, guildId)
+    : Routes.applicationCommands(appId);
+
+  await rest.put(route, { body });
+  log.info('Registered slash commands', {
+    count: body.length,
+    scope: guildId ? `guild ${guildId}` : 'global',
+  });
+}
+
+// Allow running this module directly as a CLI.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  registerCommands().catch(err => {
+    log.error('Slash command registration failed', { error: String(err) });
+    process.exit(1);
+  });
+}

--- a/packages/discord-ui/src/runtime/router.ts
+++ b/packages/discord-ui/src/runtime/router.ts
@@ -1,0 +1,77 @@
+/**
+ * Single `interactionCreate` dispatcher. Builds the per-interaction context
+ * and routes slash commands by name, and components/modals by the feature
+ * namespace encoded in their customId.
+ */
+import {
+  Events,
+  MessageFlags,
+  type Client,
+  type Interaction,
+} from 'discord.js';
+import { buildInvocationContext } from '../context.js';
+import { commandIndex, featureIndex, features } from '../features/index.js';
+import type { HolonBindingStore, HoloStore } from '../types.js';
+import { parseCustomId } from '../ui/customId.js';
+import { errorMessage } from '../utils/errorHandler.js';
+import { log } from '../utils/logger.js';
+
+export interface RouterDeps {
+  holosphere: HoloStore;
+  bindings: HolonBindingStore;
+}
+
+export function attachRouter(client: Client, deps: RouterDeps): void {
+  const byCommand = commandIndex(features);
+  const byFeature = featureIndex(features);
+
+  client.on(Events.InteractionCreate, async (interaction: Interaction) => {
+    try {
+      const ctx = await buildInvocationContext({
+        holosphere: deps.holosphere,
+        bindings: deps.bindings,
+        guildId: interaction.guildId ?? null,
+      });
+
+      if (interaction.isChatInputCommand()) {
+        const feature = byCommand.get(interaction.commandName);
+        if (feature) await feature.handleCommand(interaction, ctx);
+        return;
+      }
+
+      if (interaction.isMessageComponent()) {
+        const parsed = parseCustomId(interaction.customId);
+        if (!parsed) return;
+        await byFeature
+          .get(parsed.feature)
+          ?.handleComponent?.(interaction, parsed, ctx);
+        return;
+      }
+
+      if (interaction.isModalSubmit()) {
+        const parsed = parseCustomId(interaction.customId);
+        if (!parsed) return;
+        await byFeature
+          .get(parsed.feature)
+          ?.handleModal?.(interaction, parsed, ctx);
+      }
+    } catch (err) {
+      log.error('Interaction handler failed', { error: errorMessage(err) });
+      await replyError(interaction);
+    }
+  });
+}
+
+async function replyError(interaction: Interaction): Promise<void> {
+  if (!interaction.isRepliable()) return;
+  const content = '⚠️ Something went wrong handling that interaction.';
+  try {
+    if (interaction.replied || interaction.deferred) {
+      await interaction.followUp({ content, flags: MessageFlags.Ephemeral });
+    } else {
+      await interaction.reply({ content, flags: MessageFlags.Ephemeral });
+    }
+  } catch {
+    /* nothing more we can do */
+  }
+}

--- a/packages/discord-ui/src/types.ts
+++ b/packages/discord-ui/src/types.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared contracts for the Discord UI: the storage surface we use from
+ * holosphere, the per-interaction context handed to features, and the
+ * `Feature` interface every command module implements.
+ */
+import type {
+  ChatInputCommandInteraction,
+  MessageComponentInteraction,
+  ModalSubmitInteraction,
+} from 'discord.js';
+import type { CommandContext } from '@holons/core/commands';
+import type { ParsedCustomId } from './ui/customId.js';
+
+/**
+ * Minimal slice of the HoloSphere instance the bot touches. Mirrors the
+ * `(holonId, bucket, key)` access pattern used across all Holons UIs.
+ * `getAll` resolves to an array of records (each typically carrying an `id`).
+ */
+export interface HoloStore {
+  get(holonId: string, bucket: string, key?: string | number): Promise<unknown>;
+  getAll(holonId: string, bucket: string): Promise<unknown[]>;
+  put(holonId: string, bucket: string, value: unknown): Promise<unknown>;
+  delete?(
+    holonId: string,
+    bucket: string,
+    key: string | number
+  ): Promise<unknown>;
+}
+
+/** The acting Discord user, normalised for `@holons/core`. */
+export interface DiscordUser {
+  id: string;
+  username?: string;
+}
+
+/** Persisted mapping of Discord guild -> Holons holon id. */
+export interface HolonBindingStore {
+  get(guildId: string): Promise<string | null>;
+  set(guildId: string, holonId: string): Promise<void>;
+}
+
+/**
+ * Everything a feature handler needs for one interaction. Built once per
+ * incoming interaction by the router (see `context.ts`).
+ */
+export interface InvocationContext {
+  /** The bot's HoloSphere instance. */
+  holosphere: HoloStore;
+  /** Holon bound to the originating guild, or null if none is bound yet. */
+  holonId: string | null;
+  /** Holosphere application namespace. */
+  appName: string;
+  /** Guild -> holon binding store (used by the `holon` feature). */
+  bindings: HolonBindingStore;
+  /** Build a `@holons/core` CommandContext for the acting user. */
+  core(user: DiscordUser): CommandContext;
+}
+
+/** A registrable slash command — anything exposing a name and `toJSON()`. */
+export interface SlashCommandSpec {
+  name: string;
+  toJSON(): unknown;
+}
+
+/**
+ * A self-contained slice of bot functionality. Owns one or more top-level
+ * slash commands and (optionally) the buttons/selects/modals they spawn,
+ * namespaced under `id` in their customIds.
+ */
+export interface Feature {
+  /** customId namespace and registry key (e.g. `'quests'`). */
+  id: string;
+  /** Top-level slash commands this feature registers. */
+  commands: SlashCommandSpec[];
+  /** Handle one of this feature's slash commands. */
+  handleCommand(
+    interaction: ChatInputCommandInteraction,
+    ctx: InvocationContext
+  ): Promise<void>;
+  /** Handle a button or select-menu interaction (customId starts `id:`). */
+  handleComponent?(
+    interaction: MessageComponentInteraction,
+    parsed: ParsedCustomId,
+    ctx: InvocationContext
+  ): Promise<void>;
+  /** Handle a modal submit (customId starts `id:`). */
+  handleModal?(
+    interaction: ModalSubmitInteraction,
+    parsed: ParsedCustomId,
+    ctx: InvocationContext
+  ): Promise<void>;
+}

--- a/packages/discord-ui/src/ui/DiscordUI.ts
+++ b/packages/discord-ui/src/ui/DiscordUI.ts
@@ -12,8 +12,9 @@ import {
 } from 'discord.js';
 import type { Quest } from '@holons/core/tasks';
 import type { ShoppingChecklist } from '@holons/core/shopping';
+import type { Checklist } from '@holons/core/checklists';
 import { encodeCustomId } from './customId.js';
-import { questEmbedView, shoppingListView } from './format.js';
+import { checklistView, questEmbedView, shoppingListView } from './format.js';
 
 /** Holons accent colour for embeds. */
 export const ACCENT = 0x7c5cff;
@@ -26,29 +27,47 @@ export function questEmbed(quest: Quest): EmbedBuilder {
     .setFooter({ text: view.footer });
   if (view.description) embed.setDescription(view.description);
   embed.addFields(view.fields);
+  const thanks = (quest.appreciation ?? []).length;
+  if (thanks > 0)
+    embed.addFields({ name: 'Appreciation', value: `🙏 ${thanks}` });
   return embed;
 }
 
-/** Join/Leave + Complete buttons for a quest. */
+/**
+ * Action buttons for a quest. While ongoing: Join/Leave + Complete. Once
+ * completed: an Appreciate button so members can thank contributors.
+ */
 export function questComponents(
   featureId: string,
   quest: Quest
 ): ActionRowBuilder<ButtonBuilder>[] {
   const questId = String(quest.id ?? '');
   const completed = quest.status === 'completed';
-  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
-    new ButtonBuilder()
-      .setCustomId(encodeCustomId(featureId, 'toggle', questId))
-      .setLabel('Join / Leave')
-      .setStyle(ButtonStyle.Primary)
-      .setDisabled(completed),
-    new ButtonBuilder()
-      .setCustomId(encodeCustomId(featureId, 'complete', questId))
-      .setLabel('Complete')
-      .setStyle(ButtonStyle.Success)
-      .setDisabled(completed)
-  );
-  return [row];
+
+  if (completed) {
+    return [
+      new ActionRowBuilder<ButtonBuilder>().addComponents(
+        new ButtonBuilder()
+          .setCustomId(encodeCustomId(featureId, 'appreciate', questId))
+          .setLabel('Appreciate')
+          .setStyle(ButtonStyle.Secondary)
+          .setEmoji('🙏')
+      ),
+    ];
+  }
+
+  return [
+    new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId(encodeCustomId(featureId, 'toggle', questId))
+        .setLabel('Join / Leave')
+        .setStyle(ButtonStyle.Primary),
+      new ButtonBuilder()
+        .setCustomId(encodeCustomId(featureId, 'complete', questId))
+        .setLabel('Complete')
+        .setStyle(ButtonStyle.Success)
+    ),
+  ];
 }
 
 export function shoppingEmbed(
@@ -94,6 +113,41 @@ export function shoppingComponents(
           .setStyle(ButtonStyle.Danger)
       )
     );
+  }
+  return rows;
+}
+
+export function checklistEmbed(checklist: Checklist): EmbedBuilder {
+  return new EmbedBuilder()
+    .setColor(ACCENT)
+    .setTitle(`📝 ${checklist.id}`)
+    .setDescription(checklistView(checklist));
+}
+
+/**
+ * Toggle buttons for checklist items, addressed by index (up to 20, 5 per
+ * row). The checklist id is colon-free (core rejects `_`; the feature also
+ * rejects `:`), so it packs safely into the customId.
+ */
+export function checklistComponents(
+  featureId: string,
+  checklist: Checklist
+): ActionRowBuilder<ButtonBuilder>[] {
+  const rows: ActionRowBuilder<ButtonBuilder>[] = [];
+  const items = (checklist.items ?? []).slice(0, 20);
+
+  for (let i = 0; i < items.length; i += 5) {
+    const row = new ActionRowBuilder<ButtonBuilder>();
+    items.slice(i, i + 5).forEach((item, j) => {
+      const index = i + j;
+      row.addComponents(
+        new ButtonBuilder()
+          .setCustomId(encodeCustomId(featureId, 'toggle', checklist.id, index))
+          .setLabel(item.text.slice(0, 80))
+          .setStyle(item.checked ? ButtonStyle.Secondary : ButtonStyle.Primary)
+      );
+    });
+    rows.push(row);
   }
   return rows;
 }

--- a/packages/discord-ui/src/ui/DiscordUI.ts
+++ b/packages/discord-ui/src/ui/DiscordUI.ts
@@ -1,0 +1,99 @@
+/**
+ * discord.js presentation helpers — turns the pure views in `format.ts` into
+ * embeds and interactive component rows. This is the Discord analogue of
+ * telegram-ui's `UI.js` (embeds instead of HTML, buttons instead of inline
+ * keyboards).
+ */
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  EmbedBuilder,
+} from 'discord.js';
+import type { Quest } from '@holons/core/tasks';
+import type { ShoppingChecklist } from '@holons/core/shopping';
+import { encodeCustomId } from './customId.js';
+import { questEmbedView, shoppingListView } from './format.js';
+
+/** Holons accent colour for embeds. */
+export const ACCENT = 0x7c5cff;
+
+export function questEmbed(quest: Quest): EmbedBuilder {
+  const view = questEmbedView(quest);
+  const embed = new EmbedBuilder()
+    .setColor(quest.status === 'completed' ? 0x57f287 : ACCENT)
+    .setTitle(view.title)
+    .setFooter({ text: view.footer });
+  if (view.description) embed.setDescription(view.description);
+  embed.addFields(view.fields);
+  return embed;
+}
+
+/** Join/Leave + Complete buttons for a quest. */
+export function questComponents(
+  featureId: string,
+  quest: Quest
+): ActionRowBuilder<ButtonBuilder>[] {
+  const questId = String(quest.id ?? '');
+  const completed = quest.status === 'completed';
+  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(encodeCustomId(featureId, 'toggle', questId))
+      .setLabel('Join / Leave')
+      .setStyle(ButtonStyle.Primary)
+      .setDisabled(completed),
+    new ButtonBuilder()
+      .setCustomId(encodeCustomId(featureId, 'complete', questId))
+      .setLabel('Complete')
+      .setStyle(ButtonStyle.Success)
+      .setDisabled(completed)
+  );
+  return [row];
+}
+
+export function shoppingEmbed(
+  checklist: ShoppingChecklist | null
+): EmbedBuilder {
+  return new EmbedBuilder()
+    .setColor(ACCENT)
+    .setTitle('🛒 Shopping List')
+    .setDescription(shoppingListView(checklist));
+}
+
+/**
+ * Toggle buttons for shopping items (up to 20, 5 per row) plus a final row
+ * with a "Remove checked" action. Discord allows at most 5 action rows / 25
+ * components per message, so we cap the item count.
+ */
+export function shoppingComponents(
+  featureId: string,
+  checklist: ShoppingChecklist | null
+): ActionRowBuilder<ButtonBuilder>[] {
+  const rows: ActionRowBuilder<ButtonBuilder>[] = [];
+  const items = (checklist?.items ?? []).slice(0, 20);
+
+  for (let i = 0; i < items.length; i += 5) {
+    const row = new ActionRowBuilder<ButtonBuilder>();
+    for (const item of items.slice(i, i + 5)) {
+      row.addComponents(
+        new ButtonBuilder()
+          .setCustomId(encodeCustomId(featureId, 'toggle', String(item.id)))
+          .setLabel(item.text.slice(0, 80))
+          .setStyle(item.checked ? ButtonStyle.Secondary : ButtonStyle.Primary)
+      );
+    }
+    rows.push(row);
+  }
+
+  if (items.length > 0) {
+    rows.push(
+      new ActionRowBuilder<ButtonBuilder>().addComponents(
+        new ButtonBuilder()
+          .setCustomId(encodeCustomId(featureId, 'clearChecked'))
+          .setLabel('Remove checked')
+          .setStyle(ButtonStyle.Danger)
+      )
+    );
+  }
+  return rows;
+}

--- a/packages/discord-ui/src/ui/customId.test.ts
+++ b/packages/discord-ui/src/ui/customId.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { encodeCustomId, parseCustomId } from './customId.js';
+
+describe('customId codec', () => {
+  it('round-trips feature/action/args', () => {
+    const id = encodeCustomId('quests', 'join', 'abc123');
+    expect(id).toBe('quests:join:abc123');
+    expect(parseCustomId(id)).toEqual({
+      feature: 'quests',
+      action: 'join',
+      args: ['abc123'],
+    });
+  });
+
+  it('supports multiple args and coerces numbers', () => {
+    const id = encodeCustomId('shopping', 'toggle', 42, 'x');
+    expect(parseCustomId(id)).toEqual({
+      feature: 'shopping',
+      action: 'toggle',
+      args: ['42', 'x'],
+    });
+  });
+
+  it('parses an action with no args', () => {
+    expect(parseCustomId('quests:list')).toEqual({
+      feature: 'quests',
+      action: 'list',
+      args: [],
+    });
+  });
+
+  it('rejects segments containing the separator', () => {
+    expect(() => encodeCustomId('quests', 'join', 'a:b')).toThrow();
+  });
+
+  it('rejects ids over the Discord 100-char limit', () => {
+    expect(() => encodeCustomId('quests', 'join', 'x'.repeat(120))).toThrow();
+  });
+
+  it('returns null for malformed ids', () => {
+    expect(parseCustomId('')).toBeNull();
+    expect(parseCustomId('lonely')).toBeNull();
+  });
+});

--- a/packages/discord-ui/src/ui/customId.ts
+++ b/packages/discord-ui/src/ui/customId.ts
@@ -1,0 +1,50 @@
+/**
+ * Encoding for Discord component `customId`s.
+ *
+ * Discord caps a customId at 100 characters and gives us a single opaque
+ * string per button/select/modal. We pack routing info into it as
+ * colon-separated segments:
+ *
+ *     <feature>:<action>[:<arg>...]
+ *
+ * The router splits this back out and dispatches to the owning feature's
+ * component handler. Segments must not contain ':'; holon/quest/shopping ids
+ * in this codebase are colon-free (base36 / `<ms>-<rand>`), so no escaping is
+ * needed — we assert it instead to fail loudly if that ever changes.
+ */
+
+export interface ParsedCustomId {
+  feature: string;
+  action: string;
+  args: string[];
+}
+
+export const CUSTOM_ID_SEP = ':';
+export const CUSTOM_ID_MAX = 100;
+
+export function encodeCustomId(
+  feature: string,
+  action: string,
+  ...args: Array<string | number>
+): string {
+  const segments = [feature, action, ...args.map(String)];
+  for (const seg of segments) {
+    if (seg.includes(CUSTOM_ID_SEP)) {
+      throw new Error(
+        `customId segment "${seg}" contains the reserved separator "${CUSTOM_ID_SEP}"`
+      );
+    }
+  }
+  const id = segments.join(CUSTOM_ID_SEP);
+  if (id.length > CUSTOM_ID_MAX) {
+    throw new Error(`customId "${id}" exceeds ${CUSTOM_ID_MAX} characters`);
+  }
+  return id;
+}
+
+export function parseCustomId(customId: string): ParsedCustomId | null {
+  if (!customId) return null;
+  const [feature, action, ...args] = customId.split(CUSTOM_ID_SEP);
+  if (!feature || !action) return null;
+  return { feature, action, args };
+}

--- a/packages/discord-ui/src/ui/format.test.ts
+++ b/packages/discord-ui/src/ui/format.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import {
+  questEmbedView,
+  questSummaryLine,
+  participantNames,
+  shoppingListView,
+} from './format.js';
+import type { Quest } from '@holons/core/tasks';
+import type { ShoppingChecklist } from '@holons/core/shopping';
+
+function quest(overrides: Partial<Quest> = {}): Quest {
+  return {
+    title: 'Fix the fence',
+    status: 'ongoing',
+    type: 'task',
+    participants: [],
+    ...overrides,
+  } as Quest;
+}
+
+describe('quest formatting', () => {
+  it('lists participant display names, preferring username', () => {
+    const q = quest({
+      participants: [
+        { id: 1, username: 'bob' },
+        { id: 2, firstName: 'Carol' },
+        { id: 3 },
+      ],
+    });
+    expect(participantNames(q)).toEqual(['bob', 'Carol', '3']);
+  });
+
+  it('builds an embed view with type/status/participant fields', () => {
+    const view = questEmbedView(quest({ location: 'Barn', when: 'Sat 10am' }));
+    expect(view.title).toBe('Fix the fence');
+    const fieldNames = view.fields.map(f => f.name);
+    expect(fieldNames).toContain('Type');
+    expect(fieldNames).toContain('Status');
+    expect(fieldNames.some(n => n.startsWith('Participants'))).toBe(true);
+    expect(fieldNames).toContain('When');
+    expect(fieldNames).toContain('Where');
+  });
+
+  it('marks completed quests in the summary line', () => {
+    expect(questSummaryLine(quest({ status: 'completed' }))).toContain('✅');
+    expect(questSummaryLine(quest())).not.toContain('✅');
+  });
+});
+
+describe('shopping formatting', () => {
+  it('renders an empty-state for no items', () => {
+    expect(shoppingListView(null)).toMatch(/empty/i);
+  });
+
+  it('groups items by category and shows checkbox state', () => {
+    const list: ShoppingChecklist = {
+      id: 'shopping',
+      type: 'shopping',
+      title: 'Shopping List',
+      created: new Date().toISOString(),
+      items: [
+        { id: '1', text: 'Milk', checked: false, category: 'Dairy' },
+        { id: '2', text: 'Eggs', checked: true, category: 'Dairy' },
+        { id: '3', text: 'Nails', checked: false },
+      ],
+    };
+    const out = shoppingListView(list);
+    expect(out).toContain('__Dairy__');
+    expect(out).toContain('⬜ Milk');
+    expect(out).toContain('☑️ Eggs');
+    expect(out).toContain('⬜ Nails');
+  });
+});

--- a/packages/discord-ui/src/ui/format.test.ts
+++ b/packages/discord-ui/src/ui/format.test.ts
@@ -4,9 +4,16 @@ import {
   questSummaryLine,
   participantNames,
   shoppingListView,
+  memberListView,
+  balancesView,
+  formatAmount,
+  checklistView,
+  checklistSummaryLine,
 } from './format.js';
 import type { Quest } from '@holons/core/tasks';
 import type { ShoppingChecklist } from '@holons/core/shopping';
+import type { BalancesResult } from '@holons/core/expenses';
+import type { Checklist } from '@holons/core/checklists';
 
 function quest(overrides: Partial<Quest> = {}): Quest {
   return {
@@ -69,5 +76,84 @@ describe('shopping formatting', () => {
     expect(out).toContain('⬜ Milk');
     expect(out).toContain('☑️ Eggs');
     expect(out).toContain('⬜ Nails');
+  });
+});
+
+describe('member formatting', () => {
+  it('prefers username, falls back to first_name then id', () => {
+    expect(memberListView([{ id: 1, username: 'bob' }])).toContain('• bob');
+    expect(memberListView([{ id: 2, first_name: 'Carol' }])).toContain(
+      '• Carol'
+    );
+    expect(memberListView([{ id: 3 }])).toContain('• 3');
+  });
+
+  it('shows an empty state', () => {
+    expect(memberListView([])).toMatch(/no members/i);
+  });
+});
+
+describe('expense formatting', () => {
+  it('formats amounts, dropping trailing .00', () => {
+    expect(formatAmount(10)).toBe('10');
+    expect(formatAmount(10.5)).toBe('10.50');
+    expect(formatAmount(10.333)).toBe('10.33');
+  });
+
+  it('renders owed/owes lines and resolves names', () => {
+    const result: BalancesResult = {
+      creditMatrix: [],
+      userIds: ['a', 'b'],
+      balances: [
+        { userId: 'a', net: 12.5 },
+        { userId: 'b', net: -12.5 },
+      ],
+    };
+    const out = balancesView(result, 'eur', id =>
+      id === 'a' ? 'Alice' : 'Bob'
+    );
+    expect(out).toContain('🟢 **Alice** is owed 12.50 EUR');
+    expect(out).toContain('🔴 **Bob** owes 12.50 EUR');
+  });
+
+  it('reports a settled state when all balances are ~zero', () => {
+    const result: BalancesResult = {
+      creditMatrix: [],
+      userIds: ['a'],
+      balances: [{ userId: 'a', net: 0 }],
+    };
+    expect(balancesView(result, 'usd')).toMatch(/settled up/i);
+  });
+});
+
+describe('checklist formatting', () => {
+  function checklist(items: Checklist['items']): Checklist {
+    return { id: 'chores', type: 'checklist', items };
+  }
+
+  it('renders items with checkbox state', () => {
+    const out = checklistView(
+      checklist([
+        { text: 'Sweep', checked: true },
+        { text: 'Mop', checked: false },
+      ])
+    );
+    expect(out).toContain('☑️ Sweep');
+    expect(out).toContain('⬜ Mop');
+  });
+
+  it('summarises done/total', () => {
+    const line = checklistSummaryLine(
+      checklist([
+        { text: 'a', checked: true },
+        { text: 'b', checked: false },
+      ])
+    );
+    expect(line).toContain('chores');
+    expect(line).toContain('1/2');
+  });
+
+  it('shows an empty state', () => {
+    expect(checklistView(checklist([]))).toMatch(/empty/i);
   });
 });

--- a/packages/discord-ui/src/ui/format.test.ts
+++ b/packages/discord-ui/src/ui/format.test.ts
@@ -53,6 +53,21 @@ describe('quest formatting', () => {
     expect(questSummaryLine(quest({ status: 'completed' }))).toContain('✅');
     expect(questSummaryLine(quest())).not.toContain('✅');
   });
+
+  it('surfaces dependencies and a linked checklist when present', () => {
+    const view = questEmbedView(
+      quest({ dependencies: ['a', 'b'], checklistId: 'abc123' })
+    );
+    const fields = Object.fromEntries(view.fields.map(f => [f.name, f.value]));
+    expect(fields['Depends on']).toBe('2 tasks');
+    expect(fields['Checklist']).toBeDefined();
+  });
+
+  it('omits dependency/checklist fields when absent', () => {
+    const names = questEmbedView(quest()).fields.map(f => f.name);
+    expect(names).not.toContain('Depends on');
+    expect(names).not.toContain('Checklist');
+  });
 });
 
 describe('shopping formatting', () => {

--- a/packages/discord-ui/src/ui/format.test.ts
+++ b/packages/discord-ui/src/ui/format.test.ts
@@ -9,6 +9,7 @@ import {
   formatAmount,
   checklistView,
   checklistSummaryLine,
+  leaderboardView,
 } from './format.js';
 import type { Quest } from '@holons/core/tasks';
 import type { ShoppingChecklist } from '@holons/core/shopping';
@@ -155,5 +156,28 @@ describe('checklist formatting', () => {
 
   it('shows an empty state', () => {
     expect(checklistView(checklist([]))).toMatch(/empty/i);
+  });
+});
+
+describe('leaderboard formatting', () => {
+  it('sorts by score descending and medals the top three', () => {
+    const out = leaderboardView([
+      { name: 'Bob', score: 8, percentage: 30 },
+      { name: 'Alice', score: 12, percentage: 45 },
+      { name: 'Carol', score: 4, percentage: 15 },
+      { name: 'Dan', score: 2, percentage: 10 },
+    ]);
+    const lines = out.split('\n');
+    expect(lines[0]).toContain('🥇');
+    expect(lines[0]).toContain('Alice');
+    expect(lines[1]).toContain('🥈');
+    expect(lines[1]).toContain('Bob');
+    expect(lines[2]).toContain('🥉');
+    expect(lines[3]).toContain('4.'); // numbered after the medals
+    expect(lines[0]).toContain('(45%)');
+  });
+
+  it('shows an empty state', () => {
+    expect(leaderboardView([])).toMatch(/no contributions/i);
   });
 });

--- a/packages/discord-ui/src/ui/format.ts
+++ b/packages/discord-ui/src/ui/format.ts
@@ -181,3 +181,31 @@ export function checklistSummaryLine(checklist: Checklist): string {
   const done = (checklist.items ?? []).filter(i => i.checked).length;
   return `📝 **${checklist.id}** — ${done}/${total} done`;
 }
+
+// ---------------------------------------------------------------------------
+// Scores / leaderboard
+// ---------------------------------------------------------------------------
+
+export interface LeaderboardEntry {
+  name: string;
+  score: number;
+  /** Share of the holon's total, already on a 0–100 scale. */
+  percentage: number;
+}
+
+const MEDALS = ['🥇', '🥈', '🥉'];
+
+/** Render a contribution leaderboard, sorted by score descending. */
+export function leaderboardView(entries: LeaderboardEntry[]): string {
+  if (!entries || entries.length === 0) {
+    return '_No contributions scored yet._';
+  }
+  return [...entries]
+    .sort((a, b) => b.score - a.score)
+    .map((entry, i) => {
+      const rank = MEDALS[i] ?? `**${i + 1}.**`;
+      const pct = Math.round(entry.percentage);
+      return `${rank} **${entry.name}** — ${formatAmount(entry.score)} (${pct}%)`;
+    })
+    .join('\n');
+}

--- a/packages/discord-ui/src/ui/format.ts
+++ b/packages/discord-ui/src/ui/format.ts
@@ -4,6 +4,8 @@
  */
 import type { Quest } from '@holons/core/tasks';
 import type { ShoppingChecklist, ShoppingItem } from '@holons/core/shopping';
+import type { BalancesResult } from '@holons/core/expenses';
+import type { Checklist } from '@holons/core/checklists';
 
 const TYPE_LABELS: Record<string, string> = {
   task: '📋 Task',
@@ -103,4 +105,79 @@ export function shoppingListView(checklist: ShoppingChecklist | null): string {
     }
   }
   return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Members
+// ---------------------------------------------------------------------------
+
+export interface MemberLike {
+  id: string | number;
+  username?: string | null;
+  first_name?: string | null;
+}
+
+export function memberName(member: MemberLike): string {
+  return member.username || member.first_name || String(member.id ?? 'unknown');
+}
+
+export function memberListView(members: MemberLike[]): string {
+  if (!members || members.length === 0) {
+    return '_No members yet. Use `/join` to register._';
+  }
+  return members.map(m => `• ${memberName(m)}`).join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Expenses
+// ---------------------------------------------------------------------------
+
+/** Round to 2 decimals and drop a trailing `.00`. */
+export function formatAmount(value: number): string {
+  const rounded = Math.round(value * 100) / 100;
+  return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(2);
+}
+
+/**
+ * Render net balances for one currency. `nameFor` resolves a user id to a
+ * display name (defaults to the raw id). Positive net = is owed; negative =
+ * owes.
+ */
+export function balancesView(
+  result: BalancesResult,
+  currency: string,
+  nameFor: (id: string | number) => string = String
+): string {
+  const cur = currency.toUpperCase();
+  const nonZero = result.balances.filter(b => Math.abs(b.net) >= 0.005);
+  if (nonZero.length === 0) return `Everyone is settled up in ${cur}. 🎉`;
+
+  return nonZero
+    .sort((a, b) => b.net - a.net)
+    .map(b => {
+      const name = nameFor(b.userId);
+      if (b.net > 0)
+        return `🟢 **${name}** is owed ${formatAmount(b.net)} ${cur}`;
+      return `🔴 **${name}** owes ${formatAmount(-b.net)} ${cur}`;
+    })
+    .join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Checklists
+// ---------------------------------------------------------------------------
+
+export function checklistView(checklist: Checklist): string {
+  if (!checklist.items || checklist.items.length === 0) {
+    return '_This checklist is empty._';
+  }
+  return checklist.items
+    .map(item => `${item.checked ? '☑️' : '⬜'} ${item.text}`)
+    .join('\n');
+}
+
+export function checklistSummaryLine(checklist: Checklist): string {
+  const total = checklist.items?.length ?? 0;
+  const done = (checklist.items ?? []).filter(i => i.checked).length;
+  return `📝 **${checklist.id}** — ${done}/${total} done`;
 }

--- a/packages/discord-ui/src/ui/format.ts
+++ b/packages/discord-ui/src/ui/format.ts
@@ -64,6 +64,18 @@ export function questEmbedView(quest: Quest): QuestEmbedView {
     fields.push({ name: 'Where', value: quest.location, inline: true });
   }
 
+  const deps = (quest.dependencies as string[] | undefined) ?? [];
+  if (deps.length > 0) {
+    fields.push({
+      name: 'Depends on',
+      value: `${deps.length} task${deps.length === 1 ? '' : 's'}`,
+      inline: true,
+    });
+  }
+  if (quest.checklistId) {
+    fields.push({ name: 'Checklist', value: '✓ linked', inline: true });
+  }
+
   const initiator =
     quest.initiator?.username ||
     quest.initiator?.firstName ||

--- a/packages/discord-ui/src/ui/format.ts
+++ b/packages/discord-ui/src/ui/format.ts
@@ -1,0 +1,106 @@
+/**
+ * Pure presentation helpers — no discord.js imports, so they're trivially
+ * unit-testable. `DiscordUI` turns these into EmbedBuilders / components.
+ */
+import type { Quest } from '@holons/core/tasks';
+import type { ShoppingChecklist, ShoppingItem } from '@holons/core/shopping';
+
+const TYPE_LABELS: Record<string, string> = {
+  task: '📋 Task',
+  quest: '📋 Quest',
+  event: '📅 Event',
+  recurring: '🔁 Recurring',
+  offer: '🎁 Offer',
+  request: '🙏 Request',
+  need: '🙏 Need',
+};
+
+export function questTypeLabel(type: string | undefined): string {
+  return TYPE_LABELS[type ?? 'task'] ?? '📋 Task';
+}
+
+export function participantNames(quest: Quest): string[] {
+  return (quest.participants ?? [])
+    .map(
+      p => p?.username || p?.firstName || (p?.id != null ? String(p.id) : '')
+    )
+    .filter((name): name is string => name.length > 0);
+}
+
+export interface QuestEmbedView {
+  title: string;
+  description: string;
+  fields: Array<{ name: string; value: string; inline?: boolean }>;
+  footer: string;
+}
+
+/** Build a plain, render-agnostic view of a quest for an embed. */
+export function questEmbedView(quest: Quest): QuestEmbedView {
+  const fields: QuestEmbedView['fields'] = [];
+
+  fields.push({
+    name: 'Type',
+    value: questTypeLabel(quest.type),
+    inline: true,
+  });
+  fields.push({
+    name: 'Status',
+    value: quest.status === 'completed' ? '✅ Completed' : '🟢 Ongoing',
+    inline: true,
+  });
+
+  const names = participantNames(quest);
+  fields.push({
+    name: `Participants (${names.length})`,
+    value: names.length > 0 ? names.join(', ') : '—',
+    inline: false,
+  });
+
+  if (quest.when)
+    fields.push({ name: 'When', value: quest.when, inline: true });
+  if (quest.location) {
+    fields.push({ name: 'Where', value: quest.location, inline: true });
+  }
+
+  const initiator =
+    quest.initiator?.username ||
+    quest.initiator?.firstName ||
+    (quest.initiator?.id != null ? String(quest.initiator.id) : 'unknown');
+
+  return {
+    title: quest.title || '(untitled)',
+    description: quest.description || '',
+    fields,
+    footer: `Created by ${initiator}`,
+  };
+}
+
+/** One-line summary used in the `/quests` list. */
+export function questSummaryLine(quest: Quest): string {
+  const done = quest.status === 'completed' ? '✅ ' : '';
+  const count = participantNames(quest).length;
+  const people = count > 0 ? ` · 👥 ${count}` : '';
+  return `${done}${questTypeLabel(quest.type)} — **${quest.title}**${people}`;
+}
+
+/** Render a shopping checklist as grouped markdown lines. */
+export function shoppingListView(checklist: ShoppingChecklist | null): string {
+  if (!checklist || checklist.items.length === 0) {
+    return '_The shopping list is empty._';
+  }
+  const byCategory = new Map<string, ShoppingItem[]>();
+  for (const item of checklist.items) {
+    const cat = (item.category as string) || '';
+    if (!byCategory.has(cat)) byCategory.set(cat, []);
+    byCategory.get(cat)!.push(item);
+  }
+
+  const lines: string[] = [];
+  for (const [cat, items] of byCategory) {
+    if (cat) lines.push(`__${cat}__`);
+    for (const item of items) {
+      lines.push(`${item.checked ? '☑️' : '⬜'} ${item.text}`);
+    }
+  }
+  return lines.join('\n');
+}

--- a/packages/discord-ui/src/ui/holonBinding.ts
+++ b/packages/discord-ui/src/ui/holonBinding.ts
@@ -1,0 +1,50 @@
+/**
+ * Guild -> holon binding. A Discord guild (server) is bound to exactly one
+ * Holons holon; every command in that guild operates on the bound holon.
+ *
+ * Bindings are persisted in holosphere under a fixed system namespace so they
+ * survive restarts, with an in-memory cache for hot reads.
+ */
+import type { HoloStore, HolonBindingStore } from '../types.js';
+import { log } from '../utils/logger.js';
+
+/** System namespace + bucket where guild->holon bindings live. */
+export const BINDING_NAMESPACE = '__discord__';
+export const BINDING_BUCKET = 'guildBindings';
+
+interface BindingRecord {
+  /** Holosphere keys each record by its `id` — here, the guild id. */
+  id: string;
+  holonId: string;
+}
+
+export class HolosphereHolonBindings implements HolonBindingStore {
+  private cache = new Map<string, string>();
+
+  constructor(private readonly holosphere: HoloStore) {}
+
+  async get(guildId: string): Promise<string | null> {
+    const cached = this.cache.get(guildId);
+    if (cached) return cached;
+    try {
+      const record = (await this.holosphere.get(
+        BINDING_NAMESPACE,
+        BINDING_BUCKET,
+        guildId
+      )) as BindingRecord | null | undefined;
+      if (record?.holonId) {
+        this.cache.set(guildId, record.holonId);
+        return record.holonId;
+      }
+    } catch (err) {
+      log.warn('Failed to read guild binding', { guildId, error: String(err) });
+    }
+    return null;
+  }
+
+  async set(guildId: string, holonId: string): Promise<void> {
+    const record: BindingRecord = { id: guildId, holonId };
+    await this.holosphere.put(BINDING_NAMESPACE, BINDING_BUCKET, record);
+    this.cache.set(guildId, holonId);
+  }
+}

--- a/packages/discord-ui/src/utils/config.ts
+++ b/packages/discord-ui/src/utils/config.ts
@@ -1,0 +1,32 @@
+/**
+ * Environment configuration for the Discord UI.
+ *
+ * Loads the monorepo-root `.env` first (single source of truth shared with the
+ * web app, telegram-ui and mcp-ui), then a package-local `.env` for overrides.
+ */
+import dotenv from 'dotenv';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// packages/discord-ui/src/utils -> repo root is four levels up.
+dotenv.config({ path: resolve(__dirname, '../../../../.env') });
+dotenv.config();
+
+export interface DiscordConfig {
+  /** Discord bot token. */
+  readonly token: string | undefined;
+  /** Discord application (client) id, needed to register slash commands. */
+  readonly appId: string | undefined;
+  /** Optional dev guild id — register commands there for instant updates. */
+  readonly guildId: string | undefined;
+  /** Holosphere application namespace. */
+  readonly appName: string;
+}
+
+export const config: DiscordConfig = {
+  token: process.env.DISCORD_TOKEN,
+  appId: process.env.DISCORD_APP_ID,
+  guildId: process.env.DISCORD_GUILD_ID,
+  appName: process.env.APPNAME || 'Holons',
+};

--- a/packages/discord-ui/src/utils/errorHandler.ts
+++ b/packages/discord-ui/src/utils/errorHandler.ts
@@ -1,0 +1,26 @@
+/**
+ * Process-level error handlers so an unhandled rejection in a Gun/holosphere
+ * callback or a Discord interaction handler doesn't crash the whole bot.
+ */
+import { log } from './logger.js';
+
+/** Extract a printable message from an unknown caught value. */
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function setupGlobalErrorHandlers(): void {
+  process.on('unhandledRejection', (reason: unknown) => {
+    log.error('Unhandled promise rejection', {
+      error: errorMessage(reason),
+      stack: reason instanceof Error ? reason.stack : undefined,
+    });
+  });
+
+  process.on('uncaughtException', (error: Error) => {
+    log.error('Uncaught exception', {
+      error: error.message,
+      stack: error.stack,
+    });
+  });
+}

--- a/packages/discord-ui/src/utils/keyStorage.ts
+++ b/packages/discord-ui/src/utils/keyStorage.ts
@@ -1,0 +1,53 @@
+/**
+ * Filesystem-based Nostr private-key storage (Node only). Ported from
+ * telegram-ui's `utils/key-storage.js` so the Discord bot persists a stable
+ * holosphere identity across restarts.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+function getKeyDir(): string {
+  const configDir =
+    process.env.XDG_CONFIG_HOME ||
+    (process.platform === 'win32'
+      ? process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming')
+      : path.join(os.homedir(), '.config'));
+  return path.join(configDir, 'holosphere', 'keys');
+}
+
+function getKeyPath(appName: string): string {
+  const safeName = appName.replace(/[^a-zA-Z0-9-_]/g, '_');
+  return path.join(getKeyDir(), `${safeName}.key`);
+}
+
+export function loadKey(appName: string): string | null {
+  const keyPath = getKeyPath(appName);
+  if (fs.existsSync(keyPath)) {
+    const key = fs.readFileSync(keyPath, 'utf8').trim();
+    if (/^[0-9a-f]{64}$/i.test(key)) return key;
+  }
+  return null;
+}
+
+export function saveKey(appName: string, privateKey: string): string {
+  if (!/^[0-9a-f]{64}$/i.test(privateKey)) {
+    throw new Error('Invalid private key format');
+  }
+  const keyPath = getKeyPath(appName);
+  const dir = path.dirname(keyPath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(keyPath, privateKey, { mode: 0o600 });
+  return keyPath;
+}
+
+export function getOrCreateKey(
+  appName: string,
+  generateFn: () => string
+): string {
+  const existing = loadKey(appName);
+  if (existing) return existing;
+  const newKey = generateFn();
+  saveKey(appName, newKey);
+  return newKey;
+}

--- a/packages/discord-ui/src/utils/logger.ts
+++ b/packages/discord-ui/src/utils/logger.ts
@@ -1,0 +1,44 @@
+/**
+ * Structured logger for the Discord UI. Mirrors the telegram-ui logger shape
+ * (a `log` helper with level methods) so service code reads the same in both
+ * bots, but is TypeScript and console-only by default.
+ */
+import winston from 'winston';
+
+const logLevels = { error: 0, warn: 1, info: 2, debug: 3 } as const;
+
+const logger = winston.createLogger({
+  levels: logLevels,
+  level: process.env.LOG_LEVEL || 'info',
+  format: winston.format.combine(
+    winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
+    winston.format.errors({ stack: true }),
+    winston.format.colorize(),
+    winston.format.printf(({ level, message, timestamp, stack, ...meta }) => {
+      delete (meta as Record<string, unknown>).timestamp;
+      delete (meta as Record<string, unknown>).level;
+      delete (meta as Record<string, unknown>).message;
+      let line = `${timestamp} [${level}]: ${message}`;
+      if (stack) line += `\n${stack}`;
+      const keys = Object.keys(meta);
+      if (keys.length > 0) line += ` ${JSON.stringify(meta)}`;
+      return line;
+    })
+  ),
+  transports: [
+    new winston.transports.Console({
+      level: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
+    }),
+  ],
+});
+
+type Meta = Record<string, unknown>;
+
+export const log = {
+  error: (message: string, meta: Meta = {}) => logger.error(message, meta),
+  warn: (message: string, meta: Meta = {}) => logger.warn(message, meta),
+  info: (message: string, meta: Meta = {}) => logger.info(message, meta),
+  debug: (message: string, meta: Meta = {}) => logger.debug(message, meta),
+};
+
+export default logger;

--- a/packages/discord-ui/tsconfig.json
+++ b/packages/discord-ui/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node"],
+    "noEmit": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,13 +30,13 @@ importers:
     devDependencies:
       '@sveltejs/adapter-static':
         specifier: ^3.0.6
-        version: 3.0.10(@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.2))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))
+        version: 3.0.10(@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))
       '@sveltejs/kit':
         specifier: ^2.59.1
-        version: 2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.2))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+        version: 2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.1
-        version: 5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+        version: 5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       '@tsconfig/svelte':
         specifier: ^5.0.4
         version: 5.0.8
@@ -48,13 +48,13 @@ importers:
         version: 3.8.3
       prettier-plugin-svelte:
         specifier: ^3.3.2
-        version: 3.5.1(prettier@3.8.3)(svelte@5.55.5(@typescript-eslint/types@8.59.2))
+        version: 3.5.1(prettier@3.8.3)(svelte@5.55.5(@typescript-eslint/types@8.60.0))
       svelte:
         specifier: ^5.0.0
-        version: 5.55.5(@typescript-eslint/types@8.59.2)
+        version: 5.55.5(@typescript-eslint/types@8.60.0)
       svelte-check:
         specifier: ^3.0.1
-        version: 3.8.6(postcss-load-config@3.1.4(postcss@8.5.14))(postcss@8.5.14)(sass@1.99.0)(svelte@5.55.5(@typescript-eslint/types@8.59.2))
+        version: 3.8.6(postcss-load-config@3.1.4(postcss@8.5.14))(postcss@8.5.14)(sass@1.99.0)(svelte@5.55.5(@typescript-eslint/types@8.60.0))
       tslib:
         specifier: ^2.4.1
         version: 2.8.1
@@ -141,29 +141,29 @@ importers:
         version: 1.99.0
       svelte:
         specifier: ^5.0.0
-        version: 5.55.5(@typescript-eslint/types@8.59.2)
+        version: 5.55.5(@typescript-eslint/types@8.60.0)
       svelte-dnd-action:
         specifier: ^0.9.65
-        version: 0.9.69(svelte@5.55.5(@typescript-eslint/types@8.59.2))
+        version: 0.9.69(svelte@5.55.5(@typescript-eslint/types@8.60.0))
       svelte-feathers:
         specifier: ^1.0.6
-        version: 1.0.6(svelte@5.55.5(@typescript-eslint/types@8.59.2))
+        version: 1.0.6(svelte@5.55.5(@typescript-eslint/types@8.60.0))
       svelte-preprocess:
         specifier: ^6.0.3
-        version: 6.0.3(postcss-load-config@3.1.4(postcss@8.5.14))(postcss@8.5.14)(sass@1.99.0)(svelte@5.55.5(@typescript-eslint/types@8.59.2))(typescript@5.9.3)
+        version: 6.0.3(postcss-load-config@3.1.4(postcss@8.5.14))(postcss@8.5.14)(sass@1.99.0)(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)
       ws:
         specifier: ^8.20.0
         version: 8.20.0
     devDependencies:
       '@sveltejs/adapter-netlify':
         specifier: ^4.4.2
-        version: 4.4.2(@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.2))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))
+        version: 4.4.2(@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))
       '@sveltejs/kit':
         specifier: ^2.59.1
-        version: 2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.2))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+        version: 2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.1
-        version: 5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+        version: 5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       '@tsconfig/svelte':
         specifier: ^5.0.4
         version: 5.0.8
@@ -193,7 +193,7 @@ importers:
         version: 9.1.2(eslint@8.57.1)
       eslint-plugin-svelte:
         specifier: ^3.5.1
-        version: 3.17.1(eslint@8.57.1)(svelte@5.55.5(@typescript-eslint/types@8.59.2))
+        version: 3.17.1(eslint@8.57.1)(svelte@5.55.5(@typescript-eslint/types@8.60.0))
       eslint-plugin-tailwindcss:
         specifier: ^3.18.0
         version: 3.18.3(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
@@ -211,10 +211,10 @@ importers:
         version: 3.8.3
       prettier-plugin-svelte:
         specifier: ^3.3.2
-        version: 3.5.1(prettier@3.8.3)(svelte@5.55.5(@typescript-eslint/types@8.59.2))
+        version: 3.5.1(prettier@3.8.3)(svelte@5.55.5(@typescript-eslint/types@8.60.0))
       svelte-check:
         specifier: ^3.0.1
-        version: 3.8.6(postcss-load-config@3.1.4(postcss@8.5.14))(postcss@8.5.14)(sass@1.99.0)(svelte@5.55.5(@typescript-eslint/types@8.59.2))
+        version: 3.8.6(postcss-load-config@3.1.4(postcss@8.5.14))(postcss@8.5.14)(sass@1.99.0)(svelte@5.55.5(@typescript-eslint/types@8.60.0))
       tailwindcss:
         specifier: ^3.4.16
         version: 3.4.19(tsx@4.21.0)(yaml@2.8.4)
@@ -277,6 +277,58 @@ importers:
       vitest:
         specifier: ^4.0.18
         version: 4.1.5(@types/node@22.19.17)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+
+  packages/discord-ui:
+    dependencies:
+      '@holons/core':
+        specifier: workspace:*
+        version: link:../core
+      discord.js:
+        specifier: ^14.16.3
+        version: 14.26.4
+      dotenv:
+        specifier: ^17.2.3
+        version: 17.4.2
+      holosphere:
+        specifier: 1.3.0-alpha7
+        version: 1.3.0-alpha7(gun@0.2020.1241)(h3-js@4.4.0)(openai@4.104.0(ws@8.20.0)(zod@3.25.76))
+      nostr-tools:
+        specifier: ^2.17.2
+        version: 2.23.3(typescript@5.9.3)
+      winston:
+        specifier: ^3.17.0
+        version: 3.19.0
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.39.4
+        version: 9.39.4
+      '@types/node':
+        specifier: ^22.19.17
+        version: 22.19.17
+      eslint:
+        specifier: ^9.35.0
+        version: 9.39.4(jiti@2.7.0)
+      eslint-config-prettier:
+        specifier: ^10.1.8
+        version: 10.1.8(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-prettier:
+        specifier: ^5.5.4
+        version: 5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3)
+      prettier:
+        specifier: ^3.6.2
+        version: 3.8.3
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.20.0
+        version: 8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
 
   packages/mcp-ui:
     dependencies:
@@ -1743,8 +1795,23 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/eslint-plugin@8.60.0':
+    resolution: {integrity: sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.60.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/parser@8.59.2':
     resolution: {integrity: sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.60.0':
+    resolution: {integrity: sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -1756,12 +1823,28 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/project-service@8.60.0':
+    resolution: {integrity: sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/scope-manager@8.59.2':
     resolution: {integrity: sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/scope-manager@8.60.0':
+    resolution: {integrity: sha512-pFzqhllJMs+jghLQWzV00ds39xLzuyqPSev5pd8f4Ir0rtKR3ZLUB4/4dhjOFighWb9larvtfJvqL+4yKDI3Xw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/tsconfig-utils@8.59.2':
     resolution: {integrity: sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/tsconfig-utils@8.60.0':
+    resolution: {integrity: sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -1773,12 +1856,29 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/type-utils@8.60.0':
+    resolution: {integrity: sha512-SX46wEUtitCpq7AN38HkUU/+zvUpdKf7ephtWAFgckH8O7PQIyL5gvrhQgBLuEYgLfuKWOVvWVskMbuFHAz5xg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/types@8.59.2':
     resolution: {integrity: sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.60.0':
+    resolution: {integrity: sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.59.2':
     resolution: {integrity: sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/typescript-estree@8.60.0':
+    resolution: {integrity: sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -1790,8 +1890,19 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/utils@8.60.0':
+    resolution: {integrity: sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/visitor-keys@8.59.2':
     resolution: {integrity: sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.60.0':
+    resolution: {integrity: sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.1':
@@ -4490,6 +4601,13 @@ packages:
     peerDependencies:
       typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x
 
+  typescript-eslint@8.60.0:
+    resolution: {integrity: sha512-9f65qWLZdAW9m1JaxBDUHcqRUfL8bkxxXL7XxEfI+F09q56PkBvIfCjLF3yInsDM/BBmwkqmCQdCZe/RYlIWEw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -5633,22 +5751,22 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/adapter-netlify@4.4.2(@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.2))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))':
+  '@sveltejs/adapter-netlify@4.4.2(@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))':
     dependencies:
       '@iarna/toml': 2.2.5
-      '@sveltejs/kit': 2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.2))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@sveltejs/kit': 2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       esbuild: 0.27.7
       set-cookie-parser: 2.7.2
 
-  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.2))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))':
+  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))':
     dependencies:
-      '@sveltejs/kit': 2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.2))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@sveltejs/kit': 2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
 
-  '@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.2))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       '@types/cookie': 0.6.0
       acorn: 8.16.0
       cookie: 0.7.2
@@ -5659,16 +5777,16 @@ snapshots:
       mrmime: 2.0.1
       set-cookie-parser: 3.1.0
       sirv: 3.0.2
-      svelte: 5.55.5(@typescript-eslint/types@8.59.2)
+      svelte: 5.55.5(@typescript-eslint/types@8.60.0)
       vite: 6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.2))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       '@types/cookie': 0.6.0
       acorn: 8.16.0
       cookie: 0.7.2
@@ -5679,50 +5797,50 @@ snapshots:
       mrmime: 2.0.1
       set-cookie-parser: 3.1.0
       sirv: 3.0.2
-      svelte: 5.55.5(@typescript-eslint/types@8.59.2)
+      svelte: 5.55.5(@typescript-eslint/types@8.60.0)
       vite: 6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       debug: 4.4.3(supports-color@5.5.0)
-      svelte: 5.55.5(@typescript-eslint/types@8.59.2)
+      svelte: 5.55.5(@typescript-eslint/types@8.60.0)
       vite: 6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       debug: 4.4.3(supports-color@5.5.0)
-      svelte: 5.55.5(@typescript-eslint/types@8.59.2)
+      svelte: 5.55.5(@typescript-eslint/types@8.60.0)
       vite: 6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       debug: 4.4.3(supports-color@5.5.0)
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.21
-      svelte: 5.55.5(@typescript-eslint/types@8.59.2)
+      svelte: 5.55.5(@typescript-eslint/types@8.60.0)
       vite: 6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
       vitefu: 1.1.3(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       debug: 4.4.3(supports-color@5.5.0)
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.21
-      svelte: 5.55.5(@typescript-eslint/types@8.59.2)
+      svelte: 5.55.5(@typescript-eslint/types@8.60.0)
       vite: 6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
       vitefu: 1.1.3(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
     transitivePeerDependencies:
@@ -5952,6 +6070,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.60.0
+      '@typescript-eslint/type-utils': 8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.60.0
+      eslint: 9.39.4(jiti@2.7.0)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.59.2(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.59.2
@@ -5960,6 +6094,18 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.59.2
       debug: 4.4.3(supports-color@5.5.0)
       eslint: 8.57.1
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.60.0
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/typescript-estree': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.60.0
+      debug: 4.4.3(supports-color@5.5.0)
+      eslint: 9.39.4(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -5973,12 +6119,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.60.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.60.0
+      debug: 4.4.3(supports-color@5.5.0)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@8.59.2':
     dependencies:
       '@typescript-eslint/types': 8.59.2
       '@typescript-eslint/visitor-keys': 8.59.2
 
+  '@typescript-eslint/scope-manager@8.60.0':
+    dependencies:
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/visitor-keys': 8.60.0
+
   '@typescript-eslint/tsconfig-utils@8.59.2(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/tsconfig-utils@8.60.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
@@ -5994,7 +6158,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/type-utils@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/typescript-estree': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      debug: 4.4.3(supports-color@5.5.0)
+      eslint: 9.39.4(jiti@2.7.0)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@8.59.2': {}
+
+  '@typescript-eslint/types@8.60.0': {}
 
   '@typescript-eslint/typescript-estree@8.59.2(typescript@5.9.3)':
     dependencies:
@@ -6002,6 +6180,21 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@5.9.3)
       '@typescript-eslint/types': 8.59.2
       '@typescript-eslint/visitor-keys': 8.59.2
+      debug: 4.4.3(supports-color@5.5.0)
+      minimatch: 10.2.5
+      semver: 7.7.4
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.60.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/visitor-keys': 8.60.0
       debug: 4.4.3(supports-color@5.5.0)
       minimatch: 10.2.5
       semver: 7.7.4
@@ -6022,9 +6215,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
+      '@typescript-eslint/scope-manager': 8.60.0
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/typescript-estree': 8.60.0(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@8.59.2':
     dependencies:
       '@typescript-eslint/types': 8.59.2
+      eslint-visitor-keys: 5.0.1
+
+  '@typescript-eslint/visitor-keys@8.60.0':
+    dependencies:
+      '@typescript-eslint/types': 8.60.0
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.1': {}
@@ -6939,7 +7148,7 @@ snapshots:
     optionalDependencies:
       eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.7.0))
 
-  eslint-plugin-svelte@3.17.1(eslint@8.57.1)(svelte@5.55.5(@typescript-eslint/types@8.59.2)):
+  eslint-plugin-svelte@3.17.1(eslint@8.57.1)(svelte@5.55.5(@typescript-eslint/types@8.60.0)):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -6951,9 +7160,9 @@ snapshots:
       postcss-load-config: 3.1.4(postcss@8.5.14)
       postcss-safe-parser: 7.0.1(postcss@8.5.14)
       semver: 7.7.4
-      svelte-eslint-parser: 1.6.1(svelte@5.55.5(@typescript-eslint/types@8.59.2))
+      svelte-eslint-parser: 1.6.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))
     optionalDependencies:
-      svelte: 5.55.5(@typescript-eslint/types@8.59.2)
+      svelte: 5.55.5(@typescript-eslint/types@8.60.0)
     transitivePeerDependencies:
       - ts-node
 
@@ -7091,11 +7300,11 @@ snapshots:
     dependencies:
       estraverse: 5.3.0
 
-  esrap@2.2.6(@typescript-eslint/types@8.59.2):
+  esrap@2.2.6(@typescript-eslint/types@8.60.0):
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
     optionalDependencies:
-      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/types': 8.60.0
 
   esrecurse@4.3.0:
     dependencies:
@@ -8189,10 +8398,10 @@ snapshots:
     dependencies:
       fast-diff: 1.3.0
 
-  prettier-plugin-svelte@3.5.1(prettier@3.8.3)(svelte@5.55.5(@typescript-eslint/types@8.59.2)):
+  prettier-plugin-svelte@3.5.1(prettier@3.8.3)(svelte@5.55.5(@typescript-eslint/types@8.60.0)):
     dependencies:
       prettier: 3.8.3
-      svelte: 5.55.5(@typescript-eslint/types@8.59.2)
+      svelte: 5.55.5(@typescript-eslint/types@8.60.0)
 
   prettier@3.8.3: {}
 
@@ -8721,14 +8930,14 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@3.8.6(postcss-load-config@3.1.4(postcss@8.5.14))(postcss@8.5.14)(sass@1.99.0)(svelte@5.55.5(@typescript-eslint/types@8.59.2)):
+  svelte-check@3.8.6(postcss-load-config@3.1.4(postcss@8.5.14))(postcss@8.5.14)(sass@1.99.0)(svelte@5.55.5(@typescript-eslint/types@8.60.0)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       chokidar: 3.6.0
       picocolors: 1.1.1
       sade: 1.8.1
-      svelte: 5.55.5(@typescript-eslint/types@8.59.2)
-      svelte-preprocess: 5.1.4(postcss-load-config@3.1.4(postcss@8.5.14))(postcss@8.5.14)(sass@1.99.0)(svelte@5.55.5(@typescript-eslint/types@8.59.2))(typescript@5.9.3)
+      svelte: 5.55.5(@typescript-eslint/types@8.60.0)
+      svelte-preprocess: 5.1.4(postcss-load-config@3.1.4(postcss@8.5.14))(postcss@8.5.14)(sass@1.99.0)(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@babel/core'
@@ -8741,11 +8950,11 @@ snapshots:
       - stylus
       - sugarss
 
-  svelte-dnd-action@0.9.69(svelte@5.55.5(@typescript-eslint/types@8.59.2)):
+  svelte-dnd-action@0.9.69(svelte@5.55.5(@typescript-eslint/types@8.60.0)):
     dependencies:
-      svelte: 5.55.5(@typescript-eslint/types@8.59.2)
+      svelte: 5.55.5(@typescript-eslint/types@8.60.0)
 
-  svelte-eslint-parser@1.6.1(svelte@5.55.5(@typescript-eslint/types@8.59.2)):
+  svelte-eslint-parser@1.6.1(svelte@5.55.5(@typescript-eslint/types@8.60.0)):
     dependencies:
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -8755,36 +8964,36 @@ snapshots:
       postcss-selector-parser: 7.1.1
       semver: 7.7.4
     optionalDependencies:
-      svelte: 5.55.5(@typescript-eslint/types@8.59.2)
+      svelte: 5.55.5(@typescript-eslint/types@8.60.0)
 
-  svelte-feathers@1.0.6(svelte@5.55.5(@typescript-eslint/types@8.59.2)):
+  svelte-feathers@1.0.6(svelte@5.55.5(@typescript-eslint/types@8.60.0)):
     dependencies:
-      svelte: 5.55.5(@typescript-eslint/types@8.59.2)
+      svelte: 5.55.5(@typescript-eslint/types@8.60.0)
 
-  svelte-preprocess@5.1.4(postcss-load-config@3.1.4(postcss@8.5.14))(postcss@8.5.14)(sass@1.99.0)(svelte@5.55.5(@typescript-eslint/types@8.59.2))(typescript@5.9.3):
+  svelte-preprocess@5.1.4(postcss-load-config@3.1.4(postcss@8.5.14))(postcss@8.5.14)(sass@1.99.0)(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3):
     dependencies:
       '@types/pug': 2.0.10
       detect-indent: 6.1.0
       magic-string: 0.30.21
       sorcery: 0.11.1
       strip-indent: 3.0.0
-      svelte: 5.55.5(@typescript-eslint/types@8.59.2)
+      svelte: 5.55.5(@typescript-eslint/types@8.60.0)
     optionalDependencies:
       postcss: 8.5.14
       postcss-load-config: 3.1.4(postcss@8.5.14)
       sass: 1.99.0
       typescript: 5.9.3
 
-  svelte-preprocess@6.0.3(postcss-load-config@3.1.4(postcss@8.5.14))(postcss@8.5.14)(sass@1.99.0)(svelte@5.55.5(@typescript-eslint/types@8.59.2))(typescript@5.9.3):
+  svelte-preprocess@6.0.3(postcss-load-config@3.1.4(postcss@8.5.14))(postcss@8.5.14)(sass@1.99.0)(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3):
     dependencies:
-      svelte: 5.55.5(@typescript-eslint/types@8.59.2)
+      svelte: 5.55.5(@typescript-eslint/types@8.60.0)
     optionalDependencies:
       postcss: 8.5.14
       postcss-load-config: 3.1.4(postcss@8.5.14)
       sass: 1.99.0
       typescript: 5.9.3
 
-  svelte@5.55.5(@typescript-eslint/types@8.59.2):
+  svelte@5.55.5(@typescript-eslint/types@8.60.0):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -8797,7 +9006,7 @@ snapshots:
       clsx: 2.1.1
       devalue: 5.8.0
       esm-env: 1.2.2
-      esrap: 2.2.6(@typescript-eslint/types@8.59.2)
+      esrap: 2.2.6(@typescript-eslint/types@8.60.0)
       is-reference: 3.0.3
       locate-character: 3.0.0
       magic-string: 0.30.21
@@ -9006,6 +9215,17 @@ snapshots:
       minimatch: 10.2.5
       typescript: 5.9.3
       yaml: 2.8.4
+
+  typescript-eslint@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.60.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
 
   typescript@5.9.3: {}
 


### PR DESCRIPTION
## Summary

Adds a new `packages/discord-ui` (`@holons/discord-ui`) — the Discord counterpart to `telegram-ui`. Like every other Holons UI, it is a thin adapter that delegates **all** business logic to `@holons/core`; the package only translates Discord interactions and renders embeds/buttons.

Forked from `sharedlogic`, so this PR targets that branch and the diff is essentially just the new package (plus one additive line in core and a root script).

## Architecture

- **Runtime:** discord.js gateway client, REST slash-command registration (guild for dev / global for prod), and a single `interactionCreate` router that dispatches slash commands by name and components/modals by a `feature:action:args` customId namespace.
- **Context bridge:** per-interaction `@holons/core` `CommandContext` (`source: 'discord'`); added `'discord'` to the core `source` union.
- **Guild → holon binding** persisted in holosphere.
- **UI helpers:** embed/button builders over pure, unit-tested formatters.
- Mirrors telegram-ui's tooling (eslint flat config, tsconfig, prettier, vitest) and DI `ServiceContainer`; adds a `dev:discord` root script.

### Telegram → Discord mapping
| Telegram (telegraf) | Discord (discord.js) |
| --- | --- |
| `bot.command('x')` | slash command |
| `ctx.reply()` | `interaction.reply()` (embeds) |
| inline keyboard buttons | `ButtonBuilder` + `ActionRowBuilder` |
| scenes / wizards | modals + collectors |
| editable "hologram" msg | stored message id + `message.edit()` |
| per-chat → holon | per-guild → holon (`/holon bind`) |

## Commands (13 across 6 features)

- `/holon bind|current` — bind a server to a holon.
- `/join` · `/leave` · `/members` — membership (profiles in the `users` lens).
- `/task` · `/event` · `/offer` · `/request` — create quests; join/leave + complete via buttons; **appreciate** once completed.
- `/quests` — list quests.
- `/shopping add|list` — shared shopping list (toggle + remove-checked buttons).
- `/expense` · `/balances` — record shared costs and show credit-matrix balances per currency.
- `/checklist create|add|show|list` — checklists with per-item toggle buttons.

All domain logic comes from `@holons/core/{tasks,shopping,expenses,users,checklists,commands}`.

## Verification

- `pnpm -F @holons/discord-ui typecheck` ✅
- `pnpm -F @holons/discord-ui lint` ✅
- `pnpm -F @holons/discord-ui build` ✅
- `pnpm -F @holons/discord-ui test` ✅ (26 unit tests: router/registry, customId codec, context mapping, and all pure formatters)
- `@holons/core` unchanged behavior (169 tests pass); smoke test confirms all 13 commands register.

Live Discord smoke-testing needs `DISCORD_TOKEN` / `DISCORD_APP_ID` and gateway network access (see `.env.example`).

## Roadmap (telegram parity)

✅ Phase 1 (runtime + quests/shopping) · ✅ Phase 2 (membership, expenses, checklists, appreciation) · ⬜ deeper quests, tags/roles, scheduler, federation, library, settings, long tail.

https://claude.ai/code/session_01XVG6Tyd4QAKDvDws2ZSWA1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XVG6Tyd4QAKDvDws2ZSWA1)_