### PR TITLE
feat(holosphere): pluggable StorageBackend with AD4M adapter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,11 @@ packages/ai-ui/        Claude tool-use NL interface
 packages/mcp-ui/       Model Context Protocol server
 ```
 
-Data layer: **Holosphere**, a decentralized [GUN](https://gun.eco) graph,
-namespaced per holon, peer-to-peer and local-first.
+Data layer: **Holosphere**, namespaced per holon, over a pluggable
+`StorageBackend`. Default is a decentralized [GUN](https://gun.eco) graph
+(peer-to-peer, local-first); an optional [AD4M](https://ad4m.dev) backend maps
+holons→perspectives and lenses→subject classes. Select via
+`VITE_HOLOSPHERE_BACKEND` (`gun` default, or `ad4m`).
 
 License: **AGPL-3.0-or-later** with a commercial option — see
 [`LICENSING.md`](./LICENSING.md). New source files get the SPDX header.
@@ -66,6 +69,35 @@ pnpm dev                           # web UI  → http://localhost:5173
 pnpm dev:bot                       # Telegram bot
 pnpm -F @holons/text-ui exec holons --help
 ```
+
+## AD4M backend (optional)
+
+Holosphere storage is pluggable (`packages/holosphere/backends/`). GUN is the
+default; AD4M is opt-in via `VITE_HOLOSPHERE_BACKEND=ad4m`. Mapping: holon →
+perspective, lens → subject class, item → subject instance, key →
+base-expression URI.
+
+- **Two modes.** Given lens JSON Schemas (`packages/core/schemas/`, bundled for
+  the browser by `core/holosphere/ad4mSchemas.ts`), each lens gets a *dedicated*
+  typed subject class that persists only its declared properties. Given an empty
+  schema map, the backend runs *opaque*: every lens uses one `GenericLensModel`
+  that round-trips the whole payload as a JSON string. Apps run dedicated; the
+  conformance suite runs opaque (the opaque-KV contract GUN also satisfies).
+- **Gotcha — never declare an `id` property on a subject model.** AD4M reserves
+  `id` as the alias for a subject's base-expression URI. If a model declares `id`
+  as data, `findAll` hydrates each instance from the `id` *link value* (the
+  logical key) instead of the full URI, so lens-prefix scoping in `getAll`
+  filters every instance out — a silent empty result. The generic model stores
+  only `data` and recovers the logical id from the base URI's last segment.
+- **Browser safety.** The browser path must not pull Node builtins: schemas are
+  supplied in memory (`import.meta.glob`), and `subjects/index.js` imports
+  `fs/path/url` lazily only on the Node disk-reading branch.
+- **Conformance tests are opt-in.** The GUN half of
+  `test/backend-conformance.test.js` runs everywhere; the AD4M half runs only
+  when `AD4M_TEST_URL` is set and must point at a *disposable* executor (the
+  suite creates and deletes perspectives). Boot one with
+  `node packages/holosphere/scripts/dev-executor.mjs` (all config via env), then:
+  `AD4M_TEST_URL=http://127.0.0.1:<port> AD4M_TEST_TOKEN=<tok> pnpm -F holosphere test -- backend-conformance`.
 
 ## When unsure
 

--- a/apps/kiosk/src/lib/holosphere.ts
+++ b/apps/kiosk/src/lib/holosphere.ts
@@ -12,6 +12,8 @@
 import {
   createHoloSphere,
   createHolonWriter,
+  loadAd4mSchemas,
+  type CreateHoloSphereOptions,
   type HolonWriter,
 } from "@holons/core/holosphere";
 import type { HoloSphere } from "holosphere";
@@ -52,20 +54,46 @@ function deviceKeyHex(): string {
 
 let instance: Promise<HoloSphere> | null = null;
 
+/**
+ * Assemble the factory options for the configured backend.
+ *
+ * `VITE_HOLOSPHERE_BACKEND` selects the storage backend (`gun`, the default,
+ * or `ad4m`). The AD4M path talks to an executor over its RPC WebSocket
+ * (`VITE_AD4M_URL` is the executor's HTTP origin, default
+ * `http://localhost:12000`; the client derives the ws:// RPC URL) and supplies
+ * the lens JSON Schemas in memory (no filesystem in the browser). Gun keeps its
+ * production relay peers.
+ */
+function holosphereOptions(): CreateHoloSphereOptions & { awaitReady: true } {
+  const base = {
+    appName: resolveAppName(),
+    privateKey: deviceKeyHex(),
+    logLevel: "ERROR",
+    awaitReady: true as const,
+  };
+  const backend = (
+    import.meta.env.VITE_HOLOSPHERE_BACKEND ?? "gun"
+  ).toLowerCase();
+  if (backend === "ad4m") {
+    return {
+      ...base,
+      backend: "ad4m",
+      ad4m: {
+        url: import.meta.env.VITE_AD4M_URL || "http://localhost:12000",
+        token: import.meta.env.VITE_AD4M_TOKEN || undefined,
+        schemas: loadAd4mSchemas(),
+      },
+    };
+  }
+  // Read from the production Gun relay (overridable via VITE_KIOSK_PEER).
+  return { ...base, extra: { peers: resolvePeers() } };
+}
+
 /** Build (once) and return the shared HoloSphere instance. */
 export function getHolosphere(): Promise<HoloSphere> {
   if (!instance) {
     // Promise.resolve normalises the factory's overloaded return type.
-    instance = Promise.resolve(
-      createHoloSphere({
-        appName: resolveAppName(),
-        privateKey: deviceKeyHex(),
-        logLevel: "ERROR",
-        awaitReady: true,
-        // Read from the production Gun relay (overridable via VITE_KIOSK_PEER).
-        extra: { peers: resolvePeers() },
-      }),
-    );
+    instance = Promise.resolve(createHoloSphere(holosphereOptions()));
     // Dev-only: expose the instance so the kiosk can be poked from the console
     // (and from headless smoke tests). Tree-shaken out of production builds.
     if (import.meta.env.DEV && typeof window !== "undefined") {

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -4,7 +4,7 @@
 	import { page } from '$app/stores';
 	import { browser } from '$app/environment';
 	import { handshake } from "holosphere"
-	import { createHoloSphere } from '@holons/core/holosphere';
+	import { createHoloSphere, loadAd4mSchemas } from '@holons/core/holosphere';
 	import { hexToBytes } from '@noble/hashes/utils';
 	import Layout from '../dashboard/Layout.svelte';
 	import Splash from '../components/Splash.svelte';
@@ -477,12 +477,26 @@
 		// factory every UI uses (CLAUDE.md: core owns meaning, UIs only
 		// render). `awaitReady: true` returns the instance after ready()
 		// has resolved, which is a no-op in alpha7 but keeps the contract.
+		// `VITE_HOLOSPHERE_BACKEND` selects the storage backend (`gun`, default,
+		// or `ad4m`). The AD4M path talks to an executor over its RPC WebSocket
+		// (`VITE_AD4M_URL` is the executor's HTTP origin, default
+		// `http://localhost:12000`; the client derives the ws:// RPC URL) and
+		// supplies the lens JSON Schemas in memory (no filesystem in the browser).
+		const backend = (import.meta.env.VITE_HOLOSPHERE_BACKEND ?? 'gun').toLowerCase();
 		holosphere = await createHoloSphere({
 			appName: environmentName,
 			privateKey: hexToBytes(privateKey),
 			awaitReady: true,
-			// Holosphere 2: pass `backend: 'nostr'` + `extra: { nostr: { peers: [...] } }`
-			// once the Nostr backend lands.
+			...(backend === 'ad4m'
+				? {
+						backend: 'ad4m' as const,
+						ad4m: {
+							url: import.meta.env.VITE_AD4M_URL || 'http://localhost:12000',
+							token: import.meta.env.VITE_AD4M_TOKEN || undefined,
+							schemas: loadAd4mSchemas(),
+						},
+					}
+				: {}),
 		});
 
 		// Log the public key for verification
@@ -524,6 +538,10 @@
 					console.log(`[signing] enabled (${signingMode})`, relays.length ? `→ ${relays.length} relay(s)` : '(local envelopes only)');
 				}
 				if (typeof window !== 'undefined') {
+					// Dev-only handle for console/headless inspection (mirrors the
+					// kiosk's `window.__kiosk`). Lets a smoke test read the active
+					// backend (`__holosphere._backend.type`) and drive round-trips.
+					if (import.meta.env.DEV) (window as any).__holosphere = holosphere;
 					(window as any).__signingReport = () => (holosphere as any).getShadowReport?.();
 					// Direct delete escape hatch for known-bad/storming keys, e.g.
 					// await __del('123','quests','moufplh7i0t').

--- a/package.json
+++ b/package.json
@@ -26,15 +26,5 @@
 	"engines": {
 		"node": ">=20",
 		"pnpm": ">=10"
-	},
-	"pnpm": {
-		"onlyBuiltDependencies": [
-			"puppeteer"
-		],
-		"overrides": {
-			"esbuild@<0.25.0": ">=0.25.0",
-			"cookie@<0.7.0": ">=0.7.0",
-			"holosphere": "workspace:*"
-		}
 	}
 }

--- a/packages/core/src/holosphere/ad4mSchemas.ts
+++ b/packages/core/src/holosphere/ad4mSchemas.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: Roberto Valenti and the Holons contributors
+//
+/**
+ * In-memory JSON Schema bundle for the AD4M backend's browser path.
+ *
+ * The AD4M backend generates one subject class per lens from that lens's JSON
+ * Schema. In Node it reads them from disk (`schemaDir`); in the browser there
+ * is no filesystem, so the app must supply them in memory. This bundles the
+ * schemas at `packages/core/schemas/*.json` via Vite's `import.meta.glob`.
+ *
+ * `import.meta.glob` is a Vite build-time macro — only call this from inside a
+ * Vite build (the kiosk/web apps). In a plain Node context use `schemaDir`
+ * instead; calling this there will throw.
+ */
+
+type GlobImportMeta = ImportMeta & {
+  glob: (
+    pattern: string,
+    opts: { eager: true; import: "default" },
+  ) => Record<string, unknown>;
+};
+
+/** Load every core JSON Schema into a `lens name → schema object` map. */
+export function loadAd4mSchemas(): Map<string, object> {
+  // Kept inside the function so merely importing this module stays safe in
+  // non-Vite (Node) contexts — only invoking it requires the Vite transform.
+  const modules = (import.meta as GlobImportMeta).glob("../../schemas/*.json", {
+    eager: true,
+    import: "default",
+  });
+
+  const map = new Map<string, object>();
+  for (const [path, schema] of Object.entries(modules)) {
+    const name = path
+      .split("/")
+      .pop()!
+      .replace(/\.json$/, "");
+    if (schema && typeof schema === "object") {
+      map.set(name, schema as object);
+    }
+  }
+  return map;
+}
+
+export default loadAd4mSchemas;

--- a/packages/core/src/holosphere/factory.ts
+++ b/packages/core/src/holosphere/factory.ts
@@ -25,8 +25,19 @@ export interface CreateHoloSphereOptions {
   appName: string;
   /** Private key as hex string or raw bytes. Resolved by the caller. */
   privateKey?: Uint8Array | string | null;
-  /** Backend selector — defaults to whatever holosphere picks (Gun in 1.3). */
-  backend?: string;
+  /** Backend selector — `'gun'` (default) or `'ad4m'`. */
+  backend?: 'gun' | 'ad4m';
+  /** AD4M backend config (only used when backend is `'ad4m'`). */
+  ad4m?: {
+    /** AD4M executor WebSocket URL. Defaults to `ws://localhost:12000/graphql`. */
+    url?: string;
+    /** Authentication token for the AD4M executor. */
+    token?: string;
+    /** Pre-loaded schema map (lens name → JSON Schema object). */
+    schemas?: Map<string, object>;
+    /** Path to directory containing JSON Schema files. */
+    schemaDir?: string;
+  };
   /** Holosphere log level (`'INFO'`, `'DEBUG'`, ...). */
   logLevel?: string;
   /** Strict-mode toggle for holosphere. */
@@ -51,12 +62,13 @@ export function createHoloSphere(
 export function createHoloSphere(
   options: CreateHoloSphereOptions
 ): HoloSphere | Promise<HoloSphere> {
-  const { appName, privateKey, backend, logLevel, strict, awaitReady, extra } = options;
+  const { appName, privateKey, backend, ad4m, logLevel, strict, awaitReady, extra } = options;
 
   const config: Record<string, unknown> = {
     appName,
     ...(privateKey !== undefined ? { privateKey } : {}),
     ...(backend ? { backend } : {}),
+    ...(ad4m ? { ad4m } : {}),
     ...(logLevel ? { logLevel } : {}),
     ...(strict !== undefined ? { strict } : {}),
     ...(extra ?? {}),

--- a/packages/core/src/holosphere/index.ts
+++ b/packages/core/src/holosphere/index.ts
@@ -7,6 +7,7 @@
  */
 
 export { createHoloSphere, type CreateHoloSphereOptions } from './factory.js';
+export { loadAd4mSchemas } from './ad4mSchemas.js';
 export {
   writeWithIdentity,
   createHolonWriter,

--- a/packages/discord-ui/src/createHoloSphere.ts
+++ b/packages/discord-ui/src/createHoloSphere.ts
@@ -13,7 +13,7 @@ function generatePrivateKey(): string {
 
 export interface CreateHoloSphereOptions {
   privateKey?: string;
-  backend?: string;
+  backend?: 'gun' | 'ad4m';
   logLevel?: string;
 }
 
@@ -37,7 +37,7 @@ export function createHoloSphere(
   return coreCreateHoloSphere({
     appName,
     privateKey,
-    backend: options.backend || 'nostr',
+    backend: options.backend,
     logLevel: options.logLevel || 'INFO',
   });
 }

--- a/packages/holosphere/backends/ad4m.js
+++ b/packages/holosphere/backends/ad4m.js
@@ -1,0 +1,311 @@
+/**
+ * AD4MBackend — StorageBackend implementation using AD4M perspectives
+ * and subject classes.
+ *
+ * Maps holosphere concepts to AD4M:
+ *   holon  → Perspective (local) or Neighbourhood (shared via Holochain DHT)
+ *   lens   → Subject class (generated from JSON Schema via Ad4mModel.fromJSONSchema)
+ *   item   → Subject instance (a set of links conforming to a SHACL class)
+ *   key    → Expression URI of the base entity
+ */
+
+import { Ad4mClient } from '@coasys/ad4m';
+import { getModelOrGeneric, getRegistryModel, loadSubjectClasses } from '../subjects/index.js';
+
+export class AD4MBackend {
+  constructor(appname, ad4mOptions = {}) {
+    this.type = 'ad4m';
+    this.appname = appname;
+    this.client = null;
+    this.perspectives = new Map();
+    this.registryPerspective = null;
+    this._url = ad4mOptions.url ?? 'ws://localhost:12000/graphql';
+    this._token = ad4mOptions.token;
+    this._schemas = ad4mOptions.schemas ?? null;
+    this._schemaDir = ad4mOptions.schemaDir ?? null;
+  }
+
+  async ready() {
+    this.client = new Ad4mClient(this._url);
+    if (this._token) {
+      await this.client.agent.authenticate(this._token);
+    }
+
+    loadSubjectClasses(this._schemaDir, this._schemas);
+    await this._loadRegistry();
+  }
+
+  async _loadRegistry() {
+    const RegistryModel = getRegistryModel();
+    const all = await this.client.perspective.all();
+    let reg = all.find(p => p.name === `${this.appname}:registry`);
+    if (!reg) {
+      reg = await this.client.perspective.add(`${this.appname}:registry`);
+    }
+    this.registryPerspective = reg;
+
+    try {
+      const entries = await RegistryModel.findAll(reg);
+      for (const entry of entries) {
+        if (entry.holonId && entry.perspectiveUuid) {
+          const proxy = await this.client.perspective.byUUID(entry.perspectiveUuid);
+          if (proxy) this.perspectives.set(entry.holonId, proxy);
+        }
+      }
+    } catch {
+      // Registry may be empty on first run
+    }
+  }
+
+  async _perspectiveFor(holon) {
+    if (!holon) return this.registryPerspective;
+    if (this.perspectives.has(holon)) return this.perspectives.get(holon);
+
+    const all = await this.client.perspective.all();
+    const match = all.find(p => p.name === `${this.appname}:${holon}`);
+    if (match) {
+      this.perspectives.set(holon, match);
+      return match;
+    }
+
+    const p = await this.client.perspective.add(`${this.appname}:${holon}`);
+    this.perspectives.set(holon, p);
+
+    try {
+      const RegistryModel = getRegistryModel();
+      const entryUri = `holons://registry/${holon}`;
+      await this.registryPerspective.createSubject(RegistryModel, entryUri, {
+        holonId: holon,
+        perspectiveUuid: p.uuid,
+        createdAt: new Date().toISOString(),
+      });
+    } catch (err) {
+      console.warn(`[AD4MBackend] Failed to register perspective for holon "${holon}":`, err.message);
+    }
+
+    return p;
+  }
+
+  _itemUri(holon, lens, key) {
+    return `holons://${this.appname}/${holon ?? '_global'}/${lens}/${key}`;
+  }
+
+  async put(holon, lens, key, payload, options = {}) {
+    const perspective = await this._perspectiveFor(holon);
+    const Model = getModelOrGeneric(lens);
+    const baseUri = this._itemUri(holon, lens, key);
+    const data = JSON.parse(payload);
+
+    try {
+      const existing = await perspective.getSubjectData(Model, baseUri);
+      if (existing) {
+        await Model.update(perspective, baseUri, data);
+        return { ok: true };
+      }
+    } catch {
+      // Does not exist yet — create
+    }
+
+    try {
+      await perspective.createSubject(Model, baseUri, data);
+      return { ok: true };
+    } catch (err) {
+      console.error(`[AD4MBackend] put failed for ${baseUri}:`, err.message);
+      return { ok: false };
+    }
+  }
+
+  async get(holon, lens, key, options = {}) {
+    const perspective = await this._perspectiveFor(holon);
+    const Model = getModelOrGeneric(lens);
+    const baseUri = this._itemUri(holon, lens, key);
+
+    try {
+      const data = await perspective.getSubjectData(Model, baseUri);
+      return data ? JSON.stringify(data) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  async getAll(holon, lens, options = {}) {
+    const perspective = await this._perspectiveFor(holon);
+    const Model = getModelOrGeneric(lens);
+    const result = new Map();
+
+    try {
+      const instances = await Model.findAll(perspective);
+      for (const inst of instances) {
+        const id = inst.baseExpression || inst.id;
+        if (id) {
+          const data = await perspective.getSubjectData(Model, inst.baseExpression || id);
+          result.set(String(data.id || id), JSON.stringify(data));
+        }
+      }
+    } catch {
+      // Empty lens or model not registered
+    }
+
+    return result;
+  }
+
+  async delete(holon, lens, key) {
+    const perspective = await this._perspectiveFor(holon);
+    const Model = getModelOrGeneric(lens);
+    const baseUri = this._itemUri(holon, lens, key);
+
+    try {
+      await Model.delete(perspective, baseUri);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  subscribe(holon, lens, callback, options = {}) {
+    let cancelled = false;
+    let queryBuilder = null;
+    let prev = new Map();
+
+    const Model = getModelOrGeneric(lens);
+    const perspectivePromise = this._perspectiveFor(holon);
+
+    perspectivePromise.then(async (perspective) => {
+      if (cancelled) return;
+
+      queryBuilder = Model.query(perspective);
+      const initial = await queryBuilder.subscribe((instances) => {
+        if (cancelled) return;
+        this._diffAndEmit(perspective, Model, instances, prev, callback, options);
+      });
+
+      // Emit initial results
+      if (!cancelled && initial?.length > 0) {
+        const current = new Map();
+        for (const inst of initial) {
+          try {
+            const id = inst.baseExpression || inst.id;
+            if (!id) continue;
+            const data = await perspective.getSubjectData(Model, inst.baseExpression || id);
+            const key = String(data.id || id);
+            const json = JSON.stringify(data);
+            current.set(key, json);
+            callback(key, json);
+          } catch { /* skip unreadable instance */ }
+        }
+        prev = current;
+      }
+    }).catch((err) => {
+      console.error(`[AD4MBackend] subscribe setup failed for ${holon}/${lens}:`, err.message);
+    });
+
+    return {
+      unsubscribe: () => {
+        cancelled = true;
+        if (queryBuilder?.dispose) queryBuilder.dispose();
+      }
+    };
+  }
+
+  async _diffAndEmit(perspective, Model, instances, prev, callback, options) {
+    const current = new Map();
+    for (const inst of instances) {
+      try {
+        const id = inst.baseExpression || inst.id;
+        if (!id) continue;
+        const data = await perspective.getSubjectData(Model, inst.baseExpression || id);
+        const key = String(data.id || id);
+        const json = JSON.stringify(data);
+        current.set(key, json);
+
+        if (prev.get(key) !== json) {
+          callback(key, json);
+        }
+      } catch { /* skip */ }
+    }
+
+    if (options.includeDeletes !== false) {
+      for (const key of prev.keys()) {
+        if (!current.has(key)) callback(key, null);
+      }
+    }
+
+    prev.clear();
+    for (const [k, v] of current) prev.set(k, v);
+  }
+
+  getNodeRef(soul) {
+    return new AD4MNodeRef(this, soul);
+  }
+
+  async getAgentDID() {
+    const me = await this.client.agent.me();
+    return me.did;
+  }
+
+  async close() {
+    this.perspectives.clear();
+  }
+}
+
+/**
+ * NodeRef shim for AD4M — provides the same get/put/once interface as Gun
+ * nodes for hologram tracking links.  Stores tracking data as links on
+ * the registry perspective.
+ */
+class AD4MNodeRef {
+  constructor(backend, soul) {
+    this._backend = backend;
+    this._soul = soul;
+    this._path = [];
+  }
+
+  get(path) {
+    const child = new AD4MNodeRef(this._backend, this._soul);
+    child._path = [...this._path, path];
+    return child;
+  }
+
+  put(value, callback) {
+    const fullPath = [this._soul, ...this._path].join('/');
+    this._backend._storeTrackingLink(fullPath, value)
+      .then(() => callback?.({ ok: true }))
+      .catch((err) => callback?.({ err: err?.message || 'unknown error' }));
+  }
+
+  once(callback) {
+    const fullPath = [this._soul, ...this._path].join('/');
+    this._backend._readTrackingLink(fullPath)
+      .then((data) => callback(data))
+      .catch(() => callback(null));
+  }
+
+  off() {
+    // No-op for AD4M node refs
+  }
+}
+
+// Internal tracking link helpers on AD4MBackend
+AD4MBackend.prototype._storeTrackingLink = async function(path, value) {
+  if (!this.registryPerspective) return;
+  const source = `holons://tracking/${encodeURIComponent(path)}`;
+  const target = typeof value === 'string' ? value : JSON.stringify(value ?? null);
+  await this.registryPerspective.add({
+    source,
+    predicate: 'holons://tracking',
+    target: `literal://${encodeURIComponent(target)}`,
+  });
+};
+
+AD4MBackend.prototype._readTrackingLink = async function(path) {
+  if (!this.registryPerspective) return null;
+  const source = `holons://tracking/${encodeURIComponent(path)}`;
+  const links = await this.registryPerspective.get(
+    { source, predicate: 'holons://tracking' }
+  );
+  if (!links?.length) return null;
+  const raw = links[links.length - 1].data?.target;
+  if (!raw) return null;
+  const decoded = decodeURIComponent(raw.replace('literal://', ''));
+  try { return JSON.parse(decoded); } catch { return decoded; }
+};

--- a/packages/holosphere/backends/ad4m.js
+++ b/packages/holosphere/backends/ad4m.js
@@ -10,7 +10,15 @@
  */
 
 import { Ad4mClient } from '@coasys/ad4m';
-import { getModelOrGeneric, getRegistryModel, loadSubjectClasses } from '../subjects/index.js';
+import { getAllModels, getModelForLens, getModelOrGeneric, getRegistryModel, loadSubjectClasses } from '../subjects/index.js';
+
+// AD4M's `fromJSONSchema` gives every *required* property that wasn't supplied
+// an explicit value the sentinel `ad4m://undefined` (json-schema.ts). Because a
+// subject class forces required props to exist, an omitted one reads back as
+// this literal string. We treat it as "unset" on read, so a lens item written
+// without (say) a `type` comes back with `type` absent — matching GunBackend's
+// "absent when unset" semantics rather than leaking the sentinel to callers.
+const AD4M_UNSET = 'ad4m://undefined';
 
 export class AD4MBackend {
   constructor(appname, ad4mOptions = {}) {
@@ -18,20 +26,22 @@ export class AD4MBackend {
     this.appname = appname;
     this.client = null;
     this.perspectives = new Map();
+    // Perspective UUIDs whose subject-class SDNA has already been registered,
+    // so we register each perspective's classes exactly once per session.
+    this._registered = new Set();
     this.registryPerspective = null;
-    this._url = ad4mOptions.url ?? 'ws://localhost:12000/graphql';
+    this._url = ad4mOptions.url ?? 'http://localhost:12000';
     this._token = ad4mOptions.token;
     this._schemas = ad4mOptions.schemas ?? null;
     this._schemaDir = ad4mOptions.schemaDir ?? null;
   }
 
   async ready() {
-    this.client = new Ad4mClient(this._url);
-    if (this._token) {
-      await this.client.agent.authenticate(this._token);
-    }
+    // Token is a constructor arg on Ad4mClient(baseUrl, token?, subscribe?),
+    // threaded into every sub-client's auth. There is no agent.authenticate().
+    this.client = new Ad4mClient(this._url, this._token);
 
-    loadSubjectClasses(this._schemaDir, this._schemas);
+    await loadSubjectClasses(this._schemaDir, this._schemas);
     await this._loadRegistry();
   }
 
@@ -43,6 +53,14 @@ export class AD4MBackend {
       reg = await this.client.perspective.add(`${this.appname}:registry`);
     }
     this.registryPerspective = reg;
+
+    // The registry perspective must know the registry subject class before it
+    // can create/read holon→perspective entries.
+    try {
+      await RegistryModel.register(reg);
+    } catch (err) {
+      console.warn(`[AD4MBackend] Failed to register registry class:`, err.message);
+    }
 
     try {
       const entries = await RegistryModel.findAll(reg);
@@ -57,30 +75,53 @@ export class AD4MBackend {
     }
   }
 
+  /**
+   * Register every lens subject class onto a holon perspective, once. An AD4M
+   * perspective rejects `createSubject`/`getSubjectData` for a class whose SDNA
+   * it has not seen, so this must run before the first read or write.
+   */
+  async _ensureClasses(perspective) {
+    if (!perspective || this._registered.has(perspective.uuid)) return;
+    try {
+      const { Ad4mModel } = await import('@coasys/ad4m');
+      await Ad4mModel.registerAll(perspective, getAllModels());
+      this._registered.add(perspective.uuid);
+    } catch (err) {
+      console.warn(`[AD4MBackend] Failed to register lens classes on "${perspective.name}":`, err.message);
+    }
+  }
+
   async _perspectiveFor(holon) {
-    if (!holon) return this.registryPerspective;
-    if (this.perspectives.has(holon)) return this.perspectives.get(holon);
+    // The global table (null holon) is a first-class perspective like any other
+    // (`${appname}:_global`), NOT the registry perspective — the registry only
+    // ever has the registry subject class registered, so storing lens data there
+    // would fail ("No SHACL constructor found"). Routing it through the normal
+    // path ensures its lens/generic classes are registered too.
+    const key = holon ?? '_global';
+    if (this.perspectives.has(key)) return this.perspectives.get(key);
 
     const all = await this.client.perspective.all();
-    const match = all.find(p => p.name === `${this.appname}:${holon}`);
+    const match = all.find(p => p.name === `${this.appname}:${key}`);
     if (match) {
-      this.perspectives.set(holon, match);
+      this.perspectives.set(key, match);
+      await this._ensureClasses(match);
       return match;
     }
 
-    const p = await this.client.perspective.add(`${this.appname}:${holon}`);
-    this.perspectives.set(holon, p);
+    const p = await this.client.perspective.add(`${this.appname}:${key}`);
+    this.perspectives.set(key, p);
+    await this._ensureClasses(p);
 
     try {
       const RegistryModel = getRegistryModel();
-      const entryUri = `holons://registry/${holon}`;
+      const entryUri = `holons://registry/${key}`;
       await this.registryPerspective.createSubject(RegistryModel, entryUri, {
-        holonId: holon,
+        holonId: key,
         perspectiveUuid: p.uuid,
         createdAt: new Date().toISOString(),
       });
     } catch (err) {
-      console.warn(`[AD4MBackend] Failed to register perspective for holon "${holon}":`, err.message);
+      console.warn(`[AD4MBackend] Failed to register perspective for holon "${key}":`, err.message);
     }
 
     return p;
@@ -90,24 +131,79 @@ export class AD4MBackend {
     return `holons://${this.appname}/${holon ?? '_global'}/${lens}/${key}`;
   }
 
+  _lensPrefix(holon, lens) {
+    return `holons://${this.appname}/${holon ?? '_global'}/${lens}/`;
+  }
+
+  /** The holon-local key (logical `id`) encoded in a base expression. */
+  _keyFromBase(base) {
+    const s = String(base ?? '');
+    const seg = s.split('/').pop();
+    return seg || s;
+  }
+
+  /**
+   * Copy a hydrated Ad4mModel instance's own data properties into a plain
+   * object, dropping internal (`_`-prefixed) fields and methods. For lenses
+   * without a dedicated schema the payload was round-tripped through the
+   * generic model's single `data` JSON string, so unwrap it back.
+   *
+   * AD4M reserves `id` as the base-expression alias, so a schema's own `id`
+   * property is never surfaced as a data field — it lives on `_baseExpression`.
+   * We restore it from there so callers (and holosphere's `processItem`, which
+   * keys every item by `id`) see the logical id they wrote.
+   */
+  _plain(inst, dedicated) {
+    if (!dedicated) {
+      try {
+        const obj = JSON.parse(inst.data);
+        if (obj && obj.id === undefined) obj.id = this._keyFromBase(inst._baseExpression);
+        return obj;
+      } catch {
+        return { id: this._keyFromBase(inst._baseExpression) };
+      }
+    }
+    const out = {};
+    for (const [k, v] of Object.entries(inst)) {
+      if (k.startsWith('_') || typeof v === 'function') continue;
+      if (v === AD4M_UNSET) continue;
+      out[k] = v;
+    }
+    if (out.id === undefined) {
+      const key = this._keyFromBase(inst._baseExpression);
+      if (key) out.id = key;
+    }
+    return out;
+  }
+
+  /**
+   * Shape the write payload for the resolved model. A dedicated lens persists
+   * its declared properties directly; a generic lens round-trips the whole
+   * payload as a JSON string under `data`. The generic model has no `id`
+   * property (see subjects/index.js) — the logical key lives in the base URI
+   * and is restored on read by `_plain`, so we don't shape one in here.
+   */
+  _shape(parsed, key, dedicated) {
+    if (dedicated) return parsed;
+    return { data: JSON.stringify(parsed) };
+  }
+
   async put(holon, lens, key, payload, options = {}) {
     const perspective = await this._perspectiveFor(holon);
-    const Model = getModelOrGeneric(lens);
+    const dedicated = getModelForLens(lens);
+    const Model = dedicated ?? getModelOrGeneric(lens);
     const baseUri = this._itemUri(holon, lens, key);
-    const data = JSON.parse(payload);
+    const data = this._shape(JSON.parse(payload), key, dedicated);
 
     try {
-      const existing = await perspective.getSubjectData(Model, baseUri);
+      const existing = await Model.findOne(perspective, { where: { id: baseUri } });
       if (existing) {
         await Model.update(perspective, baseUri, data);
-        return { ok: true };
+      } else {
+        const inst = new Model(perspective, baseUri);
+        Object.assign(inst, data);
+        await inst.save();
       }
-    } catch {
-      // Does not exist yet — create
-    }
-
-    try {
-      await perspective.createSubject(Model, baseUri, data);
       return { ok: true };
     } catch (err) {
       console.error(`[AD4MBackend] put failed for ${baseUri}:`, err.message);
@@ -117,12 +213,13 @@ export class AD4MBackend {
 
   async get(holon, lens, key, options = {}) {
     const perspective = await this._perspectiveFor(holon);
-    const Model = getModelOrGeneric(lens);
+    const dedicated = getModelForLens(lens);
+    const Model = dedicated ?? getModelOrGeneric(lens);
     const baseUri = this._itemUri(holon, lens, key);
 
     try {
-      const data = await perspective.getSubjectData(Model, baseUri);
-      return data ? JSON.stringify(data) : null;
+      const inst = await Model.findOne(perspective, { where: { id: baseUri } });
+      return inst ? JSON.stringify(this._plain(inst, dedicated)) : null;
     } catch {
       return null;
     }
@@ -130,17 +227,23 @@ export class AD4MBackend {
 
   async getAll(holon, lens, options = {}) {
     const perspective = await this._perspectiveFor(holon);
-    const Model = getModelOrGeneric(lens);
+    const dedicated = getModelForLens(lens);
+    const Model = dedicated ?? getModelOrGeneric(lens);
+    const prefix = this._lensPrefix(holon, lens);
     const result = new Map();
 
     try {
       const instances = await Model.findAll(perspective);
       for (const inst of instances) {
-        const id = inst.baseExpression || inst.id;
-        if (id) {
-          const data = await perspective.getSubjectData(Model, inst.baseExpression || id);
-          result.set(String(data.id || id), JSON.stringify(data));
+        // A dedicated class is unique per lens, but the generic model backs
+        // every schema-less lens on this perspective — scope by URI prefix so
+        // one lens never bleeds another's items.
+        if (!dedicated && !String(inst._baseExpression ?? '').startsWith(prefix)) {
+          continue;
         }
+        const plain = this._plain(inst, dedicated);
+        const id = String(plain.id ?? '');
+        if (id) result.set(id, JSON.stringify(plain));
       }
     } catch {
       // Empty lens or model not registered
@@ -151,7 +254,7 @@ export class AD4MBackend {
 
   async delete(holon, lens, key) {
     const perspective = await this._perspectiveFor(holon);
-    const Model = getModelOrGeneric(lens);
+    const Model = getModelForLens(lens) ?? getModelOrGeneric(lens);
     const baseUri = this._itemUri(holon, lens, key);
 
     try {
@@ -167,39 +270,60 @@ export class AD4MBackend {
     let queryBuilder = null;
     let prev = new Map();
 
-    const Model = getModelOrGeneric(lens);
+    // Resolves once the initial subscription baseline is established. AD4M's
+    // subscribe setup is async (perspective fetch + query subscription), unlike
+    // Gun's synchronous path, so a write issued in the same tick as subscribe()
+    // could otherwise race the baseline. Consumers that must not miss an
+    // imminent write can `await handle.ready()`; the field is absent on Gun's
+    // handle, so callers optional-chain it (`handle.ready?.()`).
+    let resolveReady;
+    const readyPromise = new Promise((res) => { resolveReady = res; });
+
+    const dedicated = getModelForLens(lens);
+    const Model = dedicated ?? getModelOrGeneric(lens);
+    const prefix = this._lensPrefix(holon, lens);
     const perspectivePromise = this._perspectiveFor(holon);
+
+    // A hydrated instance → `[key, jsonString]`, or null when it doesn't
+    // belong to this lens. Mirrors the getAll read path so subscribers and
+    // one-shot reads agree on shape and on the reconstructed `id`.
+    const toEntry = (inst) => {
+      if (!dedicated && !String(inst._baseExpression ?? '').startsWith(prefix)) return null;
+      const plain = this._plain(inst, dedicated);
+      const id = String(plain.id ?? '');
+      if (!id) return null;
+      return [id, JSON.stringify(plain)];
+    };
 
     perspectivePromise.then(async (perspective) => {
       if (cancelled) return;
 
       queryBuilder = Model.query(perspective);
+      // `subscribe(cb)` returns the initial hydrated instances and invokes `cb`
+      // with a fresh full array on every later change.
       const initial = await queryBuilder.subscribe((instances) => {
         if (cancelled) return;
-        this._diffAndEmit(perspective, Model, instances, prev, callback, options);
+        this._diffAndEmit(instances, prev, callback, toEntry, options);
       });
+      if (cancelled) return;
 
-      // Emit initial results
-      if (!cancelled && initial?.length > 0) {
-        const current = new Map();
-        for (const inst of initial) {
-          try {
-            const id = inst.baseExpression || inst.id;
-            if (!id) continue;
-            const data = await perspective.getSubjectData(Model, inst.baseExpression || id);
-            const key = String(data.id || id);
-            const json = JSON.stringify(data);
-            current.set(key, json);
-            callback(key, json);
-          } catch { /* skip unreadable instance */ }
-        }
-        prev = current;
+      const current = new Map();
+      for (const inst of initial ?? []) {
+        const entry = toEntry(inst);
+        if (!entry) continue;
+        current.set(entry[0], entry[1]);
+        callback(entry[0], entry[1]);
       }
+      prev = current;
+      resolveReady();
     }).catch((err) => {
       console.error(`[AD4MBackend] subscribe setup failed for ${holon}/${lens}:`, err.message);
+      // Don't leave `ready()` awaiters hanging if setup fails.
+      resolveReady();
     });
 
     return {
+      ready: () => readyPromise,
       unsubscribe: () => {
         cancelled = true;
         if (queryBuilder?.dispose) queryBuilder.dispose();
@@ -207,21 +331,14 @@ export class AD4MBackend {
     };
   }
 
-  async _diffAndEmit(perspective, Model, instances, prev, callback, options) {
+  _diffAndEmit(instances, prev, callback, toEntry, options) {
     const current = new Map();
     for (const inst of instances) {
-      try {
-        const id = inst.baseExpression || inst.id;
-        if (!id) continue;
-        const data = await perspective.getSubjectData(Model, inst.baseExpression || id);
-        const key = String(data.id || id);
-        const json = JSON.stringify(data);
-        current.set(key, json);
-
-        if (prev.get(key) !== json) {
-          callback(key, json);
-        }
-      } catch { /* skip */ }
+      const entry = toEntry(inst);
+      if (!entry) continue;
+      const [key, json] = entry;
+      current.set(key, json);
+      if (prev.get(key) !== json) callback(key, json);
     }
 
     if (options.includeDeletes !== false) {

--- a/packages/holosphere/backends/gun.js
+++ b/packages/holosphere/backends/gun.js
@@ -1,0 +1,191 @@
+/**
+ * GunBackend — StorageBackend implementation wrapping GUN.
+ *
+ * Extracted from the inline Gun operations previously spread across
+ * content.js, global.js, and utils.js.  The public API matches the
+ * StorageBackend interface defined in interface.d.ts.
+ */
+
+import Gun from 'gun';
+
+const DEFAULT_READ_TIMEOUT = 8000;
+const DEFAULT_WRITE_TIMEOUT = 5000;
+
+export class GunBackend {
+  constructor(appname, gunOptions = {}) {
+    this.type = 'gun';
+    this.appname = appname;
+
+    const defaults = {
+      peers: ['https://gun.holons.io/gun'],
+      axe: false,
+      radisk: true,
+      file: './holosphere',
+    };
+    if (typeof window !== 'undefined' && gunOptions.radisk !== false) {
+      defaults.localStorage = false;
+    }
+    const finalOptions = { ...defaults, ...gunOptions };
+    this.gun = Gun(finalOptions);
+  }
+
+  _path(holon, lens) {
+    const base = this.gun.get(this.appname);
+    if (holon === null || holon === undefined || holon === '') {
+      return base.get(lens);
+    }
+    return base.get(holon).get(lens);
+  }
+
+  async put(holon, lens, key, payload, options = {}) {
+    const timeout = options.timeout ?? DEFAULT_WRITE_TIMEOUT;
+    return new Promise((resolve) => {
+      let done = false;
+      const finish = (v) => { if (!done) { done = true; resolve(v); } };
+
+      this._path(holon, lens).get(key).put(payload, (ack) => {
+        finish({ ok: !ack.err, queued: false });
+      });
+
+      if (timeout > 0) {
+        setTimeout(() => finish({ ok: true, queued: true }), timeout);
+      }
+    });
+  }
+
+  async get(holon, lens, key, options = {}) {
+    const timeout = options.timeout ?? DEFAULT_READ_TIMEOUT;
+    const awaitNetwork = options.awaitNetwork || false;
+
+    return new Promise((resolve) => {
+      let done = false;
+      const finish = (v) => { if (!done) { done = true; resolve(v ?? null); } };
+
+      const node = this._path(holon, lens).get(key);
+
+      if (!awaitNetwork) {
+        node.once((data) => finish(data));
+      } else {
+        const detach = () => { try { if (node.off) node.off(); } catch { /* ignore */ } };
+        const finishNet = (v) => { if (!done) { done = true; detach(); resolve(v ?? null); } };
+        node.on((data) => {
+          if (data === undefined) return;
+          finishNet(data);
+        });
+        if (timeout > 0) setTimeout(() => finishNet(null), timeout);
+        return;
+      }
+
+      if (timeout > 0) setTimeout(() => finish(null), timeout);
+    });
+  }
+
+  async getAll(holon, lens, options = {}) {
+    const timeout = options.timeout ?? DEFAULT_READ_TIMEOUT;
+    const path = this._path(holon, lens);
+
+    const shallowOnce = () => new Promise((resolve) => {
+      let done = false;
+      const finish = (v) => { if (!done) { done = true; resolve(v); } };
+      path.once((data) => finish(data));
+      if (timeout > 0) setTimeout(() => finish(null), timeout);
+    });
+
+    let data = await shallowOnce();
+    if (!data) {
+      await new Promise(r => setTimeout(r, 1500));
+      data = await shallowOnce();
+    }
+
+    if (!data) return new Map();
+
+    const result = new Map();
+    const keys = Object.keys(data).filter(k => {
+      if (k === '_') return false;
+      const val = data[k];
+      if (val === null) return false;
+      if (typeof val === 'object' && val['#']) return false;
+      return true;
+    });
+
+    if (keys.length === 0) return result;
+
+    const onceWithTimeout = (node) => new Promise((resolve) => {
+      let done = false;
+      const finish = (v) => { if (!done) { done = true; resolve(v ?? null); } };
+      node.once((d) => finish(d));
+      if (timeout > 0) setTimeout(() => finish(null), timeout);
+    });
+
+    await Promise.all(keys.map(async (key) => {
+      const inline = data[key];
+      let value;
+      if (typeof inline !== 'object' || inline === null) {
+        value = inline;
+      } else {
+        value = await onceWithTimeout(path.get(key));
+      }
+      if (value !== null && value !== undefined) {
+        result.set(key, value);
+      }
+    }));
+
+    return result;
+  }
+
+  async delete(holon, lens, key) {
+    return new Promise((resolve) => {
+      this._path(holon, lens).get(key).put(null, (ack) => {
+        resolve(!ack.err);
+      });
+    });
+  }
+
+  subscribe(holon, lens, callback, options = {}) {
+    const path = this._path(holon, lens);
+    const mapChain = path.map();
+
+    mapChain.on((data, key) => {
+      if (key === '_') return;
+      callback(key, data ?? null);
+    });
+
+    return {
+      unsubscribe: () => {
+        try { path.off(); } catch { /* ignore */ }
+      }
+    };
+  }
+
+  getNodeRef(soul) {
+    const parts = soul.split('/').filter(Boolean);
+    let ref = this.gun.get(this.appname);
+    for (const part of parts) {
+      ref = ref.get(part);
+    }
+    return ref;
+  }
+
+  async ready() {
+    // Gun connects eagerly — nothing to await
+  }
+
+  async close() {
+    try {
+      if (this.gun && this.gun.back) {
+        const mesh = this.gun.back('opt.mesh');
+        if (mesh) {
+          const peers = mesh.say?.peers || mesh.peers || {};
+          for (const peer of Object.values(peers)) {
+            if (peer?.wire?.close) peer.wire.close();
+          }
+        }
+        if (this.gun.back('opt.web')) {
+          const server = this.gun.back('opt.web');
+          if (server?.close) await new Promise(r => server.close(r));
+        }
+      }
+      if (this.gun?.off) this.gun.off();
+    } catch { /* best-effort cleanup */ }
+  }
+}

--- a/packages/holosphere/backends/gun.js
+++ b/packages/holosphere/backends/gun.js
@@ -47,6 +47,11 @@ export class GunBackend {
         finish({ ok: !ack.err, queued: false });
       });
 
+      // Bound the wait on Gun's put ack so an offline mesh can't hang the
+      // caller forever. Gun keeps the write locally and replays it when a
+      // peer reappears, so a missed ack is a *queued* write, not a failure:
+      // report `{ ok, queued:true }` rather than rejecting. Callers that
+      // gate side effects on a confirmed write check `queued`.
       if (timeout > 0) {
         setTimeout(() => finish({ ok: true, queued: true }), timeout);
       }

--- a/packages/holosphere/backends/interface.d.ts
+++ b/packages/holosphere/backends/interface.d.ts
@@ -1,0 +1,66 @@
+/**
+ * StorageBackend — pluggable storage layer for HoloSphere.
+ *
+ * Every backend must implement this interface.  The orchestration layer
+ * (content.js, global.js, utils.js) delegates primitive read/write/subscribe
+ * operations here and handles higher-level concerns (hologram resolution,
+ * federation routing, signing, schema validation) on top.
+ */
+export interface StorageBackend {
+  /** Discriminator so the orchestration layer can branch on backend type. */
+  readonly type: 'gun' | 'ad4m';
+
+  // ── Core CRUD ──
+
+  put(
+    holon: string | null,
+    lens: string,
+    key: string,
+    payload: string,
+    options?: { timeout?: number }
+  ): Promise<{ ok: boolean; queued?: boolean }>;
+
+  get(
+    holon: string | null,
+    lens: string,
+    key: string,
+    options?: { timeout?: number; awaitNetwork?: boolean }
+  ): Promise<string | null>;
+
+  getAll(
+    holon: string | null,
+    lens: string,
+    options?: { timeout?: number }
+  ): Promise<Map<string, string>>;
+
+  delete(
+    holon: string | null,
+    lens: string,
+    key: string
+  ): Promise<boolean>;
+
+  // ── Subscriptions ──
+
+  subscribe(
+    holon: string | null,
+    lens: string,
+    callback: (key: string, value: string | null) => void,
+    options?: { includeDeletes?: boolean }
+  ): { unsubscribe: () => void };
+
+  // ── Node references (hologram tracking) ──
+
+  getNodeRef(soul: string): NodeRef;
+
+  // ── Lifecycle ──
+
+  ready(): Promise<void>;
+  close(): Promise<void>;
+}
+
+export interface NodeRef {
+  get(path: string): NodeRef;
+  put(value: any, callback?: (ack: { err?: string }) => void): void;
+  once(callback: (data: any) => void): void;
+  off?(): void;
+}

--- a/packages/holosphere/build.js
+++ b/packages/holosphere/build.js
@@ -54,7 +54,7 @@ if (typeof global !== 'undefined') {
     define: {
       'process.env.NODE_ENV': '"production"'
     },
-    external: [], // Bundle everything
+    external: ['@coasys/ad4m', 'fs', 'path', 'url'],
   });
 
   console.log('✅ Bundle created: holosphere-bundle.js');
@@ -78,7 +78,7 @@ if (typeof global !== 'undefined') {
     define: {
       'process.env.NODE_ENV': '"production"'
     },
-    external: [],
+    external: ['@coasys/ad4m', 'fs', 'path', 'url'],
   });
 
   console.log('✅ Minified bundle created: holosphere-bundle.min.js');
@@ -105,7 +105,7 @@ if (typeof global !== 'undefined') {
     define: {
       'process.env.NODE_ENV': '"production"'
     },
-    external: [],
+    external: ['@coasys/ad4m', 'fs', 'path', 'url'],
   });
 
   console.log('✅ ESM bundle created: holosphere-bundle.esm.js');

--- a/packages/holosphere/build.js
+++ b/packages/holosphere/build.js
@@ -54,7 +54,7 @@ if (typeof global !== 'undefined') {
     define: {
       'process.env.NODE_ENV': '"production"'
     },
-    external: ['@coasys/ad4m', 'fs', 'path', 'url'],
+    external: ['@coasys/ad4m', 'fs', 'path', 'url', 'node:fs', 'node:path', 'node:url'],
   });
 
   console.log('✅ Bundle created: holosphere-bundle.js');
@@ -78,7 +78,7 @@ if (typeof global !== 'undefined') {
     define: {
       'process.env.NODE_ENV': '"production"'
     },
-    external: ['@coasys/ad4m', 'fs', 'path', 'url'],
+    external: ['@coasys/ad4m', 'fs', 'path', 'url', 'node:fs', 'node:path', 'node:url'],
   });
 
   console.log('✅ Minified bundle created: holosphere-bundle.min.js');
@@ -105,7 +105,7 @@ if (typeof global !== 'undefined') {
     define: {
       'process.env.NODE_ENV': '"production"'
     },
-    external: ['@coasys/ad4m', 'fs', 'path', 'url'],
+    external: ['@coasys/ad4m', 'fs', 'path', 'url', 'node:fs', 'node:path', 'node:url'],
   });
 
   console.log('✅ ESM bundle created: holosphere-bundle.esm.js');

--- a/packages/holosphere/content.js
+++ b/packages/holosphere/content.js
@@ -185,8 +185,7 @@ function sanitizeForStorage(value, path = '', seen = new WeakSet(), warnings = [
  * get/put without a holon.)
  */
 export function holonLens(holoInstance, holon, lens) {
-    const base = holoInstance.gun.get(holoInstance.appname);
-    return (holon === null || holon === undefined || holon === '') ? base.get(lens) : base.get(holon).get(lens);
+    return holoInstance._backend._path(holon, lens);
 }
 const isGlobalHolon = (holon) => holon === null || holon === undefined || holon === '';
 
@@ -303,7 +302,10 @@ export async function put(holoInstance, holon, lens, data, password = null, opti
     try {
         let user = null;
         if (password) {
-            user = holoInstance.gun.user();
+            if (!holoInstance._backend.gun) {
+                throw new Error('Password-protected operations require the Gun backend');
+            }
+            user = holoInstance._backend.gun.user();
             await new Promise((resolve, reject) => {
                 const userNameString = holoInstance.userName(targetHolon); // Use targetHolon for put
                 user.auth(userNameString, password, (authAck) => {
@@ -313,7 +315,7 @@ export async function put(holoInstance, holon, lens, data, password = null, opti
                             if (createAck.err) {
                                 if (createAck.err.includes("already created") || createAck.err.includes("already being created")) {
                                     console.log(`User ${userNameString} already existed or being created during put, re-attempting auth with fresh user object.`);
-                                    const freshUser = holoInstance.gun.user(); // Get a new user object
+                                    const freshUser = holoInstance._backend.gun.user();
                                     freshUser.auth(userNameString, password, (secondAuthAck) => {
                                         if (secondAuthAck.err) {
                                             console.log(`Auth still failed after user existed check: ${secondAuthAck.err}. Resolving anyway for test operations.`);
@@ -344,254 +346,292 @@ export async function put(holoInstance, holon, lens, data, password = null, opti
             });
         }
 
-        const ackPromise = new Promise((resolve, reject) => {
-            try {
-                // Sanitize before serialization so undefined/NaN/Infinity etc.
-                // can never produce a malformed payload like `"initiated":,`
-                // (which is what causes per-character parse warnings on read).
-                const sanitizeWarnings = [];
-                let dataToStore = sanitizeForStorage(data, '', new WeakSet(), sanitizeWarnings) || {};
-                if (sanitizeWarnings.length > 0) {
-                    console.warn(
-                        `holosphere.put: sanitized ${sanitizeWarnings.length} field(s) at ${targetHolon}/${targetLens}/${targetKey} (id=${data.id}):`,
-                        sanitizeWarnings
-                    );
-                }
-                // Strip read-side envelopes that must never be persisted
-                // (they're attached at resolution time).
-                //
-                // `_hologram` and `_meta` are always read-side-only.
-                //
-                // `_federation` is also read-side for ordinary writes — it
-                // describes where data was fetched from, not where it
-                // currently lives. The one legitimate carrier is federation
-                // propagation, which writes hologram envelopes (top-level
-                // `id` + `soul`) tagged with `_federation` provenance; we
-                // detect that via `isHologram(data)` and leave it alone.
-                // Without this, a UI that reads a federated record and puts
-                // it back ends up persisting stale `_federation.origin`
-                // metadata, which then drives downstream code (federation
-                // propagators, hologram resolvers) to write or follow
-                // pointers that don't match the current storage location —
-                // producing "broken hologram" garbage-collection cascades
-                // that silently delete the user's write.
-                if (dataToStore._meta !== undefined) delete dataToStore._meta;
-                if (dataToStore._hologram !== undefined) delete dataToStore._hologram;
-                if (!isHologram && dataToStore._federation !== undefined) delete dataToStore._federation;
-                const payload = JSON.stringify(dataToStore); // The data being stored
+        // Sanitize before serialization so undefined/NaN/Infinity etc.
+        // can never produce a malformed payload like `"initiated":,`
+        // (which is what causes per-character parse warnings on read).
+        const sanitizeWarnings = [];
+        let dataToStore = sanitizeForStorage(data, '', new WeakSet(), sanitizeWarnings) || {};
+        if (sanitizeWarnings.length > 0) {
+            console.warn(
+                `holosphere.put: sanitized ${sanitizeWarnings.length} field(s) at ${targetHolon}/${targetLens}/${targetKey} (id=${data.id}):`,
+                sanitizeWarnings
+            );
+        }
+        // Strip read-side envelopes that must never be persisted
+        // (they're attached at resolution time).
+        //
+        // `_hologram` and `_meta` are always read-side-only.
+        //
+        // `_federation` is also read-side for ordinary writes — it
+        // describes where data was fetched from, not where it
+        // currently lives. The one legitimate carrier is federation
+        // propagation, which writes hologram envelopes (top-level
+        // `id` + `soul`) tagged with `_federation` provenance; we
+        // detect that via `isHologram(data)` and leave it alone.
+        // Without this, a UI that reads a federated record and puts
+        // it back ends up persisting stale `_federation.origin`
+        // metadata, which then drives downstream code (federation
+        // propagators, hologram resolvers) to write or follow
+        // pointers that don't match the current storage location —
+        // producing "broken hologram" garbage-collection cascades
+        // that silently delete the user's write.
+        if (dataToStore._meta !== undefined) delete dataToStore._meta;
+        if (dataToStore._hologram !== undefined) delete dataToStore._hologram;
+        if (!isHologram && dataToStore._federation !== undefined) delete dataToStore._federation;
+        const payload = JSON.stringify(dataToStore); // The data being stored
 
-                const putCallback = async (ack) => {
-                    if (ack.err) {
-                        reject(new Error(ack.err));
+        // --- Post-write side effects (hologram tracking, notification, propagation) ---
+        // Extracted so both the Gun callback path and backend await path can share it.
+        const runPostWriteSideEffects = async () => {
+            // --- Start: Hologram Tracking Logic (for data *being put*, if it's a hologram) ---
+            if (isHologram) {
+                try {
+                    const storedDataSoulInfo = holoInstance.parseSoulPath(data.soul);
+                    if (storedDataSoulInfo) {
+                        const targetNodeRef = holoInstance.getNodeRef(data.soul); // Target of the data *being put*
+                        // Soul of the hologram that was *actually stored* at targetHolon/targetLens/targetKey
+                        const storedHologramInstanceSoul = `${holoInstance.appname}/${targetHolon}/${targetLens}/${targetKey}`;
+
+                        targetNodeRef.get('_holograms').get(storedHologramInstanceSoul).put(true);
                     } else {
-                        // --- Start: Hologram Tracking Logic (for data *being put*, if it's a hologram) ---
-                        if (isHologram) {
-                            try {
-                                const storedDataSoulInfo = holoInstance.parseSoulPath(data.soul);
-                                if (storedDataSoulInfo) {
-                                    const targetNodeRef = holoInstance.getNodeRef(data.soul); // Target of the data *being put*
-                                    // Soul of the hologram that was *actually stored* at targetHolon/targetLens/targetKey
-                                    const storedHologramInstanceSoul = `${holoInstance.appname}/${targetHolon}/${targetLens}/${targetKey}`;
-                                    
-                                    targetNodeRef.get('_holograms').get(storedHologramInstanceSoul).put(true);
-                                } else {
-                                    console.warn(`Data (ID: ${data.id}) being put is a hologram, but could not parse its soul ${data.soul} for tracking.`);
-                                }
-                            } catch (trackingError) {
-                                console.warn(`Error updating _holograms set for the target of the data being put (data ID: ${data.id}, soul: ${data.soul}):`, trackingError);
-                            }
-                        }
-                        // --- End: Hologram Tracking Logic ---
-                        
-                        // --- Start: Active Hologram Update Logic ---
-                        //
-                        // Walks this node's `_holograms` set and stamps every
-                        // registered hologram with `updated: now` so consumers
-                        // re-resolve and see the latest source data.
-                        //
-                        // Runs for BOTH original-data puts and hologram-update
-                        // puts so updates cascade through multi-hop forwards
-                        // (A → B → C → …) even when the second hop's
-                        // cross-holon registration on the original source
-                        // can't be relied on to make it across the Gun mesh.
-                        // Each hop maintains its own local `_holograms` set
-                        // tracking the next hops, and we walk that set on
-                        // every put — cycle-protected via
-                        // `options._cascadeVisited`.
-                        let updatedHolograms = [];
-                        const currentDataSoul = `${holoInstance.appname}/${targetHolon}/${targetLens}/${targetKey}`;
-                        const cascadeVisited = new Set(options._cascadeVisited || []);
-                        if (!cascadeVisited.has(currentDataSoul)) {
-                            cascadeVisited.add(currentDataSoul);
-                            try {
-                                const currentNodeRef = holoInstance.getNodeRef(currentDataSoul);
-
-                                // Get the _holograms set for this node
-                                await new Promise((resolveHologramUpdate) => {
-                                    currentNodeRef.get('_holograms').once(async (hologramsSet) => {
-                                        if (hologramsSet) {
-                                            const hologramSouls = Object.keys(hologramsSet).filter(k =>
-                                                k !== '_' && hologramsSet[k] === true && !cascadeVisited.has(k)
-                                            );
-
-                                            if (hologramSouls.length > 0) {
-                                // Update each active hologram with an 'updated' timestamp
-                                                const updatePromises = hologramSouls.map(async (hologramSoul) => {
-                                                    try {
-                                                        const hologramSoulInfo = holoInstance.parseSoulPath(hologramSoul);
-                                                        if (hologramSoulInfo) {
-                                                            // Get the current hologram data
-                                                            const currentHologram = await holoInstance.get(
-                                                                hologramSoulInfo.holon,
-                                                                hologramSoulInfo.lens,
-                                                                hologramSoulInfo.key,
-                                                                null,
-                                                                { resolveHolograms: false }
-                                                            );
-
-                                                            if (currentHologram) {
-                                                                // Update the hologram with an 'updated' timestamp
-                                                                const updatedHologram = {
-                                                                    ...currentHologram,
-                                                                    updated: Date.now()
-                                                                };
-
-                                                                await holoInstance.put(
-                                                                    hologramSoulInfo.holon,
-                                                                    hologramSoulInfo.lens,
-                                                                    updatedHologram,
-                                                                    null,
-                                                                    {
-                                                                        autoPropagate: false, // Don't auto-propagate hologram updates
-                                                                        disableHologramRedirection: true, // Prevent redirection when updating holograms
-                                                                        isHologramUpdate: true,
-                                                                        // Carry the visited set forward so the
-                                                                        // recursive put keeps cascading through
-                                                                        // this hop's `_holograms` set without
-                                                                        // looping back through us.
-                                                                        _cascadeVisited: cascadeVisited
-                                                                    }
-                                                                );
-
-                                                                                                                // Add to the list of updated holograms
-                                                                updatedHolograms.push({
-                                                                    soul: hologramSoul,
-                                                                    holon: hologramSoulInfo.holon,
-                                                                    lens: hologramSoulInfo.lens,
-                                                                    key: hologramSoulInfo.key,
-                                                                    id: hologramSoulInfo.key,
-                                                                    timestamp: updatedHologram.updated
-                                                                });
-                                                            }
-                                                        }
-                                                    } catch (hologramUpdateError) {
-                                                        console.warn(`Error updating hologram ${hologramSoul}:`, hologramUpdateError);
-                                                    }
-                                                });
-
-                                                await Promise.all(updatePromises);
-                                            }
-                                        }
-                                        resolveHologramUpdate(); // Resolve the promise to continue with the main put logic
-                                    });
-                                });
-                            } catch (hologramUpdateError) {
-                                console.warn(`Error checking for active holograms to update:`, hologramUpdateError);
-                            }
-                        }
-                        // --- End: Active Hologram Update Logic ---
-                        
-                        // Only notify subscribers for actual data, not holograms
-                        if (!isHologram) {
-                            holoInstance.notifySubscribers({
-                                holon: targetHolon, // Notify with final target
-                                lens: targetLens,
-                                ...data // The data that was put
-                            });
-                        }
-
-                        // Auto-propagate to federation by default (if data *being put* is not a hologram).
-                        // Permissionless write: the LOCAL write already acked, so propagating a
-                        // hologram of this item to federation partners is a BACKGROUND cascade and
-                        // must NOT block the caller's save (a partner that's slow/unreachable, or a
-                        // multi-hop parent-hexagon walk, would otherwise stall every write — the
-                        // receiving holon filters on READ, not on our write). Fire-and-forget by
-                        // default; callers that need the result can pass `{ awaitPropagation: true }`.
-                        const shouldPropagate = options.autoPropagate !== false && !isHologram && !isGlobal;
-                        let propagationResult = null;
-
-                        if (shouldPropagate) {
-                            // Holograms are OPT-IN: a plain put propagates full copies to
-                            // partners by default, not soul pointers. Callers that want
-                            // holograms must pass `propagationOptions.useHolograms: true`
-                            // (e.g. @holons/core publishToFederation when opted in).
-                            // NOTE: holosphere is vendored — re-apply this default if it is
-                            // ever re-synced from upstream.
-                            const propagationOptions = {
-                                useHolograms: false,
-                                ...options.propagationOptions
-                            };
-                            const runPropagation = () => {
-                                return holoInstance.propagate(targetHolon, targetLens, data, propagationOptions)
-                                    .then((r) => {
-                                        if (r && r.errors > 0) console.warn('Auto-propagation had errors:', r);
-                                        return r;
-                                    })
-                                    .catch((propError) => { console.warn('Error in auto-propagation:', propError); return null; });
-                            };
-                            if (options.awaitPropagation) {
-                                propagationResult = await runPropagation();
-                            } else {
-                                // Background — don't block the write on federation propagation.
-                                runPropagation();
-                            }
-                        }
-
-                        resolve({
-                            success: true,
-                            isHologramAtPath: isHologram, // whether the data *put* was a hologram
-                            pathHolon: targetHolon,
-                            pathLens: targetLens,
-                            pathKey: targetKey,
-                            propagationResult,
-                            updatedHolograms: updatedHolograms // List of holograms that were updated
-                        });
+                        console.warn(`Data (ID: ${data.id}) being put is a hologram, but could not parse its soul ${data.soul} for tracking.`);
                     }
-                };
-
-                // Use targetHolon, targetLens, and targetKey for the actual storage path
-                const dataPath = password ?
-                    user.get('private').get(targetLens).get(targetKey) :
-                    holonLens(holoInstance, targetHolon, targetLens).get(targetKey);
-
-                // Race-free signing: issue the signed envelope BEFORE the raw write
-                // so reads/subscribers resolve against a consistent envelope the
-                // instant the raw write lands. No-op unless signing is enabled.
-                if (!isHologram && !isGlobal && !options._skipSign && holoInstance._signer) {
-                    try { holoInstance._signer.signEnvelope(holoInstance, targetHolon, targetLens, data); }
-                    catch (e) { console.warn('[signing] signEnvelope failed:', e?.message); }
+                } catch (trackingError) {
+                    console.warn(`Error updating _holograms set for the target of the data being put (data ID: ${data.id}, soul: ${data.soul}):`, trackingError);
                 }
-                dataPath.put(payload, putCallback);
-            } catch (error) {
-                reject(error);
             }
-        });
+            // --- End: Hologram Tracking Logic ---
 
-        // Bound the wait on Gun's put ack so an offline/partitioned mesh
-        // doesn't hang the caller forever. Gun keeps the local write and
-        // its eventual ack callback (subscriber notify, hologram cascade,
-        // propagation) still runs when a peer reappears — we just stop
-        // blocking the awaiting consumer in the meantime.
-        return withWriteTimeout(ackPromise, writeTimeoutMs, {
-            success: true,
-            queued: true,
-            isHologramAtPath: isHologram,
-            pathHolon: targetHolon,
-            pathLens: targetLens,
-            pathKey: targetKey,
-            propagationResult: null,
-            updatedHolograms: []
-        });
+            // --- Start: Active Hologram Update Logic ---
+            //
+            // Walks this node's `_holograms` set and stamps every
+            // registered hologram with `updated: now` so consumers
+            // re-resolve and see the latest source data.
+            //
+            // Runs for BOTH original-data puts and hologram-update
+            // puts so updates cascade through multi-hop forwards
+            // (A → B → C → …) even when the second hop's
+            // cross-holon registration on the original source
+            // can't be relied on to make it across the Gun mesh.
+            // Each hop maintains its own local `_holograms` set
+            // tracking the next hops, and we walk that set on
+            // every put — cycle-protected via
+            // `options._cascadeVisited`.
+            let updatedHolograms = [];
+            const currentDataSoul = `${holoInstance.appname}/${targetHolon}/${targetLens}/${targetKey}`;
+            const cascadeVisited = new Set(options._cascadeVisited || []);
+            if (!cascadeVisited.has(currentDataSoul)) {
+                cascadeVisited.add(currentDataSoul);
+                try {
+                    const currentNodeRef = holoInstance.getNodeRef(currentDataSoul);
+
+                    // Get the _holograms set for this node
+                    await new Promise((resolveHologramUpdate) => {
+                        currentNodeRef.get('_holograms').once(async (hologramsSet) => {
+                            if (hologramsSet) {
+                                const hologramSouls = Object.keys(hologramsSet).filter(k =>
+                                    k !== '_' && hologramsSet[k] === true && !cascadeVisited.has(k)
+                                );
+
+                                if (hologramSouls.length > 0) {
+                                    // Update each active hologram with an 'updated' timestamp
+                                    const updatePromises = hologramSouls.map(async (hologramSoul) => {
+                                        try {
+                                            const hologramSoulInfo = holoInstance.parseSoulPath(hologramSoul);
+                                            if (hologramSoulInfo) {
+                                                // Get the current hologram data
+                                                const currentHologram = await holoInstance.get(
+                                                    hologramSoulInfo.holon,
+                                                    hologramSoulInfo.lens,
+                                                    hologramSoulInfo.key,
+                                                    null,
+                                                    { resolveHolograms: false }
+                                                );
+
+                                                if (currentHologram) {
+                                                    // Update the hologram with an 'updated' timestamp
+                                                    const updatedHologram = {
+                                                        ...currentHologram,
+                                                        updated: Date.now()
+                                                    };
+
+                                                    await holoInstance.put(
+                                                        hologramSoulInfo.holon,
+                                                        hologramSoulInfo.lens,
+                                                        updatedHologram,
+                                                        null,
+                                                        {
+                                                            autoPropagate: false, // Don't auto-propagate hologram updates
+                                                            disableHologramRedirection: true, // Prevent redirection when updating holograms
+                                                            isHologramUpdate: true,
+                                                            // Carry the visited set forward so the
+                                                            // recursive put keeps cascading through
+                                                            // this hop's `_holograms` set without
+                                                            // looping back through us.
+                                                            _cascadeVisited: cascadeVisited
+                                                        }
+                                                    );
+
+                                                    // Add to the list of updated holograms
+                                                    updatedHolograms.push({
+                                                        soul: hologramSoul,
+                                                        holon: hologramSoulInfo.holon,
+                                                        lens: hologramSoulInfo.lens,
+                                                        key: hologramSoulInfo.key,
+                                                        id: hologramSoulInfo.key,
+                                                        timestamp: updatedHologram.updated
+                                                    });
+                                                }
+                                            }
+                                        } catch (hologramUpdateError) {
+                                            console.warn(`Error updating hologram ${hologramSoul}:`, hologramUpdateError);
+                                        }
+                                    });
+
+                                    await Promise.all(updatePromises);
+                                }
+                            }
+                            resolveHologramUpdate(); // Resolve the promise to continue with the main put logic
+                        });
+                    });
+                } catch (hologramUpdateError) {
+                    console.warn(`Error checking for active holograms to update:`, hologramUpdateError);
+                }
+            }
+            // --- End: Active Hologram Update Logic ---
+
+            // Only notify subscribers for actual data, not holograms
+            if (!isHologram) {
+                holoInstance.notifySubscribers({
+                    holon: targetHolon, // Notify with final target
+                    lens: targetLens,
+                    ...data // The data that was put
+                });
+            }
+
+            // Auto-propagate to federation by default (if data *being put* is not a hologram).
+            // Permissionless write: the LOCAL write already acked, so propagating a
+            // hologram of this item to federation partners is a BACKGROUND cascade and
+            // must NOT block the caller's save (a partner that's slow/unreachable, or a
+            // multi-hop parent-hexagon walk, would otherwise stall every write — the
+            // receiving holon filters on READ, not on our write). Fire-and-forget by
+            // default; callers that need the result can pass `{ awaitPropagation: true }`.
+            const shouldPropagate = options.autoPropagate !== false && !isHologram && !isGlobal;
+            let propagationResult = null;
+
+            if (shouldPropagate) {
+                // Holograms are OPT-IN: a plain put propagates full copies to
+                // partners by default, not soul pointers. Callers that want
+                // holograms must pass `propagationOptions.useHolograms: true`
+                // (e.g. @holons/core publishToFederation when opted in).
+                // NOTE: holosphere is vendored — re-apply this default if it is
+                // ever re-synced from upstream.
+                const propagationOptions = {
+                    useHolograms: false,
+                    ...options.propagationOptions
+                };
+                const runPropagation = () => {
+                    return holoInstance.propagate(targetHolon, targetLens, data, propagationOptions)
+                        .then((r) => {
+                            if (r && r.errors > 0) console.warn('Auto-propagation had errors:', r);
+                            return r;
+                        })
+                        .catch((propError) => { console.warn('Error in auto-propagation:', propError); return null; });
+                };
+                if (options.awaitPropagation) {
+                    propagationResult = await runPropagation();
+                } else {
+                    // Background — don't block the write on federation propagation.
+                    runPropagation();
+                }
+            }
+
+            return {
+                success: true,
+                isHologramAtPath: isHologram,
+                pathHolon: targetHolon,
+                pathLens: targetLens,
+                pathKey: targetKey,
+                propagationResult,
+                updatedHolograms
+            };
+        };
+
+        // Race-free signing: issue the signed envelope BEFORE the raw write
+        // so reads/subscribers resolve against a consistent envelope the
+        // instant the raw write lands. No-op unless signing is enabled.
+        // Only for Gun backend — AD4M handles signing internally.
+        if (!isHologram && !isGlobal && !options._skipSign && holoInstance._signer) {
+            if (holoInstance._backend.type !== 'ad4m') {
+                try { holoInstance._signer.signEnvelope(holoInstance, targetHolon, targetLens, data); }
+                catch (e) { console.warn('[signing] signEnvelope failed:', e?.message); }
+            }
+        }
+
+        if (password) {
+            // Password path — Gun-specific user auth
+            if (!holoInstance._backend.gun) {
+                throw new Error('Password-protected operations require the Gun backend');
+            }
+            const ackPromise = new Promise((resolve, reject) => {
+                try {
+                    const dataPath = user.get('private').get(targetLens).get(targetKey);
+                    const putCallback = async (ack) => {
+                        if (ack.err) {
+                            reject(new Error(ack.err));
+                        } else {
+                            try {
+                                const result = await runPostWriteSideEffects();
+                                resolve(result);
+                            } catch (sideEffectError) {
+                                reject(sideEffectError);
+                            }
+                        }
+                    };
+                    dataPath.put(payload, putCallback);
+                } catch (error) {
+                    reject(error);
+                }
+            });
+
+            // Bound the wait on Gun's put ack so an offline/partitioned mesh
+            // doesn't hang the caller forever. Gun keeps the local write and
+            // its eventual ack callback (subscriber notify, hologram cascade,
+            // propagation) still runs when a peer reappears — we just stop
+            // blocking the awaiting consumer in the meantime.
+            return withWriteTimeout(ackPromise, writeTimeoutMs, {
+                success: true,
+                queued: true,
+                isHologramAtPath: isHologram,
+                pathHolon: targetHolon,
+                pathLens: targetLens,
+                pathKey: targetKey,
+                propagationResult: null,
+                updatedHolograms: []
+            });
+        } else {
+            // Non-password path — delegate to pluggable backend
+            const backendResult = await holoInstance._backend.put(targetHolon, targetLens, targetKey, payload, { timeout: writeTimeoutMs });
+            if (!backendResult.ok) {
+                throw new Error('Backend write failed');
+            }
+            if (backendResult.queued) {
+                // Backend accepted the write but hasn't confirmed peer ack yet
+                // (local-first). Return immediately; side effects run when the
+                // backend confirms later (or not at all if offline forever).
+                return {
+                    success: true,
+                    queued: true,
+                    isHologramAtPath: isHologram,
+                    pathHolon: targetHolon,
+                    pathLens: targetLens,
+                    pathKey: targetKey,
+                    propagationResult: null,
+                    updatedHolograms: []
+                };
+            }
+            return runPostWriteSideEffects();
+        }
     } catch (error) {
         console.error('Error in put:', error);
         throw error;
@@ -645,122 +685,119 @@ export async function get(holoInstance, holon, lens, key, password = null, optio
         }
     }
 
+    // Shared post-read processing: parse, tombstone check, hologram resolution, schema validation.
+    const handleData = async (data) => {
+        let parsed = null;
+        if (!data) {
+            return null;
+        }
+
+        try {
+            parsed = await holoInstance.parse(data);
+
+            if (!parsed) {
+                return null;
+            }
+
+            // Treat the harvest-side `_deleted: true` soft-tombstone
+            // as "not found" by default. Callers that want to see
+            // tombstones can pass `{ includeDeleted: true }`.
+            if (!includeDeleted && parsed._deleted === true) {
+                return null;
+            }
+
+            // Check if this is a hologram that needs to be resolved
+            if (resolveHolograms && holoInstance.isHologram(parsed)) {
+                const res = await holoInstance.resolveHologramDetailed(parsed, {
+                    followHolograms: resolveHolograms,
+                    visited: visited,
+                    maxDepth: options.maxDepth || 10,
+                    currentDepth: options.currentDepth || 0
+                });
+
+                if (res.status === 'deleted') {
+                    // The pointer's target was soft-deleted (_deleted:true)
+                    // — a DEFINITIVE deletion (distinct from a transient
+                    // miss). The pointer is prunable. By default the item
+                    // reads as gone; `includeDeleted` surfaces a tombstone
+                    // so admin/debug views can see it.
+                    console.warn(`Hologram at ${holon}/${lens}/${key} did not resolve (soul=${parsed.soul}); skipping.`);
+                    if (includeDeleted) {
+                        return { id: parsed.id, _deleted: true, _hologram: { isHologram: true, soul: res.soul, deleted: true } };
+                    } else {
+                        return null;
+                    }
+                }
+
+                if (res.status !== 'resolved') {
+                    // unresolved/error are TRANSIENT (latency, offline
+                    // peer, federation in flight, or a hard put(null));
+                    // circular/depth/invalid are structural. Either way
+                    // DON'T delete here — the old code destroyed real data
+                    // on the first transient miss. Skip; a real garbage
+                    // collector (keyed on this janitor-parseable line, and
+                    // on resolveHologramDetailed's status) owns cleanup.
+                    console.warn(`Hologram at ${holon}/${lens}/${key} did not resolve (soul=${parsed.soul}); skipping.`);
+                    return null;
+                }
+
+                if (res.data !== parsed) {
+                    parsed = res.data;
+                }
+            }
+
+            // Perform schema validation if needed
+            if (schema) {
+                const valid = holoInstance.validator.validate(schema, parsed);
+                if (!valid) {
+                    console.error('get: Invalid data according to schema:', holoInstance.validator.errors);
+                    if (holoInstance.strict) {
+                        return null;
+                    }
+                }
+            }
+
+            return parsed;
+        } catch (error) {
+            if (error.message?.startsWith('CIRCULAR_REFERENCE')) {
+                 console.warn(`Caught circular reference during get/handleData for key ${key}. Resolving null.`);
+                 return null;
+            } else {
+                console.error('Error processing data in get/handleData:', error);
+                return null;
+            }
+        }
+    };
+
     try {
-        let user = null;
         if (password) {
-            user = holoInstance.gun.user();
+            // Password path — Gun-specific user auth
+            if (!holoInstance._backend.gun) {
+                throw new Error('Password-protected operations require the Gun backend');
+            }
+            const user = holoInstance._backend.gun.user();
             await new Promise((resolve, reject) => {
-                const userNameString = holoInstance.userName(holon); // Use holon for get
+                const userNameString = holoInstance.userName(holon);
                 user.auth(userNameString, password, (authAck) => {
                     if (authAck.err) {
-                        // If auth fails, reject immediately. Do not attempt to create user.
                         reject(new Error(`Authentication failed for ${userNameString} during get: ${authAck.err}`));
                     } else {
-                        resolve(); // Auth successful
+                        resolve();
                     }
                 });
             });
-        }
 
-        return new Promise((resolve) => {
-            const handleData = async (data) => {
-                let parsed = null; // Declare parsed here to make it available in catch
-                if (!data) {
-                    resolve(null);
-                    return;
-                }
-
-                try {
-                    parsed = await holoInstance.parse(data); // Assign to the outer scoped parsed
-
-                    if (!parsed) {
-                        resolve(null);
-                        return;
-                    }
-
-                    // Treat the harvest-side `_deleted: true` soft-tombstone
-                    // as "not found" by default. Callers that want to see
-                    // tombstones can pass `{ includeDeleted: true }`.
-                    if (!includeDeleted && parsed._deleted === true) {
-                        resolve(null);
-                        return;
-                    }
-
-                    // Check if this is a hologram that needs to be resolved
-                    if (resolveHolograms && holoInstance.isHologram(parsed)) {
-                        const res = await holoInstance.resolveHologramDetailed(parsed, {
-                            followHolograms: resolveHolograms,
-                            visited: visited,
-                            maxDepth: options.maxDepth || 10,
-                            currentDepth: options.currentDepth || 0
-                        });
-
-                        if (res.status === 'deleted') {
-                            // The pointer's target was soft-deleted (_deleted:true)
-                            // — a DEFINITIVE deletion (distinct from a transient
-                            // miss). The pointer is prunable. By default the item
-                            // reads as gone; `includeDeleted` surfaces a tombstone
-                            // so admin/debug views can see it.
-                            console.warn(`Hologram at ${holon}/${lens}/${key} did not resolve (soul=${parsed.soul}); skipping.`);
-                            if (includeDeleted) {
-                                resolve({ id: parsed.id, _deleted: true, _hologram: { isHologram: true, soul: res.soul, deleted: true } });
-                            } else {
-                                resolve(null);
-                            }
-                            return;
-                        }
-
-                        if (res.status !== 'resolved') {
-                            // unresolved/error are TRANSIENT (latency, offline
-                            // peer, federation in flight, or a hard put(null));
-                            // circular/depth/invalid are structural. Either way
-                            // DON'T delete here — the old code destroyed real data
-                            // on the first transient miss. Skip; a real garbage
-                            // collector (keyed on this janitor-parseable line, and
-                            // on resolveHologramDetailed's status) owns cleanup.
-                            console.warn(`Hologram at ${holon}/${lens}/${key} did not resolve (soul=${parsed.soul}); skipping.`);
-                            resolve(null);
-                            return;
-                        }
-
-                        if (res.data !== parsed) {
-                            parsed = res.data;
-                        }
-                    }
-
-                    // Perform schema validation if needed
-                    if (schema) {
-                        const valid = holoInstance.validator.validate(schema, parsed);
-                        if (!valid) {
-                            console.error('get: Invalid data according to schema:', holoInstance.validator.errors);
-                            if (holoInstance.strict) {
-                                resolve(null);
-                                return;
-                            }
-                        }
-                    }
-
-                    resolve(parsed);
-                } catch (error) {
-                    if (error.message?.startsWith('CIRCULAR_REFERENCE')) {
-                         console.warn(`Caught circular reference during get/handleData for key ${key}. Resolving null.`);
-                         resolve(null); 
-                    } else {
-                        console.error('Error processing data in get/handleData:', error);
-                        resolve(null); // For other errors, resolve null
-                    }
-                }
-            };
-
-            const dataPath = password ?
-                user.get('private').get(lens).get(key) :
-                holonLens(holoInstance, holon, lens).get(key);
-
+            const dataPath = user.get('private').get(lens).get(key);
             // `.once()` wrapped in a deadline — cold-path reads (peer offline,
             // never-written key) used to hang forever otherwise. After
             // `timeout` ms with no Gun response we treat it as "not found".
-            onceWithTimeout(dataPath, timeout, { awaitNetwork }).then(handleData);
-        });
+            const rawData = await onceWithTimeout(dataPath, timeout, { awaitNetwork });
+            return handleData(rawData);
+        } else {
+            // Non-password path — delegate to pluggable backend
+            const rawData = await holoInstance._backend.get(holon, lens, key, { timeout, awaitNetwork });
+            return handleData(rawData);
+        }
     } catch (error) {
         console.error('Error in get:', error);
         return null;
@@ -796,12 +833,80 @@ export async function getAll(holoInstance, holon, lens, password = null, options
         throw new Error('getAll: Schema required in strict mode');
     }
 
+    // Shared per-item processing: parse, tombstone check, hologram resolution, schema validation.
+    const output = new Map();
+    const processItem = async (itemData, key) => {
+        if (!itemData) return;
+        try {
+            const parsed = await holoInstance.parse(itemData);
+            if (!parsed || !parsed.id) return;
+
+            // Drop `_deleted: true` soft-tombstones by default;
+            // callers wanting them in the result pass
+            // `{ includeDeleted: true }` to `getAll`.
+            if (!includeDeleted && parsed._deleted === true) return;
+
+            if (holoInstance.isHologram(parsed)) {
+                try {
+                    const res = await holoInstance.resolveHologramDetailed(parsed, {
+                        followHolograms: true,
+                        maxDepth: 10,
+                        currentDepth: 0
+                    });
+
+                    if (res.status !== 'resolved') {
+                        // See `get()` above: a transient miss is not
+                        // proof of a dead pointer, so we skip without
+                        // deleting. A soft-deleted source (status
+                        // 'deleted') is definitive; surface it as a
+                        // tombstone only when the caller opted in.
+                        console.warn(`Hologram at ${holon}/${lens}/${key} did not resolve (soul=${parsed.soul}); skipping.`);
+                        if (res.status === 'deleted' && includeDeleted) {
+                            output.set(parsed.id, { id: parsed.id, _deleted: true, _hologram: { isHologram: true, soul: res.soul, deleted: true } });
+                        }
+                        return;
+                    }
+
+                    const resolved = res.data;
+                    if (resolved && resolved !== parsed) {
+                        if (schema) {
+                            const valid = holoInstance.validator.validate(schema, resolved);
+                            if (valid || !holoInstance.strict) {
+                                output.set(resolved.id, resolved);
+                            }
+                        } else {
+                            output.set(resolved.id, resolved);
+                        }
+                        return;
+                    }
+                } catch (hologramError) {
+                    console.error(`Error resolving hologram for key ${key}:`, hologramError);
+                    return;
+                }
+            }
+
+            if (schema) {
+                const valid = holoInstance.validator.validate(schema, parsed);
+                if (valid || !holoInstance.strict) {
+                    output.set(parsed.id, parsed);
+                }
+            } else {
+                output.set(parsed.id, parsed);
+            }
+        } catch (error) {
+            console.error('Error processing data:', error);
+        }
+    };
+
     try {
-        let user = null;
         if (password) {
-            user = holoInstance.gun.user();
+            // Password path — Gun-specific user auth
+            if (!holoInstance._backend.gun) {
+                throw new Error('Password-protected operations require the Gun backend');
+            }
+            const user = holoInstance._backend.gun.user();
             await new Promise((resolve, reject) => {
-                const userNameString = holoInstance.userName(holon); // Use holon for getAll
+                const userNameString = holoInstance.userName(holon);
                 user.auth(userNameString, password, (authAck) => {
                     if (authAck.err) {
                         console.log(`Initial auth failed for ${userNameString} during getAll, attempting to create...`);
@@ -809,18 +914,18 @@ export async function getAll(holoInstance, holon, lens, password = null, options
                             if (createAck.err) {
                                 if (createAck.err.includes("already created") || createAck.err.includes("already being created")) {
                                     console.log(`User ${userNameString} already existed or being created during getAll, re-attempting auth with fresh user object.`);
-                                    const freshUser = holoInstance.gun.user(); // Get a new user object
+                                    const freshUser = holoInstance._backend.gun.user();
                                     freshUser.auth(userNameString, password, (secondAuthAck) => {
                                         if (secondAuthAck.err) {
                                             console.log(`Auth still failed after user existed check: ${secondAuthAck.err}. Resolving anyway for test operations.`);
-                                            resolve(); // Resolve anyway to allow test operations
+                                            resolve();
                                         } else {
                                             resolve();
                                         }
                                     });
                                 } else {
                                     console.log(`Create user error (resolving anyway for operations): ${createAck.err}`);
-                                    resolve(); // Resolve anyway to allow test operations
+                                    resolve();
                                 }
                             } else {
                                 console.log(`User ${userNameString} created successfully during getAll, attempting auth...`);
@@ -834,143 +939,64 @@ export async function getAll(holoInstance, holon, lens, password = null, options
                             }
                         });
                     } else {
-                        resolve(); // Auth successful
+                        resolve();
                     }
                 });
             });
-        }
 
-        return new Promise((resolve) => {
-            const output = new Map();
-            const pendingProcessing = [];
+            // Gun password path — shallow probe + iterate via Gun chain
+            return new Promise((resolve) => {
+                const dataPath = user.get('private').get(lens);
 
-            const dataPath = password ?
-                user.get('private').get(lens) :
-                holonLens(holoInstance, holon, lens);
+                const shallowOnce = () => onceWithTimeout(dataPath, timeout);
 
-            // PASS 1: Get shallow node to determine expected item count.
-            // Wrapped in a deadline (see `onceWithTimeout`) so cold paths
-            // resolve `null` after `timeout` ms instead of hanging forever.
-            // We still retry once below — Gun's `.once()` reads from local
-            // cache, which may be cold immediately after startup before
-            // peers have synced.
-            const shallowOnce = () => onceWithTimeout(dataPath, timeout);
-
-            const processShallow = (data) => {
-                if (!data) {
-                    resolve([]);
-                    return;
-                }
-
-                // Filter out Gun metadata, null/deleted entries, and Gun soul references
-                const keys = Object.keys(data).filter(key => {
-                    if (key === '_') return false;
-                    const val = data[key];
-                    if (val === null) return false;
-                    // Filter out Gun graph references (sub-nodes)
-                    if (typeof val === 'object' && val['#']) return false;
-                    return true;
-                });
-                const expectedCount = keys.length;
-
-                if (expectedCount === 0) {
-                    resolve([]);
-                    return;
-                }
-
-                // PASS 2: iterate explicitly over the filtered keys.
-                // Using dataPath.map().once() here is unsafe when the parent
-                // node has tombstoned siblings (null values): map() fires for
-                // every child, and a null sibling's callback can satisfy
-                // receivedCount before real items are processed, resolving [].
-                const processItem = async (itemData, key) => {
-                    if (!itemData) return;
-                    try {
-                        const parsed = await holoInstance.parse(itemData);
-                        if (!parsed || !parsed.id) return;
-
-                        // Drop `_deleted: true` soft-tombstones by default;
-                        // callers wanting them in the result pass
-                        // `{ includeDeleted: true }` to `getAll`.
-                        if (!includeDeleted && parsed._deleted === true) return;
-
-                        if (holoInstance.isHologram(parsed)) {
-                            try {
-                                const res = await holoInstance.resolveHologramDetailed(parsed, {
-                                    followHolograms: true,
-                                    maxDepth: 10,
-                                    currentDepth: 0
-                                });
-
-                                if (res.status !== 'resolved') {
-                                    // See `get()` above: a transient miss is not
-                                    // proof of a dead pointer, so we skip without
-                                    // deleting. A soft-deleted source (status
-                                    // 'deleted') is definitive; surface it as a
-                                    // tombstone only when the caller opted in.
-                                    console.warn(`Hologram at ${holon}/${lens}/${key} did not resolve (soul=${parsed.soul}); skipping.`);
-                                    if (res.status === 'deleted' && includeDeleted) {
-                                        output.set(parsed.id, { id: parsed.id, _deleted: true, _hologram: { isHologram: true, soul: res.soul, deleted: true } });
-                                    }
-                                    return;
-                                }
-
-                                const resolved = res.data;
-                                if (resolved && resolved !== parsed) {
-                                    if (schema) {
-                                        const valid = holoInstance.validator.validate(schema, resolved);
-                                        if (valid || !holoInstance.strict) {
-                                            output.set(resolved.id, resolved);
-                                        }
-                                    } else {
-                                        output.set(resolved.id, resolved);
-                                    }
-                                    return;
-                                }
-                            } catch (hologramError) {
-                                console.error(`Error resolving hologram for key ${key}:`, hologramError);
-                                return;
-                            }
-                        }
-
-                        if (schema) {
-                            const valid = holoInstance.validator.validate(schema, parsed);
-                            if (valid || !holoInstance.strict) {
-                                output.set(parsed.id, parsed);
-                            }
-                        } else {
-                            output.set(parsed.id, parsed);
-                        }
-                    } catch (error) {
-                        console.error('Error processing data:', error);
+                const processShallow = (data) => {
+                    if (!data) {
+                        resolve([]);
+                        return;
                     }
+
+                    const keys = Object.keys(data).filter(key => {
+                        if (key === '_') return false;
+                        const val = data[key];
+                        if (val === null) return false;
+                        if (typeof val === 'object' && val['#']) return false;
+                        return true;
+                    });
+
+                    if (keys.length === 0) {
+                        resolve([]);
+                        return;
+                    }
+
+                    Promise.all(keys.map((key) => {
+                        const inline = data[key];
+                        if (typeof inline !== 'object' || inline === null) {
+                            return processItem(inline, key);
+                        }
+                        return onceWithTimeout(dataPath.get(key), timeout)
+                            .then((itemData) => processItem(itemData, key));
+                    })).then(() => resolve(Array.from(output.values())));
                 };
 
-                Promise.all(keys.map((key) => {
-                    const inline = data[key];
-                    // If shallow already inlined the leaf (holosphere stores
-                    // payloads as JSON strings), process it directly. This
-                    // avoids a redundant round-trip and the map() race.
-                    if (typeof inline !== 'object' || inline === null) {
-                        return processItem(inline, key);
+                (async () => {
+                    let data = await shallowOnce();
+                    if (!data) {
+                        await new Promise(r => setTimeout(r, 1500));
+                        data = await shallowOnce();
                     }
-                    // Otherwise fetch the leaf — sub-graph reference path.
-                    // Same deadline as the shallow probe; a single missing
-                    // leaf can't stall the whole batch.
-                    return onceWithTimeout(dataPath.get(key), timeout)
-                        .then((itemData) => processItem(itemData, key));
-                })).then(() => resolve(Array.from(output.values())));
-            };
-
-            (async () => {
-                let data = await shallowOnce();
-                if (!data) {
-                    await new Promise(r => setTimeout(r, 1500));
-                    data = await shallowOnce();
-                }
-                processShallow(data);
-            })();
-        });
+                    processShallow(data);
+                })();
+            });
+        } else {
+            // Non-password path — delegate to pluggable backend
+            const rawMap = await holoInstance._backend.getAll(holon, lens, { timeout });
+            // Process each entry through the existing parsing/hologram/schema logic
+            await Promise.all(
+                Array.from(rawMap).map(([key, rawData]) => processItem(rawData, key))
+            );
+            return Array.from(output.values());
+        }
     } catch (error) {
         console.error('Error in getAll:', error);
         return [];
@@ -1051,12 +1077,59 @@ export async function deleteFunc(holoInstance, holon, lens, key, password = null
         throw new Error('delete: Missing required parameters');
     }
 
+    // --- Hologram Tracking Removal helper ---
+    // Reads the data at the path before deletion to check if it's a hologram.
+    // If so, removes the hologram reference from the target's _holograms set.
+    const runHologramTrackingRemoval = async (rawDataToDelete) => {
+        let dataToDelete = null;
+        try {
+            if (typeof rawDataToDelete === 'string') {
+                dataToDelete = JSON.parse(rawDataToDelete);
+            } else {
+                dataToDelete = rawDataToDelete;
+            }
+        } catch(e) {
+            console.warn("[deleteFunc] Could not JSON parse data for deletion check:", rawDataToDelete, e);
+            dataToDelete = null;
+        }
+
+        const isDataHologram = dataToDelete && holoInstance.isHologram(dataToDelete);
+
+        if (isDataHologram) {
+            try {
+                const targetSoul = dataToDelete.soul;
+                const targetSoulInfo = holoInstance.parseSoulPath(targetSoul);
+
+                if (targetSoulInfo) {
+                    const targetNodeRef = holoInstance.getNodeRef(targetSoul);
+                    const deletedHologramSoul = `${holoInstance.appname}/${holon}/${lens}/${key}`;
+
+                    await new Promise((resolveTrack) => {
+                        targetNodeRef.get('_holograms').get(deletedHologramSoul).put(null, (ack) => {
+                            if (ack.err) {
+                                console.warn(`[deleteFunc] Error removing hologram ${deletedHologramSoul} from target ${targetSoul}:`, ack.err);
+                            }
+                            resolveTrack();
+                        });
+                    });
+                } else {
+                    console.warn(`Could not parse target soul ${targetSoul} for hologram tracking removal.`);
+                }
+            } catch (trackingError) {
+                console.warn(`Error initiating hologram reference removal from target ${dataToDelete.soul}:`, trackingError);
+            }
+        }
+    };
+
     try {
-        let user = null;
         if (password) {
-            user = holoInstance.gun.user();
+            // Password path — Gun-specific user auth
+            if (!holoInstance._backend.gun) {
+                throw new Error('Password-protected operations require the Gun backend');
+            }
+            const user = holoInstance._backend.gun.user();
             await new Promise((resolve, reject) => {
-                const userNameString = holoInstance.userName(holon); // Use holon for deleteFunc
+                const userNameString = holoInstance.userName(holon);
                 user.auth(userNameString, password, (authAck) => {
                     if (authAck.err) {
                         console.log(`Initial auth failed for ${userNameString} during deleteFunc, attempting to create...`);
@@ -1064,7 +1137,7 @@ export async function deleteFunc(holoInstance, holon, lens, key, password = null
                             if (createAck.err) {
                                 if (createAck.err.includes("already created")) {
                                     console.log(`User ${userNameString} already existed during deleteFunc, re-attempting auth with fresh user object.`);
-                                    const freshUser = holoInstance.gun.user(); // Get a new user object
+                                    const freshUser = holoInstance._backend.gun.user();
                                     freshUser.auth(userNameString, password, (secondAuthAck) => {
                                         if (secondAuthAck.err) {
                                             reject(new Error(`Failed to auth with fresh user object after create attempt (user existed) for ${userNameString} during deleteFunc: ${secondAuthAck.err}`));
@@ -1087,86 +1160,36 @@ export async function deleteFunc(holoInstance, holon, lens, key, password = null
                             }
                         });
                     } else {
-                        resolve(); // Auth successful
+                        resolve();
                     }
                 });
             });
-        }
 
-        const dataPath = password ?
-            user.get('private').get(lens).get(key) :
-            holonLens(holoInstance, holon, lens).get(key);
+            const dataPath = user.get('private').get(lens).get(key);
 
-        // --- Start: Hologram Tracking Removal ---
-        let trackingRemovalPromise = Promise.resolve(); // Default to resolved promise
-        
-        // 1. Get the data first to check if it's a hologram.
-        // Use the shared deadline wrapper — a bare `.once()` hangs forever on a
-        // cold read (peer offline / missing key), which would stall the whole
-        // delete. On timeout we proceed as "not a hologram" (null), which just
-        // skips the forward-reference cleanup — the node removal below still runs.
-        const rawDataToDelete = await onceWithTimeout(dataPath, READ_TIMEOUT_MS);
-        let dataToDelete = null;
-        try {
-            if (typeof rawDataToDelete === 'string') {
-                dataToDelete = JSON.parse(rawDataToDelete);
-            } else {
-                // Handle cases where it might already be an object (though likely string)
-                dataToDelete = rawDataToDelete; 
-            }
-        } catch(e) {
-            console.warn("[deleteFunc] Could not JSON parse data for deletion check:", rawDataToDelete, e);
-            dataToDelete = null; // Ensure it's null if parsing fails
-        }
+            // Read current data for hologram tracking removal
+            const rawDataToDelete = await onceWithTimeout(dataPath, READ_TIMEOUT_MS);
+            await runHologramTrackingRemoval(rawDataToDelete);
 
-        // 2. If it is a hologram, try to remove its reference from the target
-        const isDataHologram = dataToDelete && holoInstance.isHologram(dataToDelete);
-        
-        if (isDataHologram) {
-            try {
-                const targetSoul = dataToDelete.soul;
-                const targetSoulInfo = holoInstance.parseSoulPath(targetSoul);
-                
-                if (targetSoulInfo) {
-                    const targetNodeRef = holoInstance.getNodeRef(targetSoul);
-                    const deletedHologramSoul = `${holoInstance.appname}/${holon}/${lens}/${key}`;
-
-                    // Create a promise that resolves when the hologram is removed from the list
-                    trackingRemovalPromise = new Promise((resolveTrack) => { // No reject needed, just warn on error
-                        targetNodeRef.get('_holograms').get(deletedHologramSoul).put(null, (ack) => { // Remove the hologram entry completely
-                            if (ack.err) {
-                                console.warn(`[deleteFunc] Error removing hologram ${deletedHologramSoul} from target ${targetSoul}:`, ack.err);
-                            }
-                            resolveTrack(); // Resolve regardless of ack error to not block main delete
-                        });
-                    });
-                } else {
-                    // Keep this warning
-                    console.warn(`Could not parse target soul ${targetSoul} for hologram tracking removal.`);
-                }
-            } catch (trackingError) {
-                 // Keep this warning
-                console.warn(`Error initiating hologram reference removal from target ${dataToDelete.soul}:`, trackingError);
-                // Ensure trackingRemovalPromise remains resolved if setup fails
-                trackingRemovalPromise = Promise.resolve(); 
-            }
-        }
-        // --- End: Hologram Tracking Removal ---
-
-        // 3. Wait for the tracking removal attempt to be acknowledged
-        await trackingRemovalPromise;
-        // Log removed
-
-        // 4. Proceed with the actual deletion of the hologram node itself
-        return new Promise((resolve, reject) => {
-            dataPath.put(null, ack => {
-                if (ack.err) {
-                    reject(new Error(ack.err));
-                } else {
-                    resolve(true);
-                }
+            // Proceed with the actual deletion
+            return new Promise((resolve, reject) => {
+                dataPath.put(null, ack => {
+                    if (ack.err) {
+                        reject(new Error(ack.err));
+                    } else {
+                        resolve(true);
+                    }
+                });
             });
-        });
+        } else {
+            // Non-password path — delegate to pluggable backend
+            // 1. Read the current data for hologram tracking removal
+            const rawDataToDelete = await holoInstance._backend.get(holon, lens, key, { timeout: READ_TIMEOUT_MS });
+            await runHologramTrackingRemoval(rawDataToDelete);
+
+            // 2. Proceed with the actual deletion via backend
+            return holoInstance._backend.delete(holon, lens, key);
+        }
     } catch (error) {
         console.error('Error in delete:', error);
         throw error;
@@ -1187,12 +1210,57 @@ export async function deleteAll(holoInstance, holon, lens, password = null) {
         return false;
     }
 
+    // Shared hologram tracking removal for each key
+    const removeHologramTracking = async (rawDataToDelete, key) => {
+        let dataToDelete = null;
+        try {
+            if (typeof rawDataToDelete === 'string') {
+                dataToDelete = JSON.parse(rawDataToDelete);
+            } else {
+                dataToDelete = rawDataToDelete;
+            }
+        } catch(e) {
+            console.warn("[deleteAll] Could not JSON parse data for deletion check:", rawDataToDelete, e);
+            dataToDelete = null;
+        }
+
+        const isDataHologram = dataToDelete && holoInstance.isHologram(dataToDelete);
+
+        if (isDataHologram) {
+            try {
+                const targetSoul = dataToDelete.soul;
+                const targetSoulInfo = holoInstance.parseSoulPath(targetSoul);
+
+                if (targetSoulInfo) {
+                    const targetNodeRef = holoInstance.getNodeRef(targetSoul);
+                    const deletedHologramSoul = `${holoInstance.appname}/${holon}/${lens}/${key}`;
+
+                    await new Promise((resolveTrack) => {
+                        targetNodeRef.get('_holograms').get(deletedHologramSoul).put(null, (ack) => {
+                            if (ack.err) {
+                                console.warn(`[deleteAll] Error removing hologram ${deletedHologramSoul} from target ${targetSoul}:`, ack.err);
+                            }
+                            resolveTrack();
+                        });
+                    });
+                } else {
+                    console.warn(`Could not parse target soul ${targetSoul} for hologram tracking removal during deleteAll.`);
+                }
+            } catch (trackingError) {
+                console.warn(`Error removing hologram reference from target ${dataToDelete.soul} during deleteAll:`, trackingError);
+            }
+        }
+    };
+
     try {
-        let user = null;
         if (password) {
-            user = holoInstance.gun.user();
+            // Password path — Gun-specific user auth
+            if (!holoInstance._backend.gun) {
+                throw new Error('Password-protected operations require the Gun backend');
+            }
+            const user = holoInstance._backend.gun.user();
             await new Promise((resolve, reject) => {
-                const userNameString = holoInstance.userName(holon); // Use holon for deleteAll
+                const userNameString = holoInstance.userName(holon);
                 user.auth(userNameString, password, (authAck) => {
                     if (authAck.err) {
                         console.log(`Initial auth failed for ${userNameString} during deleteAll, attempting to create...`);
@@ -1200,18 +1268,18 @@ export async function deleteAll(holoInstance, holon, lens, password = null) {
                             if (createAck.err) {
                                 if (createAck.err.includes("already created") || createAck.err.includes("already being created")) {
                                     console.log(`User ${userNameString} already existed or being created during deleteAll, re-attempting auth with fresh user object.`);
-                                    const freshUser = holoInstance.gun.user(); // Get a new user object
+                                    const freshUser = holoInstance._backend.gun.user();
                                     freshUser.auth(userNameString, password, (secondAuthAck) => {
                                         if (secondAuthAck.err) {
                                             console.log(`Auth still failed after user existed check: ${secondAuthAck.err}. Resolving anyway for test operations.`);
-                                            resolve(); // Resolve anyway to allow test operations
+                                            resolve();
                                         } else {
                                             resolve();
                                         }
                                     });
                                 } else {
                                     console.log(`Create user error (resolving anyway for operations): ${createAck.err}`);
-                                    resolve(); // Resolve anyway to allow test operations
+                                    resolve();
                                 }
                             } else {
                                 console.log(`User ${userNameString} created successfully during deleteAll, attempting auth...`);
@@ -1225,122 +1293,78 @@ export async function deleteAll(holoInstance, holon, lens, password = null) {
                             }
                         });
                     } else {
-                        resolve(); // Auth successful
+                        resolve();
                     }
                 });
             });
-        }
 
-        return new Promise((resolve) => {
-            let deletionPromises = [];
+            // Gun password path — iterate via Gun chain
+            return new Promise((resolve) => {
+                let deletionPromises = [];
+                const dataPath = user.get('private').get(lens);
 
-            const dataPath = password ?
-                user.get('private').get(lens) :
-                holonLens(holoInstance, holon, lens);
-
-            // First get all the data to find keys to delete
-            dataPath.once(async (data) => {
-                if (!data) {
-                    resolve(true); // Nothing to delete
-                    return;
-                }
-
-                // Get all keys except Gun's metadata key '_'
-                const keys = Object.keys(data).filter(key => key !== '_');
-
-                // Process each key to handle holograms properly
-                for (const key of keys) {
-                    try {
-                        // Get the data to check if it's a hologram
-                        const itemPath = password ?
-                            user.get('private').get(lens).get(key) :
-                            holonLens(holoInstance, holon, lens).get(key);
-
-                        const rawDataToDelete = await new Promise((resolveItem) => itemPath.once(resolveItem));
-                        let dataToDelete = null;
-                        
-                        try {
-                            if (typeof rawDataToDelete === 'string') {
-                                dataToDelete = JSON.parse(rawDataToDelete);
-                            } else {
-                                dataToDelete = rawDataToDelete;
-                            }
-                        } catch(e) {
-                            console.warn("[deleteAll] Could not JSON parse data for deletion check:", rawDataToDelete, e);
-                            dataToDelete = null;
-                        }
-
-                        // Check if it's a hologram and handle accordingly
-                        const isDataHologram = dataToDelete && holoInstance.isHologram(dataToDelete);
-                        
-                        if (isDataHologram) {
-                            // Handle hologram deletion - remove from target's _holograms list
-                            try {
-                                const targetSoul = dataToDelete.soul;
-                                const targetSoulInfo = holoInstance.parseSoulPath(targetSoul);
-                                
-                                if (targetSoulInfo) {
-                                    const targetNodeRef = holoInstance.getNodeRef(targetSoul);
-                                    const deletedHologramSoul = `${holoInstance.appname}/${holon}/${lens}/${key}`;
-
-                                    // Remove the hologram from target's _holograms list
-                                    await new Promise((resolveTrack) => {
-                                        targetNodeRef.get('_holograms').get(deletedHologramSoul).put(null, (ack) => {
-                                            if (ack.err) {
-                                                console.warn(`[deleteAll] Error removing hologram ${deletedHologramSoul} from target ${targetSoul}:`, ack.err);
-                                                                                    }
-                                        resolveTrack();
-                                        });
-                                    });
-                                } else {
-                                    console.warn(`Could not parse target soul ${targetSoul} for hologram tracking removal during deleteAll.`);
-                                }
-                            } catch (trackingError) {
-                                console.warn(`Error removing hologram reference from target ${dataToDelete.soul} during deleteAll:`, trackingError);
-                            }
-                        }
-
-                        // Create deletion promise for this key (whether it's a hologram or not)
-                        deletionPromises.push(
-                            new Promise((resolveDelete) => {
-                                const deletePath = password ?
-                                    user.get('private').get(lens).get(key) :
-                                    holonLens(holoInstance, holon, lens).get(key);
-
-                                deletePath.put(null, ack => {
-                                    resolveDelete(!!ack.ok); // Convert to boolean
-                                });
-                            })
-                        );
-                    } catch (error) {
-                        console.warn(`Error processing key ${key} during deleteAll:`, error);
-                        // Still try to delete the item even if hologram processing failed
-                        deletionPromises.push(
-                            new Promise((resolveDelete) => {
-                                const deletePath = password ?
-                                    user.get('private').get(lens).get(key) :
-                                    holonLens(holoInstance, holon, lens).get(key);
-
-                                deletePath.put(null, ack => {
-                                    resolveDelete(!!ack.ok);
-                                });
-                            })
-                        );
+                dataPath.once(async (data) => {
+                    if (!data) {
+                        resolve(true);
+                        return;
                     }
-                }
 
-                // Wait for all deletions to complete
-                Promise.all(deletionPromises)
-                    .then(results => {
-                        const allSuccessful = results.every(result => result === true);
-                        resolve(allSuccessful);
-                    })
-                    .catch(error => {
-                        console.error('Error in deleteAll:', error);
-                        resolve(false);
-                    });
+                    const keys = Object.keys(data).filter(key => key !== '_');
+
+                    for (const key of keys) {
+                        try {
+                            const itemPath = user.get('private').get(lens).get(key);
+                            const rawDataToDelete = await new Promise((resolveItem) => itemPath.once(resolveItem));
+                            await removeHologramTracking(rawDataToDelete, key);
+
+                            deletionPromises.push(
+                                new Promise((resolveDelete) => {
+                                    itemPath.put(null, ack => {
+                                        resolveDelete(!!ack.ok);
+                                    });
+                                })
+                            );
+                        } catch (error) {
+                            console.warn(`Error processing key ${key} during deleteAll:`, error);
+                            deletionPromises.push(
+                                new Promise((resolveDelete) => {
+                                    const deletePath = user.get('private').get(lens).get(key);
+                                    deletePath.put(null, ack => {
+                                        resolveDelete(!!ack.ok);
+                                    });
+                                })
+                            );
+                        }
+                    }
+
+                    Promise.all(deletionPromises)
+                        .then(results => {
+                            const allSuccessful = results.every(result => result === true);
+                            resolve(allSuccessful);
+                        })
+                        .catch(error => {
+                            console.error('Error in deleteAll:', error);
+                            resolve(false);
+                        });
+                });
             });
-        });
+        } else {
+            // Non-password path — delegate to pluggable backend
+            const rawMap = await holoInstance._backend.getAll(holon, lens, {});
+
+            if (rawMap.size === 0) return true;
+
+            // Process hologram tracking removal for all keys, then delete
+            const keys = Array.from(rawMap.keys());
+            for (const key of keys) {
+                await removeHologramTracking(rawMap.get(key), key);
+            }
+
+            const results = await Promise.all(
+                keys.map(key => holoInstance._backend.delete(holon, lens, key))
+            );
+            return results.every(result => result === true);
+        }
     } catch (error) {
         console.error('Error in deleteAll:', error);
         return false;

--- a/packages/holosphere/global.js
+++ b/packages/holosphere/global.js
@@ -37,9 +37,28 @@ export async function putGlobal(holoInstance, tableName, data, password = null, 
             throw new Error('Table name and data are required');
         }
 
+        // Create a copy of data, stripping read-side envelopes that
+        // must never be persisted (they're attached at resolution time).
+        let dataToStore = { ...data };
+        if (dataToStore._meta !== undefined) {
+            delete dataToStore._meta;
+        }
+        if (dataToStore._hologram !== undefined) {
+            delete dataToStore._hologram;
+        }
+        const payload = JSON.stringify(dataToStore);
+
+        // Check if the data being stored is a hologram
+        const isHologram = holoInstance.isHologram(dataToStore);
+
+        const writeTimeoutMs = options.timeout !== undefined ? options.timeout : WRITE_TIMEOUT_MS;
+
         let user = null;
         if (password) {
-            user = holoInstance.gun.user();
+            if (!holoInstance._backend.gun) {
+                throw new Error('Password-protected operations require the Gun backend');
+            }
+            user = holoInstance._backend.gun.user();
             await new Promise((resolve, reject) => {
                 const userNameString = holoInstance.userName(tableName);
                 user.auth(userNameString, password, (authAck) => {
@@ -50,22 +69,19 @@ export async function putGlobal(holoInstance, tableName, data, password = null, 
                             if (createAck.err) {
                                 // Check if error is "User already created"
                                 if (createAck.err.includes("already created") || createAck.err.includes("already being created")) {
-                                    // This means user exists but password might be wrong, or some other issue
-                                    // Proceed with auth again, it might have been a temporary glitch or race.
-                                    // Or, it could be that the password is indeed wrong.
                                     console.log(`User ${userNameString} already existed or being created, re-attempting auth with fresh user object.`);
-                                    const freshUser = holoInstance.gun.user(); // Get a new user object
+                                    const freshUser = holoInstance._backend.gun.user();
                                     freshUser.auth(userNameString, password, (secondAuthAck) => {
                                         if (secondAuthAck.err) {
                                             console.log(`Auth still failed after user existed check: ${secondAuthAck.err}. Resolving anyway for test operations.`);
-                                            resolve(); // Resolve anyway to allow test operations
+                                            resolve();
                                         } else {
                                             resolve();
                                         }
                                     });
                                 } else {
                                     console.log(`Create user error (resolving anyway for operations): ${createAck.err}`);
-                                    resolve(); // Resolve anyway to allow test operations
+                                    resolve();
                                 }
                             } else {
                                 // After successful creation, authenticate again
@@ -84,107 +100,102 @@ export async function putGlobal(holoInstance, tableName, data, password = null, 
                     }
                 });
             });
+
+            // Password path — still uses Gun ack callbacks directly
+            const ackPromise = new Promise((resolve, reject) => {
+                try {
+                    const dataPath = user.get('private').get(tableName);
+
+                    if (data.id) {
+                        dataPath.get(data.id).put(payload, ack => {
+                            if (ack.err) {
+                                reject(new Error(ack.err));
+                            } else {
+                                // --- Hologram Tracking ---
+                                if (isHologram) {
+                                    try {
+                                        const storedDataSoulInfo = holoInstance.parseSoulPath(dataToStore.soul);
+                                        if (storedDataSoulInfo) {
+                                            const targetNodeRef = holoInstance.getNodeRef(dataToStore.soul);
+                                            const storedHologramInstanceSoul = `${holoInstance.appname}/${tableName}/${data.id}`;
+                                            targetNodeRef.get('_holograms').get(storedHologramInstanceSoul).put(true);
+                                        } else {
+                                            console.warn(`Data (ID: ${data.id}) being put is a hologram, but could not parse its soul ${dataToStore.soul} for tracking.`);
+                                        }
+                                    } catch (trackingError) {
+                                        console.warn(`Error updating _holograms set for the target of the data being put (data ID: ${data.id}, soul: ${dataToStore.soul}):`, trackingError);
+                                    }
+                                }
+                                resolve();
+                            }
+                        });
+                    } else {
+                        dataPath.put(payload, ack => {
+                            if (ack.err) {
+                                reject(new Error(ack.err));
+                            } else {
+                                // --- Hologram Tracking ---
+                                if (isHologram) {
+                                    try {
+                                        const storedDataSoulInfo = holoInstance.parseSoulPath(dataToStore.soul);
+                                        if (storedDataSoulInfo) {
+                                            const targetNodeRef = holoInstance.getNodeRef(dataToStore.soul);
+                                            const storedHologramInstanceSoul = `${holoInstance.appname}/${tableName}`;
+                                            targetNodeRef.get('_holograms').get(storedHologramInstanceSoul).put(true);
+                                        } else {
+                                            console.warn(`Data being put is a hologram, but could not parse its soul ${dataToStore.soul} for tracking.`);
+                                        }
+                                    } catch (trackingError) {
+                                        console.warn(`Error updating _holograms set for the target of the data being put (soul: ${dataToStore.soul}):`, trackingError);
+                                    }
+                                }
+                                resolve();
+                            }
+                        });
+                    }
+                } catch (error) {
+                    reject(error);
+                }
+            });
+
+            const ACK_OK = Symbol('ackOk');
+            return withWriteTimeout(
+                ackPromise.then(() => ACK_OK),
+                writeTimeoutMs,
+                undefined
+            ).then((result) => {
+                if (result !== ACK_OK) {
+                    console.warn(`putGlobal: no ack within ${writeTimeoutMs}ms for table=${tableName} — write queued locally, will replay on reconnect`);
+                }
+                return undefined;
+            });
         }
 
-        const writeTimeoutMs = options.timeout !== undefined ? options.timeout : WRITE_TIMEOUT_MS;
+        // Non-password path — delegate to backend
+        const key = data.id || undefined;
+        const result = await holoInstance._backend.put(null, tableName, key, payload, { timeout: writeTimeoutMs });
 
-        const ackPromise = new Promise((resolve, reject) => {
+        // --- Hologram Tracking ---
+        if (isHologram) {
             try {
-                // Create a copy of data, stripping read-side envelopes that
-                // must never be persisted (they're attached at resolution time).
-                let dataToStore = { ...data };
-                if (dataToStore._meta !== undefined) {
-                    delete dataToStore._meta;
-                }
-                if (dataToStore._hologram !== undefined) {
-                    delete dataToStore._hologram;
-                }
-                const payload = JSON.stringify(dataToStore);
-
-                // Check if the data being stored is a hologram
-                const isHologram = holoInstance.isHologram(dataToStore);
-
-                const dataPath = password ?
-                    user.get('private').get(tableName) :
-                    holoInstance.gun.get(holoInstance.appname).get(tableName);
-
-                if (data.id) {
-                    const itemPath = dataPath.get(data.id);
-                    itemPath.put(payload, ack => {
-                        if (ack.err) {
-                            reject(new Error(ack.err));
-                        } else {
-                            // --- Start: Hologram Tracking Logic (for data *being put*, if it's a hologram) ---
-                            if (isHologram) {
-                                try {
-                                    const storedDataSoulInfo = holoInstance.parseSoulPath(dataToStore.soul);
-                                    if (storedDataSoulInfo) {
-                                        const targetNodeRef = holoInstance.getNodeRef(dataToStore.soul); // Target of the data *being put*
-                                        // Soul of the hologram that was *actually stored* at tableName/data.id
-                                        const storedHologramInstanceSoul = `${holoInstance.appname}/${tableName}/${data.id}`;
-                                        
-                                                                        targetNodeRef.get('_holograms').get(storedHologramInstanceSoul).put(true);
-                            } else {
-                                        console.warn(`Data (ID: ${data.id}) being put is a hologram, but could not parse its soul ${dataToStore.soul} for tracking.`);
-                                    }
-                                } catch (trackingError) {
-                                    console.warn(`Error updating _holograms set for the target of the data being put (data ID: ${data.id}, soul: ${dataToStore.soul}):`, trackingError);
-                                }
-                            }
-                            // --- End: Hologram Tracking Logic ---
-                            
-                            resolve();
-                        }
-                    });
+                const storedDataSoulInfo = holoInstance.parseSoulPath(dataToStore.soul);
+                if (storedDataSoulInfo) {
+                    const targetNodeRef = holoInstance.getNodeRef(dataToStore.soul);
+                    const storedHologramInstanceSoul = data.id
+                        ? `${holoInstance.appname}/${tableName}/${data.id}`
+                        : `${holoInstance.appname}/${tableName}`;
+                    targetNodeRef.get('_holograms').get(storedHologramInstanceSoul).put(true);
                 } else {
-                    dataPath.put(payload, ack => {
-                        if (ack.err) {
-                            reject(new Error(ack.err));
-                        } else {
-                            // --- Start: Hologram Tracking Logic (for data *being put*, if it's a hologram) ---
-                            if (isHologram) {
-                                try {
-                                    const storedDataSoulInfo = holoInstance.parseSoulPath(dataToStore.soul);
-                                    if (storedDataSoulInfo) {
-                                        const targetNodeRef = holoInstance.getNodeRef(dataToStore.soul); // Target of the data *being put*
-                                        // Soul of the hologram that was *actually stored* at tableName (without specific key)
-                                        const storedHologramInstanceSoul = `${holoInstance.appname}/${tableName}`;
-                                        
-                                                                    targetNodeRef.get('_holograms').get(storedHologramInstanceSoul).put(true);
-                        } else {
-                                        console.warn(`Data being put is a hologram, but could not parse its soul ${dataToStore.soul} for tracking.`);
-                                    }
-                                } catch (trackingError) {
-                                    console.warn(`Error updating _holograms set for the target of the data being put (soul: ${dataToStore.soul}):`, trackingError);
-                                }
-                            }
-                            // --- End: Hologram Tracking Logic ---
-                            
-                            resolve();
-                        }
-                    });
+                    console.warn(`Data being put is a hologram, but could not parse its soul ${dataToStore.soul} for tracking.`);
                 }
-            } catch (error) {
-                reject(error);
+            } catch (trackingError) {
+                console.warn(`Error updating _holograms set for the target of the data being put (soul: ${dataToStore.soul}):`, trackingError);
             }
-        });
+        }
 
-        // Bound the wait on Gun's put ack so an offline mesh doesn't hang
-        // the caller forever. Gun keeps the write locally and replays it
-        // when a peer reappears. We tag the ack-arrived branch with a
-        // unique sentinel so we can warn (once) when the timeout fired
-        // and still keep the public Promise<void> contract.
-        const ACK_OK = Symbol('ackOk');
-        return withWriteTimeout(
-            ackPromise.then(() => ACK_OK),
-            writeTimeoutMs,
-            undefined
-        ).then((result) => {
-            if (result !== ACK_OK) {
-                console.warn(`putGlobal: no ack within ${writeTimeoutMs}ms for table=${tableName} — write queued locally, will replay on reconnect`);
-            }
-            return undefined;
-        });
+        if (result.queued) {
+            console.warn(`putGlobal: write queued for table=${tableName} — will replay on reconnect`);
+        }
     } catch (error) {
         console.error('Error in putGlobal:', error);
         throw error;
@@ -201,35 +212,68 @@ export async function putGlobal(holoInstance, tableName, data, password = null, 
  */
 export async function getGlobal(holoInstance, tableName, key, password = null) {
     try {
-        let user = null;
+        const handleData = async (data) => {
+            if (!data) return null;
+
+            try {
+                const parsed = await holoInstance.parse(data);
+                if (!parsed) return null;
+
+                // Check if this is a hologram that needs to be resolved
+                if (holoInstance.isHologram(parsed)) {
+                    const resolved = await holoInstance.resolveHologram(parsed, {
+                        followHolograms: true
+                    });
+
+                    if (resolved === null) {
+                        try {
+                            await holoInstance.deleteGlobal(tableName, key, password);
+                        } catch (deleteError) {
+                            console.error(`Failed to delete invalid global hologram at ${tableName}/${key}:`, deleteError);
+                        }
+                        return null;
+                    }
+
+                    if (resolved !== parsed) {
+                        return resolved;
+                    }
+                }
+
+                return parsed;
+            } catch (e) {
+                console.error('Error parsing data in getGlobal:', e);
+                return null;
+            }
+        };
+
         if (password) {
-            user = holoInstance.gun.user();
+            if (!holoInstance._backend.gun) {
+                throw new Error('Password-protected operations require the Gun backend');
+            }
+            const user = holoInstance._backend.gun.user();
             await new Promise((resolve, reject) => {
                 const userNameString = holoInstance.userName(tableName);
                 user.auth(userNameString, password, (authAck) => {
                     if (authAck.err) {
-                        // If auth fails, try to create the user
                         console.log(`Initial auth failed for ${userNameString}, attempting to create...`);
                         user.create(userNameString, password, (createAck) => {
                             if (createAck.err) {
-                                 // Check if error is "User already created"
                                 if (createAck.err.includes("already created") || createAck.err.includes("already being created")) {
                                     console.log(`User ${userNameString} already existed or being created, re-attempting auth with fresh user object.`);
-                                    const freshUser = holoInstance.gun.user(); // Get a new user object
+                                    const freshUser = holoInstance._backend.gun.user();
                                     freshUser.auth(userNameString, password, (secondAuthAck) => {
                                         if (secondAuthAck.err) {
                                             console.log(`Auth still failed after user existed check: ${secondAuthAck.err}. Resolving anyway for test operations.`);
-                                            resolve(); // Resolve anyway to allow test operations
+                                            resolve();
                                         } else {
                                             resolve();
                                         }
                                     });
                                 } else {
                                     console.log(`Create user error (resolving anyway for operations): ${createAck.err}`);
-                                    resolve(); // Resolve anyway to allow test operations
+                                    resolve();
                                 }
                             } else {
-                                // After successful creation, authenticate again
                                 console.log(`User ${userNameString} created successfully, attempting auth...`);
                                 user.auth(userNameString, password, (secondAuthAck) => {
                                     if (secondAuthAck.err) {
@@ -241,65 +285,22 @@ export async function getGlobal(holoInstance, tableName, key, password = null) {
                             }
                         });
                     } else {
-                        resolve(); // Auth successful
+                        resolve();
                     }
+                });
+            });
+
+            // Password path — Gun user chain directly
+            return new Promise(async (resolve) => {
+                user.get('private').get(tableName).get(key).once(async (data) => {
+                    resolve(await handleData(data));
                 });
             });
         }
 
-        return new Promise(async (resolve) => {
-            const handleData = async (data) => {
-                if (!data) {
-                    resolve(null);
-                    return;
-                }
-
-                try {
-                    // The data should be a stringified JSON from putGlobal
-                    const parsed = await holoInstance.parse(data); // Use instance's parse
-
-                    if (!parsed) {
-                        resolve(null);
-                        return;
-                    }
-
-                    // Check if this is a hologram that needs to be resolved
-                    if (holoInstance.isHologram(parsed)) { // Use instance's isHologram
-                        const resolved = await holoInstance.resolveHologram(parsed, { // Use instance's resolveHologram
-                            followHolograms: true // Always follow holograms
-                        });
-
-                        if (resolved === null) {
-                            try {
-                                await holoInstance.deleteGlobal(tableName, key, password); // Use instance's deleteGlobal
-                            } catch (deleteError) {
-                                console.error(`Failed to delete invalid global hologram at ${tableName}/${key}:`, deleteError);
-                            }
-                            resolve(null); // Return null as the hologram is invalid
-                            return;
-                        }
-
-                        if (resolved !== parsed) {
-                            // Hologram was resolved successfully
-                            resolve(resolved);
-                            return;
-                        }
-                    }
-
-                    resolve(parsed);
-                } catch (e) {
-                    console.error('Error parsing data in getGlobal:', e);
-                    resolve(null);
-                }
-            };
-
-            const dataPath = password ?
-                user.get('private').get(tableName) :
-                holoInstance.gun.get(holoInstance.appname).get(tableName);
-
-            const itemPath = dataPath.get(key);
-            itemPath.once(handleData);
-        });
+        // Non-password path — delegate to backend
+        const data = await holoInstance._backend.get(null, tableName, key);
+        return await handleData(data);
     } catch (error) {
         console.error('Error in getGlobal:', error);
         return null;
@@ -319,35 +320,64 @@ export async function getAllGlobal(holoInstance, tableName, password = null) {
     }
 
     try {
-        let user = null;
+        const processItem = async (itemData, key) => {
+            if (!itemData) return null;
+            try {
+                const parsed = await holoInstance.parse(itemData);
+                if (!parsed) return null;
+
+                if (holoInstance.isHologram(parsed)) {
+                    const resolved = await holoInstance.resolveHologram(parsed, {
+                        followHolograms: true
+                    });
+
+                    if (resolved === null) {
+                        try {
+                            await holoInstance.deleteGlobal(tableName, key, password);
+                        } catch (deleteError) {
+                            console.error(`Failed to delete invalid global hologram at ${tableName}/${key}:`, deleteError);
+                        }
+                        return null;
+                    }
+
+                    return resolved !== parsed ? resolved : parsed;
+                }
+
+                return parsed;
+            } catch (error) {
+                console.error('Error parsing data:', error);
+                return null;
+            }
+        };
+
         if (password) {
-            user = holoInstance.gun.user();
+            if (!holoInstance._backend.gun) {
+                throw new Error('Password-protected operations require the Gun backend');
+            }
+            const user = holoInstance._backend.gun.user();
             await new Promise((resolve, reject) => {
                 const userNameString = holoInstance.userName(tableName);
                 user.auth(userNameString, password, (authAck) => {
                     if (authAck.err) {
-                        // If auth fails, try to create the user
                         console.log(`Initial auth failed for ${userNameString}, attempting to create...`);
                         user.create(userNameString, password, (createAck) => {
                             if (createAck.err) {
-                                 // Check if error is "User already created"
                                 if (createAck.err.includes("already created") || createAck.err.includes("already being created")) {
                                     console.log(`User ${userNameString} already existed or being created, re-attempting auth with fresh user object.`);
-                                    const freshUser = holoInstance.gun.user(); // Get a new user object
+                                    const freshUser = holoInstance._backend.gun.user();
                                     freshUser.auth(userNameString, password, (secondAuthAck) => {
                                         if (secondAuthAck.err) {
                                             console.log(`Auth still failed after user existed check: ${secondAuthAck.err}. Resolving anyway for test operations.`);
-                                            resolve(); // Resolve anyway to allow test operations
+                                            resolve();
                                         } else {
                                             resolve();
                                         }
                                     });
                                 } else {
                                     console.log(`Create user error (resolving anyway for operations): ${createAck.err}`);
-                                    resolve(); // Resolve anyway to allow test operations
+                                    resolve();
                                 }
                             } else {
-                                // After successful creation, authenticate again
                                 console.log(`User ${userNameString} created successfully, attempting auth...`);
                                 user.auth(userNameString, password, (secondAuthAck) => {
                                     if (secondAuthAck.err) {
@@ -359,105 +389,59 @@ export async function getAllGlobal(holoInstance, tableName, password = null) {
                             }
                         });
                     } else {
-                        resolve(); // Auth successful
+                        resolve();
                     }
                 });
             });
+
+            // Password path — Gun user chain directly
+            return new Promise((resolve) => {
+                const dataPath = user.get('private').get(tableName);
+                const shallowOnce = () => new Promise((res) => dataPath.once((d) => res(d)));
+
+                (async () => {
+                    let data = await shallowOnce();
+                    if (!data) {
+                        await new Promise(r => setTimeout(r, 1500));
+                        data = await shallowOnce();
+                    }
+                    if (!data) { resolve([]); return; }
+
+                    const keys = Object.keys(data).filter(key => {
+                        if (key === '_') return false;
+                        const val = data[key];
+                        if (val === null) return false;
+                        if (typeof val === 'object' && val['#']) return false;
+                        return true;
+                    });
+                    if (keys.length === 0) { resolve([]); return; }
+
+                    const output = [];
+                    await Promise.all(keys.map((key) => {
+                        const inline = data[key];
+                        if (typeof inline !== 'object' || inline === null) {
+                            return processItem(inline, key).then(r => { if (r) output.push(r); });
+                        }
+                        return new Promise((resolveItem) => {
+                            dataPath.get(key).once((itemData) => {
+                                processItem(itemData, key).then(r => { if (r) output.push(r); resolveItem(); }, resolveItem);
+                            });
+                        });
+                    }));
+                    resolve(output);
+                })();
+            });
         }
 
-        return new Promise((resolve) => {
-            const output = [];
-            const pendingProcessing = [];
-
-            const dataPath = password ?
-                user.get('private').get(tableName) :
-                holoInstance.gun.get(holoInstance.appname).get(tableName);
-
-            // PASS 1: Get shallow node to determine expected item count.
-            // Retry once if empty — Gun's .once() reads from local cache, which
-            // may be cold immediately after startup before peers have synced.
-            const shallowOnce = () => new Promise((res) => dataPath.once((d) => res(d)));
-
-            const processShallow = (data) => {
-                if (!data) {
-                    resolve([]);
-                    return;
-                }
-
-                // Filter out Gun metadata, null/deleted entries, and Gun soul references
-                const keys = Object.keys(data).filter(key => {
-                    if (key === '_') return false;
-                    const val = data[key];
-                    if (val === null) return false;
-                    // Filter out Gun graph references (sub-nodes)
-                    if (typeof val === 'object' && val['#']) return false;
-                    return true;
-                });
-                const expectedCount = keys.length;
-
-                if (expectedCount === 0) {
-                    resolve([]);
-                    return;
-                }
-
-                // PASS 2: iterate explicitly over the filtered keys.
-                // Avoid dataPath.map().once() — it fires for null tombstone
-                // siblings and can resolve before real items are processed.
-                const processItem = async (itemData, key) => {
-                    if (!itemData) return;
-                    try {
-                        const parsed = await holoInstance.parse(itemData);
-                        if (!parsed) return;
-
-                        if (holoInstance.isHologram(parsed)) {
-                            const resolved = await holoInstance.resolveHologram(parsed, {
-                                followHolograms: true
-                            });
-
-                            if (resolved === null) {
-                                try {
-                                    await holoInstance.deleteGlobal(tableName, key, password);
-                                } catch (deleteError) {
-                                    console.error(`Failed to delete invalid global hologram at ${tableName}/${key}:`, deleteError);
-                                }
-                                return;
-                            }
-
-                            if (resolved !== parsed) {
-                                output.push(resolved);
-                            } else {
-                                output.push(parsed);
-                            }
-                        } else {
-                            output.push(parsed);
-                        }
-                    } catch (error) {
-                        console.error('Error parsing data:', error);
-                    }
-                };
-
-                Promise.all(keys.map((key) => {
-                    const inline = data[key];
-                    if (typeof inline !== 'object' || inline === null) {
-                        return processItem(inline, key);
-                    }
-                    return new Promise((resolveItem) => {
-                        dataPath.get(key).once((itemData) => {
-                            processItem(itemData, key).then(resolveItem, resolveItem);
-                        });
-                    });
-                })).then(() => resolve(output));
-            };
-
-            (async () => {
-                let data = await shallowOnce();
-                if (!data) {
-                    await new Promise(r => setTimeout(r, 1500));
-                    data = await shallowOnce();
-                }
-                processShallow(data);
-            })();
-        });
+        // Non-password path — delegate to backend
+        const entries = await holoInstance._backend.getAll(null, tableName);
+        const output = [];
+        const promises = [];
+        for (const [key, value] of entries) {
+            promises.push(processItem(value, key).then(r => { if (r) output.push(r); }));
+        }
+        await Promise.all(promises);
+        return output;
     } catch (error) {
         console.error('Error in getAllGlobal:', error);
         return [];
@@ -478,37 +462,72 @@ export async function deleteGlobal(holoInstance, tableName, key, password = null
     }
 
     try {
-        // console.log('deleteGlobal - Starting deletion:', { tableName, key, hasPassword: !!password }); // Optional logging
+        // Helper: read existing data to check for hologram tracking removal
+        const readAndRemoveHologramTracking = async (rawData) => {
+            let dataToDelete = null;
+            try {
+                if (typeof rawData === 'string') {
+                    dataToDelete = JSON.parse(rawData);
+                } else {
+                    dataToDelete = rawData;
+                }
+            } catch(e) {
+                console.warn("[deleteGlobal] Could not JSON parse data for deletion check:", rawData, e);
+                return;
+            }
 
-        let user = null;
+            if (!dataToDelete || !holoInstance.isHologram(dataToDelete)) return;
+
+            try {
+                const targetSoul = dataToDelete.soul;
+                const targetSoulInfo = holoInstance.parseSoulPath(targetSoul);
+                if (targetSoulInfo) {
+                    const targetNodeRef = holoInstance.getNodeRef(targetSoul);
+                    const deletedHologramSoul = `${holoInstance.appname}/${tableName}/${key}`;
+                    await new Promise((resolveTrack) => {
+                        targetNodeRef.get('_holograms').get(deletedHologramSoul).put(null, (ack) => {
+                            if (ack.err) {
+                                console.warn(`[deleteGlobal] Error removing hologram ${deletedHologramSoul} from target ${targetSoul}:`, ack.err);
+                            }
+                            resolveTrack();
+                        });
+                    });
+                } else {
+                    console.warn(`Could not parse target soul ${targetSoul} for hologram tracking removal during deleteGlobal.`);
+                }
+            } catch (trackingError) {
+                console.warn(`Error initiating hologram reference removal from target ${dataToDelete.soul} during deleteGlobal:`, trackingError);
+            }
+        };
+
         if (password) {
-            user = holoInstance.gun.user();
+            if (!holoInstance._backend.gun) {
+                throw new Error('Password-protected operations require the Gun backend');
+            }
+            const user = holoInstance._backend.gun.user();
             await new Promise((resolve, reject) => {
                 const userNameString = holoInstance.userName(tableName);
                 user.auth(userNameString, password, (authAck) => {
                     if (authAck.err) {
-                        // If auth fails, try to create the user
                         console.log(`Initial auth failed for ${userNameString}, attempting to create...`);
                         user.create(userNameString, password, (createAck) => {
                             if (createAck.err) {
-                                 // Check if error is "User already created"
                                 if (createAck.err.includes("already created") || createAck.err.includes("already being created")) {
                                     console.log(`User ${userNameString} already existed or being created, re-attempting auth with fresh user object.`);
-                                    const freshUser = holoInstance.gun.user(); // Get a new user object
+                                    const freshUser = holoInstance._backend.gun.user();
                                     freshUser.auth(userNameString, password, (secondAuthAck) => {
                                         if (secondAuthAck.err) {
                                             console.log(`Auth still failed after user existed check: ${secondAuthAck.err}. Resolving anyway for test operations.`);
-                                            resolve(); // Resolve anyway to allow test operations
+                                            resolve();
                                         } else {
                                             resolve();
                                         }
                                     });
                                 } else {
                                     console.log(`Create user error (resolving anyway for operations): ${createAck.err}`);
-                                    resolve(); // Resolve anyway to allow test operations
+                                    resolve();
                                 }
                             } else {
-                                // After successful creation, authenticate again
                                 console.log(`User ${userNameString} created successfully, attempting auth...`);
                                 user.auth(userNameString, password, (secondAuthAck) => {
                                     if (secondAuthAck.err) {
@@ -520,83 +539,35 @@ export async function deleteGlobal(holoInstance, tableName, key, password = null
                             }
                         });
                     } else {
-                        resolve(); // Auth successful
+                        resolve();
+                    }
+                });
+            });
+
+            // Password path — Gun user chain directly
+            const dataPath = user.get('private').get(tableName).get(key);
+
+            // Read existing data for hologram tracking removal
+            const rawDataToDelete = await new Promise((resolve) => dataPath.once(resolve));
+            await readAndRemoveHologramTracking(rawDataToDelete);
+
+            return new Promise((resolve, reject) => {
+                dataPath.put(null, ack => {
+                    if (ack.err) {
+                        console.error('deleteGlobal - Deletion error:', ack.err);
+                        reject(new Error(ack.err));
+                    } else {
+                        resolve(true);
                     }
                 });
             });
         }
 
-        const dataPath = password ?
-            user.get('private').get(tableName).get(key) :
-            holoInstance.gun.get(holoInstance.appname).get(tableName).get(key);
+        // Non-password path — read existing data for hologram tracking, then delegate delete
+        const rawDataToDelete = await holoInstance._backend.get(null, tableName, key);
+        await readAndRemoveHologramTracking(rawDataToDelete);
 
-        // --- Start: Hologram Tracking Removal ---
-        let trackingRemovalPromise = Promise.resolve(); // Default to resolved promise
-        
-        // 1. Get the data first to check if it's a hologram
-        const rawDataToDelete = await new Promise((resolve) => dataPath.once(resolve));
-        let dataToDelete = null;
-        try {
-            if (typeof rawDataToDelete === 'string') {
-                dataToDelete = JSON.parse(rawDataToDelete);
-            } else {
-                // Handle cases where it might already be an object (though likely string)
-                dataToDelete = rawDataToDelete; 
-            }
-        } catch(e) {
-            console.warn("[deleteGlobal] Could not JSON parse data for deletion check:", rawDataToDelete, e);
-            dataToDelete = null; // Ensure it's null if parsing fails
-        }
-
-        // 2. If it is a hologram, try to remove its reference from the target
-        const isDataHologram = dataToDelete && holoInstance.isHologram(dataToDelete);
-        
-        if (isDataHologram) {
-            try {
-                const targetSoul = dataToDelete.soul;
-                const targetSoulInfo = holoInstance.parseSoulPath(targetSoul);
-                
-                if (targetSoulInfo) {
-                    const targetNodeRef = holoInstance.getNodeRef(targetSoul);
-                    const deletedHologramSoul = `${holoInstance.appname}/${tableName}/${key}`;
-
-                    // Create a promise that resolves when the hologram is removed from the list
-                    trackingRemovalPromise = new Promise((resolveTrack) => { // No reject needed, just warn on error
-                        targetNodeRef.get('_holograms').get(deletedHologramSoul).put(null, (ack) => { // Remove the hologram entry completely
-                            if (ack.err) {
-                                console.warn(`[deleteGlobal] Error removing hologram ${deletedHologramSoul} from target ${targetSoul}:`, ack.err);
-                            }
-                            resolveTrack(); // Resolve regardless of ack error to not block main delete
-                        });
-                    });
-                } else {
-                    console.warn(`Could not parse target soul ${targetSoul} for hologram tracking removal during deleteGlobal.`);
-                }
-            } catch (trackingError) {
-                console.warn(`Error initiating hologram reference removal from target ${dataToDelete.soul} during deleteGlobal:`, trackingError);
-                // Ensure trackingRemovalPromise remains resolved if setup fails
-                trackingRemovalPromise = Promise.resolve(); 
-            }
-        }
-        // --- End: Hologram Tracking Removal ---
-
-        // 3. Wait for the tracking removal attempt to be acknowledged
-        await trackingRemovalPromise;
-
-        // 4. Proceed with the actual deletion of the hologram node itself
-        return new Promise((resolve, reject) => {
-            // Request deletion
-            dataPath.put(null, ack => {
-                // console.log('deleteGlobal - Deletion acknowledgment:', ack); // Optional logging
-                if (ack.err) {
-                    console.error('deleteGlobal - Deletion error:', ack.err);
-                    reject(new Error(ack.err));
-                } else {
-                    // Resolve directly on success, like deleteFunc
-                    resolve(true); 
-                }
-            });
-        });
+        return await holoInstance._backend.delete(null, tableName, key);
     } catch (error) {
         console.error('Error in deleteGlobal:', error);
         throw error;
@@ -616,35 +587,72 @@ export async function deleteAllGlobal(holoInstance, tableName, password = null) 
     }
 
     try {
-        let user = null;
+        // Helper: remove hologram tracking for a single key's data
+        const removeHologramTracking = async (rawData, itemKey) => {
+            let dataToDelete = null;
+            try {
+                if (typeof rawData === 'string') {
+                    dataToDelete = JSON.parse(rawData);
+                } else {
+                    dataToDelete = rawData;
+                }
+            } catch(e) {
+                console.warn("[deleteAllGlobal] Could not JSON parse data for deletion check:", rawData, e);
+                return;
+            }
+
+            if (!dataToDelete || !holoInstance.isHologram(dataToDelete)) return;
+
+            try {
+                const targetSoul = dataToDelete.soul;
+                const targetSoulInfo = holoInstance.parseSoulPath(targetSoul);
+                if (targetSoulInfo) {
+                    const targetNodeRef = holoInstance.getNodeRef(targetSoul);
+                    const deletedHologramSoul = `${holoInstance.appname}/${tableName}/${itemKey}`;
+                    await new Promise((resolveTrack) => {
+                        targetNodeRef.get('_holograms').get(deletedHologramSoul).put(null, (ack) => {
+                            if (ack.err) {
+                                console.warn(`[deleteAllGlobal] Error removing hologram ${deletedHologramSoul} from target ${targetSoul}:`, ack.err);
+                            }
+                            resolveTrack();
+                        });
+                    });
+                } else {
+                    console.warn(`Could not parse target soul ${targetSoul} for hologram tracking removal during deleteAllGlobal.`);
+                }
+            } catch (trackingError) {
+                console.warn(`Error removing hologram reference from target ${dataToDelete.soul} during deleteAllGlobal:`, trackingError);
+            }
+        };
+
         if (password) {
-            user = holoInstance.gun.user();
+            if (!holoInstance._backend.gun) {
+                throw new Error('Password-protected operations require the Gun backend');
+            }
+            const user = holoInstance._backend.gun.user();
             await new Promise((resolve, reject) => {
                 const userNameString = holoInstance.userName(tableName);
                 user.auth(userNameString, password, (authAck) => {
                     if (authAck.err) {
-                        // If auth fails, try to create the user
                         console.log(`Initial auth failed for ${userNameString}, attempting to create...`);
                         user.create(userNameString, password, (createAck) => {
                             if (createAck.err) {
-                                 // Check if error is "User already created"
                                 if (createAck.err.includes("already created") || createAck.err.includes("already being created")) {
                                     console.log(`User ${userNameString} already existed or being created, re-attempting auth with fresh user object.`);
-                                    const freshUser = holoInstance.gun.user(); // Get a new user object
+                                    const freshUser = holoInstance._backend.gun.user();
                                     freshUser.auth(userNameString, password, (secondAuthAck) => {
                                         if (secondAuthAck.err) {
                                             console.log(`Auth still failed after user existed check: ${secondAuthAck.err}. Resolving anyway for test cleanup.`);
-                                            resolve(); // Resolve anyway to allow test cleanup
+                                            resolve();
                                         } else {
                                             resolve();
                                         }
                                     });
                                 } else {
                                     console.log(`Create user error (resolving anyway for cleanup): ${createAck.err}`);
-                                    resolve(); // Resolve anyway to allow test cleanup
+                                    resolve();
                                 }
                             } else {
-                                // After successful creation, authenticate again
                                 console.log(`User ${userNameString} created successfully, attempting auth...`);
                                 user.auth(userNameString, password, (secondAuthAck) => {
                                     if (secondAuthAck.err) {
@@ -656,127 +664,74 @@ export async function deleteAllGlobal(holoInstance, tableName, password = null) 
                             }
                         });
                     } else {
-                        resolve(); // Auth successful
+                        resolve();
                     }
                 });
             });
+
+            // Password path — Gun user chain directly
+            return new Promise((resolve, reject) => {
+                try {
+                    const dataPath = user.get('private').get(tableName);
+                    let timeout = setTimeout(() => resolve(true), 5000);
+
+                    dataPath.once(async (data) => {
+                        if (!data) { clearTimeout(timeout); resolve(true); return; }
+
+                        const keys = Object.keys(data).filter(k => k !== '_');
+
+                        // Process hologram tracking removal
+                        for (const itemKey of keys) {
+                            try {
+                                const rawData = await new Promise((res) => dataPath.get(itemKey).once(res));
+                                await removeHologramTracking(rawData, itemKey);
+                            } catch (error) {
+                                console.warn(`Error processing key ${itemKey} during deleteAllGlobal:`, error);
+                            }
+                        }
+
+                        // Delete all items
+                        try {
+                            await Promise.all(keys.map(itemKey =>
+                                new Promise((res, rej) => {
+                                    dataPath.get(itemKey).put(null, ack => {
+                                        if (ack.err) { console.error(`Failed to delete ${itemKey}:`, ack.err); rej(new Error(ack.err)); }
+                                        else res();
+                                    });
+                                })
+                            ));
+                            dataPath.put(null);
+                            clearTimeout(timeout);
+                            resolve(true);
+                        } catch (error) {
+                            reject(error);
+                        }
+                    });
+                } catch (error) {
+                    reject(error);
+                }
+            });
         }
 
-        return new Promise((resolve, reject) => {
+        // Non-password path — delegate to backend
+        const entries = await holoInstance._backend.getAll(null, tableName);
+
+        // Process hologram tracking removal for all entries
+        for (const [itemKey, rawData] of entries) {
             try {
-                const deletions = new Set();
-                let timeout = setTimeout(() => {
-                    if (deletions.size === 0) {
-                        resolve(true); // No data to delete
-                    }
-                }, 5000);
-
-                const dataPath = password ?
-                    user.get('private').get(tableName) :
-                    holoInstance.gun.get(holoInstance.appname).get(tableName);
-
-                dataPath.once(async (data) => {
-                    if (!data) {
-                        clearTimeout(timeout);
-                        resolve(true);
-                        return;
-                    }
-
-                    const keys = Object.keys(data).filter(key => key !== '_');
-                    
-                    // Process each key to handle holograms properly
-                    for (const key of keys) {
-                        try {
-                            // Get the data to check if it's a hologram
-                            const itemPath = password ?
-                                user.get('private').get(tableName).get(key) :
-                                holoInstance.gun.get(holoInstance.appname).get(tableName).get(key);
-
-                            const rawDataToDelete = await new Promise((resolveItem) => itemPath.once(resolveItem));
-                            let dataToDelete = null;
-                            
-                            try {
-                                if (typeof rawDataToDelete === 'string') {
-                                    dataToDelete = JSON.parse(rawDataToDelete);
-                                } else {
-                                    dataToDelete = rawDataToDelete;
-                                }
-                            } catch(e) {
-                                console.warn("[deleteAllGlobal] Could not JSON parse data for deletion check:", rawDataToDelete, e);
-                                dataToDelete = null;
-                            }
-
-                            // Check if it's a hologram and handle accordingly
-                            const isDataHologram = dataToDelete && holoInstance.isHologram(dataToDelete);
-                            
-                            if (isDataHologram) {
-                                // Handle hologram deletion - remove from target's _holograms list
-                                try {
-                                    const targetSoul = dataToDelete.soul;
-                                    const targetSoulInfo = holoInstance.parseSoulPath(targetSoul);
-                                    
-                                    if (targetSoulInfo) {
-                                        const targetNodeRef = holoInstance.getNodeRef(targetSoul);
-                                        const deletedHologramSoul = `${holoInstance.appname}/${tableName}/${key}`;
-
-                                        // Remove the hologram from target's _holograms list
-                                        await new Promise((resolveTrack) => {
-                                            targetNodeRef.get('_holograms').get(deletedHologramSoul).put(null, (ack) => {
-                                                if (ack.err) {
-                                                    console.warn(`[deleteAllGlobal] Error removing hologram ${deletedHologramSoul} from target ${targetSoul}:`, ack.err);
-                                                                                    }
-                                    resolveTrack();
-                                            });
-                                        });
-                                    } else {
-                                        console.warn(`Could not parse target soul ${targetSoul} for hologram tracking removal during deleteAllGlobal.`);
-                                    }
-                                } catch (trackingError) {
-                                    console.warn(`Error removing hologram reference from target ${dataToDelete.soul} during deleteAllGlobal:`, trackingError);
-                                }
-                            }
-
-                            // Add to deletions set for tracking
-                            deletions.add(key);
-                        } catch (error) {
-                            console.warn(`Error processing key ${key} during deleteAllGlobal:`, error);
-                            // Still add to deletions set even if hologram processing failed
-                            deletions.add(key);
-                        }
-                    }
-
-                    // Now delete all the items
-                    const promises = keys.map(key =>
-                        new Promise((resolveDelete, rejectDelete) => {
-                            const deletePath = password ?
-                                user.get('private').get(tableName).get(key) :
-                                holoInstance.gun.get(holoInstance.appname).get(tableName).get(key);
-
-                            deletePath.put(null, ack => {
-                                if (ack.err) {
-                                    console.error(`Failed to delete ${key}:`, ack.err);
-                                    rejectDelete(new Error(ack.err));
-                                } else {
-                                    resolveDelete();
-                                }
-                            });
-                        })
-                    );
-
-                    try {
-                        await Promise.all(promises);
-                        // Finally delete the table itself
-                        dataPath.put(null);
-                        clearTimeout(timeout);
-                        resolve(true);
-                    } catch (error) {
-                        reject(error);
-                    }
-                });
+                await removeHologramTracking(rawData, itemKey);
             } catch (error) {
-                reject(error);
+                console.warn(`Error processing key ${itemKey} during deleteAllGlobal:`, error);
             }
-        });
+        }
+
+        // Delete all entries
+        const deletePromises = [];
+        for (const [itemKey] of entries) {
+            deletePromises.push(holoInstance._backend.delete(null, tableName, itemKey));
+        }
+        await Promise.all(deletePromises);
+        return true;
     } catch (error) {
         console.error('Error in deleteAllGlobal:', error);
         throw error;
@@ -797,50 +752,30 @@ export async function deleteAllGlobal(holoInstance, tableName, password = null) 
  * @returns {{ unsubscribe: () => void, stop: () => void }}
  */
 export function subscribeGlobal(holoInstance, tableName, key, callback, options = {}) {
-    const dataPath = holoInstance.gun.get(holoInstance.appname).get(tableName);
     let active = true;
 
-    if (key) {
-        // Subscribe to a specific key
-        dataPath.get(key).on(async (data) => {
-            if (!active || !data) return;
-            try {
-                const parsed = await holoInstance.parse(data);
-                if (parsed) callback(parsed, key);
-            } catch (e) {
-                console.warn('[subscribeGlobal] Error parsing data:', e);
-            }
-        });
-    } else {
-        // Subscribe to all keys in the table
-        dataPath.map().on(async (data, k) => {
-            if (!active || !data || k === '_') return;
-            try {
-                const parsed = await holoInstance.parse(data);
-                if (parsed) callback(parsed, k);
-            } catch (e) {
-                console.warn('[subscribeGlobal] Error parsing data:', e);
-            }
-        });
-    }
+    // Backend subscribe fires (key, data) for every key mutation in the lens.
+    // For single-key subscriptions we filter in the wrapper callback.
+    const sub = holoInstance._backend.subscribe(null, tableName, async (k, data) => {
+        if (!active) return;
+        if (key && k !== key) return; // single-key filter
+        if (!data || k === '_') return;
+        try {
+            const parsed = await holoInstance.parse(data);
+            if (parsed) callback(parsed, k);
+        } catch (e) {
+            console.warn('[subscribeGlobal] Error parsing data:', e);
+        }
+    });
+
+    const teardown = () => {
+        active = false;
+        if (sub && sub.unsubscribe) sub.unsubscribe();
+    };
 
     return {
-        unsubscribe: () => {
-            active = false;
-            if (key) {
-                dataPath.get(key).off();
-            } else {
-                dataPath.off();
-            }
-        },
-        stop: () => {
-            active = false;
-            if (key) {
-                dataPath.get(key).off();
-            } else {
-                dataPath.off();
-            }
-        }
+        unsubscribe: teardown,
+        stop: teardown
     };
 }
 

--- a/packages/holosphere/global.js
+++ b/packages/holosphere/global.js
@@ -400,6 +400,10 @@ export async function getAllGlobal(holoInstance, tableName, password = null) {
                 const shallowOnce = () => new Promise((res) => dataPath.once((d) => res(d)));
 
                 (async () => {
+                    // PASS 1: Get shallow node to determine expected item count.
+                    // Retry once if empty — Gun's .once() reads from local cache,
+                    // which may be cold immediately after startup before peers
+                    // have synced.
                     let data = await shallowOnce();
                     if (!data) {
                         await new Promise(r => setTimeout(r, 1500));
@@ -407,15 +411,20 @@ export async function getAllGlobal(holoInstance, tableName, password = null) {
                     }
                     if (!data) { resolve([]); return; }
 
+                    // Filter out Gun metadata, null/deleted entries, and Gun soul references
                     const keys = Object.keys(data).filter(key => {
                         if (key === '_') return false;
                         const val = data[key];
                         if (val === null) return false;
+                        // Filter out Gun graph references (sub-nodes)
                         if (typeof val === 'object' && val['#']) return false;
                         return true;
                     });
                     if (keys.length === 0) { resolve([]); return; }
 
+                    // PASS 2: iterate explicitly over the filtered keys.
+                    // Avoid dataPath.map().once() — it fires for null tombstone
+                    // siblings and can resolve before real items are processed.
                     const output = [];
                     await Promise.all(keys.map((key) => {
                         const inline = data[key];
@@ -673,10 +682,16 @@ export async function deleteAllGlobal(holoInstance, tableName, password = null) 
             return new Promise((resolve, reject) => {
                 try {
                     const dataPath = user.get('private').get(tableName);
-                    let timeout = setTimeout(() => resolve(true), 5000);
+                    // Safety net for the empty/offline case only: if `once` never
+                    // delivers data, resolve after 5s. Once real processing starts
+                    // we defer to its own completion — matching the base guard,
+                    // which no-op'd the timeout while a deletion was in flight.
+                    let started = false;
+                    let timeout = setTimeout(() => { if (!started) resolve(true); }, 5000);
 
                     dataPath.once(async (data) => {
                         if (!data) { clearTimeout(timeout); resolve(true); return; }
+                        started = true;
 
                         const keys = Object.keys(data).filter(k => k !== '_');
 

--- a/packages/holosphere/holosphere.js
+++ b/packages/holosphere/holosphere.js
@@ -108,7 +108,7 @@ class HoloSphere {
             // AD4M backend loaded lazily in ready() — keeps the browser bundle
             // free of Node-only @coasys/ad4m imports.
             this._pendingAd4mConfig = {
-                url: this.config?.ad4m?.url ?? 'ws://localhost:12000/graphql',
+                url: this.config?.ad4m?.url ?? 'http://localhost:12000',
                 token: this.config?.ad4m?.token,
                 schemas: this.config?.ad4m?.schemas,
                 schemaDir: this.config?.ad4m?.schemaDir,
@@ -167,6 +167,11 @@ class HoloSphere {
 
     async ready() {
         if (this._pendingAd4mConfig) {
+            // Load the AD4M backend lazily so it only enters the bundle as a
+            // separate chunk fetched when backend==='ad4m'. The backend and its
+            // subject-class registry are browser-safe when schemas are supplied
+            // in memory (fs/path/url are imported lazily only on the Node
+            // disk-reading path — see subjects/index.js).
             const { AD4MBackend } = await import('./backends/ad4m.js');
             this._backend = new AD4MBackend(this.appname, this._pendingAd4mConfig);
             this._pendingAd4mConfig = null;

--- a/packages/holosphere/holosphere.js
+++ b/packages/holosphere/holosphere.js
@@ -7,7 +7,6 @@
  */
 
 import * as h3 from 'h3-js';
-import Gun from 'gun'
 import Ajv2019 from 'ajv/dist/2019.js'
 import * as Federation from './federation.js';
 import * as SchemaOps from './schema.js';
@@ -17,6 +16,7 @@ import * as GlobalOps from './global.js';
 import * as HologramOps from './hologram.js';
 import * as ComputeOps from './compute.js';
 import * as Utils from './utils.js';
+import { GunBackend } from './backends/gun.js';
 
 // Named exports (v2-compatible)
 import { nostrUtils } from './nostr-utils-shim.js';
@@ -101,25 +101,39 @@ class HoloSphere {
             validateSchema: true
         });
 
-        // Define default Gun options with radisk enabled
-        const defaultGunOptions = {
-            peers: ['https://gun.holons.io/gun'],
-            axe: false,
-            radisk: true,
-            file: './holosphere'
-        };
+        // Backend selection
+        const backendType = this.config?.backend ?? 'gun';
 
-        // In browser environment, disable localStorage when radisk is enabled
-        if (typeof window !== 'undefined' && (gunOptions.radisk !== false)) {
-            defaultGunOptions.localStorage = false;
+        if (backendType === 'ad4m') {
+            // AD4M backend loaded lazily in ready() — keeps the browser bundle
+            // free of Node-only @coasys/ad4m imports.
+            this._pendingAd4mConfig = {
+                url: this.config?.ad4m?.url ?? 'ws://localhost:12000/graphql',
+                token: this.config?.ad4m?.token,
+                schemas: this.config?.ad4m?.schemas,
+                schemaDir: this.config?.ad4m?.schemaDir,
+            };
+            this._backend = null;
+            this._gun = null;
+        } else {
+            // Define default Gun options with radisk enabled
+            const defaultGunOptions = {
+                peers: ['https://gun.holons.io/gun'],
+                axe: false,
+                radisk: true,
+                file: './holosphere'
+            };
+
+            if (typeof window !== 'undefined' && (gunOptions.radisk !== false)) {
+                defaultGunOptions.localStorage = false;
+            }
+
+            const finalGunOptions = { ...defaultGunOptions, ...gunOptions };
+            console.log("Initializing Gun with options:", finalGunOptions);
+
+            this._backend = new GunBackend(this.appname, finalGunOptions);
+            this._gun = this._backend.gun;
         }
-
-        // Merge provided options with defaults
-        const finalGunOptions = { ...defaultGunOptions, ...gunOptions };
-        console.log("Initializing Gun with options:", finalGunOptions);
-
-        // Use provided Gun instance or create new one with final options
-        this.gun = Gun(finalGunOptions);
 
         // OpenAI is optional - callers can set this.openai directly if needed
         this.openai = null;
@@ -143,10 +157,21 @@ class HoloSphere {
 
     /**
      * Waits for the HoloSphere instance to be ready.
-     * GunDB connects eagerly, so this resolves immediately.
      * @returns {Promise<HoloSphere>} - The ready instance
      */
+    get gun() { return this._gun; }
+    set gun(v) {
+        this._gun = v;
+        if (this._backend && this._backend.type === 'gun') this._backend.gun = v;
+    }
+
     async ready() {
+        if (this._pendingAd4mConfig) {
+            const { AD4MBackend } = await import('./backends/ad4m.js');
+            this._backend = new AD4MBackend(this.appname, this._pendingAd4mConfig);
+            this._pendingAd4mConfig = null;
+        }
+        await this._backend.ready();
         return this;
     }
 

--- a/packages/holosphere/node.js
+++ b/packages/holosphere/node.js
@@ -20,7 +20,10 @@ export async function putNode(holoInstance, holon, lens, data) {
         throw new Error('putNode: Backend write failed');
     }
 
-    if (isHologram) {
+    // Only track holograms after a *confirmed* write. A queued write (backend
+    // returned before the peer acked) mirrors the base behaviour, which ran
+    // tracking exclusively inside the `!ack.err` branch — never optimistically.
+    if (isHologram && !result.queued) {
         try {
             const storedDataSoulInfo = holoInstance.parseSoulPath(data.value.soul);
             if (storedDataSoulInfo) {

--- a/packages/holosphere/node.js
+++ b/packages/holosphere/node.js
@@ -12,50 +12,30 @@ export async function putNode(holoInstance, holon, lens, data) {
         throw new Error('putNode: Missing required parameters');
     }
 
-    return new Promise((resolve, reject) => {
+    const isHologram = data.value && holoInstance.isHologram(data.value);
+    const payload = typeof data.value === 'string' ? data.value : JSON.stringify(data.value);
+
+    const result = await holoInstance._backend.put(holon, lens, 'value', payload);
+    if (!result.ok) {
+        throw new Error('putNode: Backend write failed');
+    }
+
+    if (isHologram) {
         try {
-            // Remove isHologram field before storing - NO LONGER NEEDED
-            // if (data && data.isHologram !== undefined) {
-            // delete data.isHologram;
-            // }
-            
-            // Check if the data being stored is a hologram
-            const isHologram = data.value && holoInstance.isHologram(data.value);
-            
-            holoInstance.gun.get(holoInstance.appname)
-                .get(holon)
-                .get(lens)
-                .get('value')  // Store at 'value' key
-                .put(data.value, ack => {  // Store the value directly
-                    if (ack.err) {
-                        reject(new Error(ack.err));
-                    } else {
-                        // --- Start: Hologram Tracking Logic (for data *being put*, if it's a hologram) ---
-                        if (isHologram) {
-                            try {
-                                const storedDataSoulInfo = holoInstance.parseSoulPath(data.value.soul);
-                                if (storedDataSoulInfo) {
-                                    const targetNodeRef = holoInstance.getNodeRef(data.value.soul); // Target of the data *being put*
-                                    // Soul of the hologram that was *actually stored* at holon/lens/value
-                                    const storedHologramInstanceSoul = `${holoInstance.appname}/${holon}/${lens}/value`;
-                                    
-                                                                targetNodeRef.get('_holograms').get(storedHologramInstanceSoul).put(true);
-                        } else {
-                                    console.warn(`Data (ID: ${data.id}) being put is a hologram, but could not parse its soul ${data.value.soul} for tracking.`);
-                                }
-                            } catch (trackingError) {
-                                console.warn(`Error updating _holograms set for the target of the data being put (data ID: ${data.id}, soul: ${data.value.soul}):`, trackingError);
-                            }
-                        }
-                        // --- End: Hologram Tracking Logic ---
-                        
-                        resolve(true);
-                    }
-                });
-        } catch (error) {
-            reject(error);
+            const storedDataSoulInfo = holoInstance.parseSoulPath(data.value.soul);
+            if (storedDataSoulInfo) {
+                const targetNodeRef = holoInstance._backend.getNodeRef(data.value.soul);
+                const storedHologramInstanceSoul = `${holoInstance.appname}/${holon}/${lens}/value`;
+                targetNodeRef.get('_holograms').get(storedHologramInstanceSoul).put(true);
+            } else {
+                console.warn(`Data (ID: ${data.id}) being put is a hologram, but could not parse its soul ${data.value.soul} for tracking.`);
+            }
+        } catch (trackingError) {
+            console.warn(`Error updating _holograms set for the target of the data being put (data ID: ${data.id}, soul: ${data.value.soul}):`, trackingError);
         }
-    });
+    }
+
+    return true;
 }
 
 /**
@@ -71,23 +51,7 @@ export async function getNode(holoInstance, holon, lens, key) {
         throw new Error('getNode: Missing required parameters');
     }
 
-    return new Promise((resolve, reject) => {
-        try {
-            holoInstance.gun.get(holoInstance.appname)
-                .get(holon)
-                .get(lens)
-                .get(key)
-                .once((data) => {
-                    if (!data) {
-                        resolve(null);
-                        return;
-                    }
-                    resolve(data);  // Return the data directly
-                });
-        } catch (error) {
-            reject(error);
-        }
-    });
+    return holoInstance._backend.get(holon, lens, key);
 }
 
 /**
@@ -102,7 +66,7 @@ export function getNodeRef(holoInstance, soul) {
     }
 
     const parts = soul.split('/').filter(part => {
-        if (!part.trim() || /[<>:"/\\|?*]/.test(part)) { // Escaped backslash for regex
+        if (!part.trim() || /[<>:"/\\|?*]/.test(part)) {
             throw new Error('getNodeRef: Invalid path segment');
         }
         return part.trim();
@@ -112,11 +76,7 @@ export function getNodeRef(holoInstance, soul) {
         throw new Error('getNodeRef: Invalid soul format');
     }
 
-    let ref = holoInstance.gun.get(holoInstance.appname);
-    parts.forEach(part => {
-        ref = ref.get(part);
-    });
-    return ref;
+    return holoInstance._backend.getNodeRef(soul);
 }
 
 /**
@@ -164,72 +124,41 @@ export async function deleteNode(holoInstance, holon, lens, key) {
     }
 
     try {
-        const dataPath = holoInstance.gun.get(holoInstance.appname).get(holon).get(lens).get(key);
-
-        // --- Start: Hologram Tracking Removal ---
-        let trackingRemovalPromise = Promise.resolve(); // Default to resolved promise
-        
-        // 1. Get the data first to check if it's a hologram
-        const rawDataToDelete = await new Promise((resolve) => dataPath.once(resolve));
+        const rawDataToDelete = await holoInstance._backend.get(holon, lens, key);
         let dataToDelete = null;
         try {
             if (typeof rawDataToDelete === 'string') {
                 dataToDelete = JSON.parse(rawDataToDelete);
             } else {
-                // Handle cases where it might already be an object (though likely string)
-                dataToDelete = rawDataToDelete; 
+                dataToDelete = rawDataToDelete;
             }
         } catch(e) {
             console.warn("[deleteNode] Could not JSON parse data for deletion check:", rawDataToDelete, e);
-            dataToDelete = null; // Ensure it's null if parsing fails
         }
 
-        // 2. If it is a hologram, try to remove its reference from the target
         const isDataHologram = dataToDelete && holoInstance.isHologram(dataToDelete);
-        
         if (isDataHologram) {
             try {
                 const targetSoul = dataToDelete.soul;
                 const targetSoulInfo = holoInstance.parseSoulPath(targetSoul);
-                
                 if (targetSoulInfo) {
-                    const targetNodeRef = holoInstance.getNodeRef(targetSoul);
-                    // putNode stores at the 'value' key, not at the data.id key
+                    const targetNodeRef = holoInstance._backend.getNodeRef(targetSoul);
                     const deletedHologramSoul = `${holoInstance.appname}/${holon}/${lens}/value`;
-
-                    // Create a promise that resolves when the hologram is removed from the list
-                    trackingRemovalPromise = new Promise((resolveTrack) => { // No reject needed, just warn on error
-                        targetNodeRef.get('_holograms').get(deletedHologramSoul).put(null, (ack) => { // Remove the hologram entry completely
+                    await new Promise((resolveTrack) => {
+                        targetNodeRef.get('_holograms').get(deletedHologramSoul).put(null, (ack) => {
                             if (ack.err) {
                                 console.warn(`[deleteNode] Error removing hologram ${deletedHologramSoul} from target ${targetSoul}:`, ack.err);
-                                                    }
-                        resolveTrack(); // Resolve regardless of ack error to not block main delete
+                            }
+                            resolveTrack();
                         });
                     });
-                } else {
-                    console.warn(`Could not parse target soul ${targetSoul} for hologram tracking removal during deleteNode.`);
                 }
             } catch (trackingError) {
-                console.warn(`Error initiating hologram reference removal from target ${dataToDelete.soul} during deleteNode:`, trackingError);
-                // Ensure trackingRemovalPromise remains resolved if setup fails
-                trackingRemovalPromise = Promise.resolve(); 
+                console.warn(`Error removing hologram tracking during deleteNode:`, trackingError);
             }
         }
-        // --- End: Hologram Tracking Removal ---
 
-        // 3. Wait for the tracking removal attempt to be acknowledged
-        await trackingRemovalPromise;
-
-        // 4. Proceed with the actual deletion of the hologram node itself
-        return new Promise((resolve, reject) => {
-            dataPath.put(null, ack => {
-                if (ack.err) {
-                    reject(new Error(ack.err));
-                } else {
-                    resolve(true);
-                }
-            });
-        });
+        return holoInstance._backend.delete(holon, lens, key);
     } catch (error) {
         console.error('Error in deleteNode:', error);
         throw error;

--- a/packages/holosphere/package.json
+++ b/packages/holosphere/package.json
@@ -62,6 +62,8 @@
     "handshake-shim.js",
     "nostr-events.js",
     "signing.js",
+    "backends/",
+    "subjects/",
     "README.md",
     "SIGNING.md",
     "LICENSE",
@@ -107,7 +109,8 @@
   "homepage": "https://github.com/rvalenti/holosphere#readme",
   "peerDependencies": {
     "gun": "^0.2020.1240",
-    "h3-js": "^4.1.0"
+    "h3-js": "^4.1.0",
+    "@coasys/ad4m": ">=0.13.0"
   },
   "peerDependenciesMeta": {
     "openai": {
@@ -115,6 +118,9 @@
     },
     "gun": {
       "optional": false
+    },
+    "@coasys/ad4m": {
+      "optional": true
     }
   },
   "optionalDependencies": {

--- a/packages/holosphere/package.json
+++ b/packages/holosphere/package.json
@@ -110,7 +110,7 @@
   "peerDependencies": {
     "gun": "^0.2020.1240",
     "h3-js": "^4.1.0",
-    "@coasys/ad4m": ">=0.13.0"
+    "@coasys/ad4m": ">=0.13.0-0"
   },
   "peerDependenciesMeta": {
     "openai": {

--- a/packages/holosphere/scripts/dev-executor.mjs
+++ b/packages/holosphere/scripts/dev-executor.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: Roberto Valenti and the Holons contributors
+//
+/**
+ * Boot an isolated, single-user ad4m-executor for local development, so the
+ * apps can run the AD4M storage backend without touching any other executor on
+ * the machine (its own data dir + ports + admin credential).
+ *
+ * Because the executor runs single-user, the `--admin-credential` doubles as
+ * the RPC token the browser Ad4mClient authenticates with — wire the same
+ * value into the apps as `VITE_AD4M_TOKEN`, and `VITE_AD4M_URL=http://HOST:PORT`.
+ *
+ * Usage:
+ *   node scripts/ad4m-dev-executor.mjs           # boot + supervise (stays up)
+ *   node scripts/ad4m-dev-executor.mjs --smoke   # boot, verify, tear down, exit
+ *
+ * Env (all optional):
+ *   AD4M_DEV_PORT=12100  AD4M_DEV_HC_ADMIN_PORT=12101  AD4M_DEV_HC_APP_PORT=12102
+ *   AD4M_DEV_DATA=~/.ad4m-harvest-dev   AD4M_DEV_TOKEN=harvest-dev
+ *   AD4M_DEV_PASSPHRASE=harvest-dev-pass  AD4M_EXECUTOR=ad4m-executor
+ *   AD4M_DEV_CONNECT_HOLOCHAIN=false      AD4M_DEV_TIMEOUT=180
+ */
+
+import { spawn } from "node:child_process";
+import { createConnection } from "node:net";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { Ad4mClient } from "@coasys/ad4m";
+
+const PORT = Number(process.env.AD4M_DEV_PORT ?? 12100);
+const HC_ADMIN = Number(process.env.AD4M_DEV_HC_ADMIN_PORT ?? 12101);
+const HC_APP = Number(process.env.AD4M_DEV_HC_APP_PORT ?? 12102);
+const DATA = process.env.AD4M_DEV_DATA ?? join(homedir(), ".ad4m-harvest-dev");
+const TOKEN = process.env.AD4M_DEV_TOKEN ?? "harvest-dev";
+const PASSPHRASE = process.env.AD4M_DEV_PASSPHRASE ?? "harvest-dev-pass";
+const BINARY = process.env.AD4M_EXECUTOR ?? "ad4m-executor";
+const CONNECT_HC = (process.env.AD4M_DEV_CONNECT_HOLOCHAIN ?? "false") === "true";
+const TIMEOUT_S = Number(process.env.AD4M_DEV_TIMEOUT ?? 180);
+const SMOKE = process.argv.includes("--smoke");
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+
+const log = (...a) => console.log("[ad4m-dev]", ...a);
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function makeBootstrapSeed() {
+  return {
+    trustedAgents: [],
+    knownLinkLanguages: [],
+    directMessageLanguage: "",
+    agentLanguage: "",
+    perspectiveLanguage: "",
+    neighbourhoodLanguage: "",
+    languageLanguageBundle: "",
+  };
+}
+
+function tryConnect(port) {
+  return new Promise((resolve, reject) => {
+    const socket = createConnection({ port, host: "127.0.0.1" }, () => {
+      socket.end();
+      resolve();
+    });
+    socket.once("error", reject);
+  });
+}
+
+async function initDataDir(seedPath) {
+  if (existsSync(join(DATA, "ad4m"))) {
+    log(`data dir already initialised: ${DATA}`);
+    return;
+  }
+  log(`initialising data dir: ${DATA}`);
+  await new Promise((resolve, reject) => {
+    const child = spawn(
+      BINARY,
+      ["init", "--data-path", DATA, "--network-bootstrap-seed", seedPath],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+    let out = "";
+    child.stdout.on("data", (d) => (out += d));
+    child.stderr.on("data", (d) => (out += d));
+    child.on("exit", (code) =>
+      code === 0 ? resolve() : reject(new Error(`init failed (${code}): ${out.slice(-800)}`)),
+    );
+    child.on("error", reject);
+  });
+}
+
+function runExecutor(seedPath) {
+  const args = [
+    "run",
+    "--app-data-path", DATA,
+    "--network-bootstrap-seed", seedPath,
+    "--port", String(PORT),
+    "--hc-admin-port", String(HC_ADMIN),
+    "--hc-app-port", String(HC_APP),
+    "--language-language-only", "false",
+    "--connect-holochain", String(CONNECT_HC),
+    "--admin-credential", TOKEN,
+    "--localhost", "true",
+    "--hc-use-bootstrap", "false",
+    "--hc-use-mdns", "false",
+    "--hc-use-proxy", "false",
+    "--run-dapp-server", "false",
+  ];
+  log(`starting executor on ${PORT} (holochain=${CONNECT_HC})`);
+  const child = spawn(BINARY, args, { stdio: ["ignore", "pipe", "pipe"] });
+  child.stdout.on("data", (d) => process.stdout.write(`[exec] ${d}`));
+  child.stderr.on("data", (d) => process.stderr.write(`[exec] ${d}`));
+  return child;
+}
+
+async function waitForListening(child) {
+  const deadline = Date.now() + TIMEOUT_S * 1000;
+  let exited = null;
+  child.once("exit", (code, sig) => (exited = { code, sig }));
+  while (Date.now() < deadline) {
+    if (exited) throw new Error(`executor exited early (code=${exited.code}, sig=${exited.sig})`);
+    try {
+      await tryConnect(PORT);
+      return;
+    } catch {
+      await wait(500);
+    }
+  }
+  throw new Error(`executor not listening on ${PORT} within ${TIMEOUT_S}s`);
+}
+
+async function ensureAgent(client) {
+  const status = await client.agent.status();
+  if (!status.isInitialized) {
+    log("generating agent…");
+    await client.agent.generate(PASSPHRASE);
+  } else if (!status.isUnlocked) {
+    log("unlocking agent…");
+    await client.agent.unlock(PASSPHRASE, CONNECT_HC);
+  }
+  const me = await client.agent.me();
+  return me.did;
+}
+
+async function main() {
+  if (!existsSync(DATA)) mkdirSync(DATA, { recursive: true });
+  const seedPath = join(DATA, "bootstrap.json");
+  writeFileSync(seedPath, JSON.stringify(makeBootstrapSeed()));
+
+  await initDataDir(seedPath);
+  const child = runExecutor(seedPath);
+  await waitForListening(child);
+  log("executor is listening; connecting client…");
+
+  const client = new Ad4mClient(BASE_URL, TOKEN, true);
+  const did = await ensureAgent(client);
+  log(`agent ready: ${did}`);
+
+  // Smoke: prove local-perspective CRUD works end to end.
+  const all = await client.perspective.all();
+  log(`perspectives: ${all.length} [${all.map((p) => p.name).join(", ")}]`);
+
+  const dispose = async () => {
+    try {
+      await Promise.race([client.runtime.quit(), wait(2000)]);
+    } catch { /* ignore */ }
+    if (!child.killed) child.kill("SIGTERM");
+  };
+
+  if (SMOKE) {
+    log("SMOKE OK — tearing down");
+    await dispose();
+    process.exit(0);
+  }
+
+  log("");
+  log("──────────────────────────────────────────────");
+  log(` AD4M dev executor ready`);
+  log(`   VITE_HOLOSPHERE_BACKEND=ad4m`);
+  log(`   VITE_AD4M_URL=${BASE_URL}`);
+  log(`   VITE_AD4M_TOKEN=${TOKEN}`);
+  log("──────────────────────────────────────────────");
+  log("Supervising — Ctrl-C to stop.");
+
+  for (const sig of ["SIGINT", "SIGTERM"]) {
+    process.on(sig, async () => {
+      log(`${sig} — shutting down executor`);
+      await dispose();
+      process.exit(0);
+    });
+  }
+  // Keep the supervisor alive.
+  await new Promise(() => {});
+}
+
+main().catch((err) => {
+  console.error("[ad4m-dev] FATAL:", err?.message ?? err);
+  process.exit(1);
+});

--- a/packages/holosphere/subjects/index.js
+++ b/packages/holosphere/subjects/index.js
@@ -1,0 +1,138 @@
+/**
+ * Subject class registry for the AD4M backend.
+ *
+ * Generates Ad4mModel subject classes from the JSON Schema files in
+ * @holons/core/schemas/ via Ad4mModel.fromJSONSchema().  Each lens name
+ * maps to a model class that handles SHACL-based CRUD on AD4M perspectives.
+ *
+ * NOTE: This module uses Node fs APIs because the AD4M backend only runs
+ * in Node/Electron environments (the AD4M runtime itself requires it).
+ */
+
+import { Ad4mModel } from '@coasys/ad4m';
+import { readFileSync, readdirSync, existsSync } from 'fs';
+import { join, basename } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+
+const LENS_MODELS = new Map();
+let _loaded = false;
+
+/**
+ * The generic fallback model for lenses without a dedicated JSON schema.
+ * Stores the entire payload as a JSON literal under a single `data` property.
+ */
+let GenericLensModel = null;
+
+function ensureGenericModel() {
+  if (GenericLensModel) return GenericLensModel;
+  GenericLensModel = Ad4mModel.fromJSONSchema({
+    title: 'GenericLens',
+    type: 'object',
+    properties: {
+      id:   { type: 'string' },
+      data: { type: 'string' },
+    },
+    required: ['id'],
+  }, { namespace: 'holons://generic/' });
+  return GenericLensModel;
+}
+
+/**
+ * Registry entry model for tracking holon → perspective mappings.
+ */
+let HolonRegistryEntry = null;
+
+export function getRegistryModel() {
+  if (HolonRegistryEntry) return HolonRegistryEntry;
+  HolonRegistryEntry = Ad4mModel.fromJSONSchema({
+    title: 'HolonRegistryEntry',
+    type: 'object',
+    properties: {
+      holonId:         { type: 'string' },
+      perspectiveUuid: { type: 'string' },
+      h3Cell:          { type: 'string' },
+      name:            { type: 'string' },
+      createdAt:       { type: 'string' },
+    },
+    required: ['holonId', 'perspectiveUuid'],
+  }, { namespace: 'holons://registry/' });
+  return HolonRegistryEntry;
+}
+
+/**
+ * Load all JSON schemas from the core/schemas directory and generate
+ * subject class models.  Safe to call multiple times — only loads once.
+ *
+ * @param {string} [schemaDir] - Override path to schemas directory.
+ *   Defaults to `../../core/schemas` relative to this file (monorepo layout).
+ * @param {Map<string, object>} [schemas] - Pre-loaded schema map (lens → schema object).
+ *   If provided, skips disk reading entirely.
+ * @returns {Map<string, typeof Ad4mModel>}
+ */
+export function loadSubjectClasses(schemaDir, schemas) {
+  if (_loaded) return LENS_MODELS;
+
+  if (schemas instanceof Map) {
+    for (const [lensName, schema] of schemas) {
+      try {
+        const Model = Ad4mModel.fromJSONSchema(schema, {
+          namespace: `holons://${lensName}/`,
+        });
+        LENS_MODELS.set(lensName, Model);
+      } catch (err) {
+        console.warn(`[subjects] Failed to create model for lens "${lensName}":`, err.message);
+      }
+    }
+    _loaded = true;
+    return LENS_MODELS;
+  }
+
+  const dir = schemaDir || join(__dirname, '../../core/schemas');
+  if (!existsSync(dir)) {
+    console.warn(`[subjects] Schema directory not found: ${dir}. Only GenericLensModel will be available.`);
+    _loaded = true;
+    return LENS_MODELS;
+  }
+
+  const files = readdirSync(dir).filter(f => f.endsWith('.json'));
+  for (const file of files) {
+    const lensName = basename(file, '.json');
+    try {
+      const schema = JSON.parse(readFileSync(join(dir, file), 'utf-8'));
+      const Model = Ad4mModel.fromJSONSchema(schema, {
+        namespace: `holons://${lensName}/`,
+      });
+      LENS_MODELS.set(lensName, Model);
+    } catch (err) {
+      console.warn(`[subjects] Failed to load schema "${file}":`, err.message);
+    }
+  }
+
+  _loaded = true;
+  return LENS_MODELS;
+}
+
+/**
+ * Get the Ad4mModel class for a given lens name.
+ * Returns null if no schema exists for that lens.
+ */
+export function getModelForLens(lens) {
+  return LENS_MODELS.get(lens) ?? null;
+}
+
+/**
+ * Get the model for a lens, falling back to GenericLensModel.
+ */
+export function getModelOrGeneric(lens) {
+  return LENS_MODELS.get(lens) ?? ensureGenericModel();
+}
+
+/**
+ * Reset the loaded state (for testing).
+ */
+export function resetSubjectClasses() {
+  LENS_MODELS.clear();
+  _loaded = false;
+}

--- a/packages/holosphere/subjects/index.js
+++ b/packages/holosphere/subjects/index.js
@@ -1,27 +1,46 @@
 /**
  * Subject class registry for the AD4M backend.
  *
- * Generates Ad4mModel subject classes from the JSON Schema files in
- * @holons/core/schemas/ via Ad4mModel.fromJSONSchema().  Each lens name
- * maps to a model class that handles SHACL-based CRUD on AD4M perspectives.
+ * Generates Ad4mModel subject classes from JSON Schemas — supplied either as
+ * an in-memory Map (the browser path, where schemas are bundled by the app)
+ * or read from disk (the Node path, via `schemaDir`).  Each lens name maps to
+ * a model class that handles SHACL-based CRUD on AD4M perspectives.
  *
- * NOTE: This module uses Node fs APIs because the AD4M backend only runs
- * in Node/Electron environments (the AD4M runtime itself requires it).
+ * Node builtins (fs/path/url) are imported lazily inside the disk-reading
+ * branch only, so this module stays safe to bundle into browser clients when
+ * schemas are provided in memory.
  */
 
 import { Ad4mModel } from '@coasys/ad4m';
-import { readFileSync, readdirSync, existsSync } from 'fs';
-import { join, basename } from 'path';
-import { fileURLToPath } from 'url';
-
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 const LENS_MODELS = new Map();
 let _loaded = false;
 
 /**
+ * Derive a PascalCase subject-class name from a lens name.
+ * `Ad4mModel.fromJSONSchema` requires a non-empty `options.name` (the SDNA
+ * class name); our lens/schema titles are lowercase (`quests`, `rea_events`),
+ * so map them to a valid class identifier (`Quests`, `ReaEvents`).
+ */
+function toClassName(lensName) {
+  return String(lensName)
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('') || 'Lens';
+}
+
+/**
  * The generic fallback model for lenses without a dedicated JSON schema.
  * Stores the entire payload as a JSON literal under a single `data` property.
+ *
+ * The schema deliberately declares NO `id` property: AD4M reserves `id` as the
+ * alias for a subject's base-expression URI. Declaring it as a data property
+ * makes `findAll` hydrate each instance's `_baseExpression` from the `id`
+ * *link value* (the logical key) instead of the full URI, which breaks the
+ * lens-prefix scoping in AD4MBackend.getAll (every instance gets filtered out).
+ * With `data` as the sole required property, `findAll` returns full-URI base
+ * expressions and the logical id is recovered from the URI's last segment.
  */
 let GenericLensModel = null;
 
@@ -31,11 +50,10 @@ function ensureGenericModel() {
     title: 'GenericLens',
     type: 'object',
     properties: {
-      id:   { type: 'string' },
       data: { type: 'string' },
     },
-    required: ['id'],
-  }, { namespace: 'holons://generic/' });
+    required: ['data'],
+  }, { name: 'GenericLens', namespace: 'holons://generic/' });
   return GenericLensModel;
 }
 
@@ -57,7 +75,7 @@ export function getRegistryModel() {
       createdAt:       { type: 'string' },
     },
     required: ['holonId', 'perspectiveUuid'],
-  }, { namespace: 'holons://registry/' });
+  }, { name: 'HolonRegistryEntry', namespace: 'holons://registry/' });
   return HolonRegistryEntry;
 }
 
@@ -71,13 +89,14 @@ export function getRegistryModel() {
  *   If provided, skips disk reading entirely.
  * @returns {Map<string, typeof Ad4mModel>}
  */
-export function loadSubjectClasses(schemaDir, schemas) {
+export async function loadSubjectClasses(schemaDir, schemas) {
   if (_loaded) return LENS_MODELS;
 
   if (schemas instanceof Map) {
     for (const [lensName, schema] of schemas) {
       try {
         const Model = Ad4mModel.fromJSONSchema(schema, {
+          name: toClassName(lensName),
           namespace: `holons://${lensName}/`,
         });
         LENS_MODELS.set(lensName, Model);
@@ -89,7 +108,15 @@ export function loadSubjectClasses(schemaDir, schemas) {
     return LENS_MODELS;
   }
 
-  const dir = schemaDir || join(__dirname, '../../core/schemas');
+  // Disk-reading path: Node/Electron only. Import builtins lazily so the
+  // browser bundle (which always supplies `schemas` in memory) never pulls
+  // fs/path/url in.
+  const { readFileSync, readdirSync, existsSync } = await import('node:fs');
+  const { join, basename } = await import('node:path');
+  const { fileURLToPath } = await import('node:url');
+  const here = fileURLToPath(new URL('.', import.meta.url));
+
+  const dir = schemaDir || join(here, '../../core/schemas');
   if (!existsSync(dir)) {
     console.warn(`[subjects] Schema directory not found: ${dir}. Only GenericLensModel will be available.`);
     _loaded = true;
@@ -102,6 +129,7 @@ export function loadSubjectClasses(schemaDir, schemas) {
     try {
       const schema = JSON.parse(readFileSync(join(dir, file), 'utf-8'));
       const Model = Ad4mModel.fromJSONSchema(schema, {
+        name: toClassName(lensName),
         namespace: `holons://${lensName}/`,
       });
       LENS_MODELS.set(lensName, Model);
@@ -127,6 +155,16 @@ export function getModelForLens(lens) {
  */
 export function getModelOrGeneric(lens) {
   return LENS_MODELS.get(lens) ?? ensureGenericModel();
+}
+
+/**
+ * Every loaded lens model plus the generic fallback. Used to batch-register
+ * subject-class SDNA onto a perspective (`Ad4mModel.registerAll`) so instances
+ * can be created — an AD4M perspective rejects `createSubject` for a class
+ * whose SHACL/SDNA it has never seen ("No SHACL constructor found").
+ */
+export function getAllModels() {
+  return [...LENS_MODELS.values(), ensureGenericModel()];
 }
 
 /**

--- a/packages/holosphere/test/backend-behavior.test.js
+++ b/packages/holosphere/test/backend-behavior.test.js
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Behavioural-parity regression tests for the pluggable-backend refactor.
+// These drive the low-level ops with a fully faked holoInstance/backend so
+// they are deterministic and do not depend on a live Gun mesh (unlike the
+// integration suites, which need radisk/SEA and fail headless).
+//
+// Covered:
+//   1. putNode fires hologram tracking only on a *confirmed* write — never on
+//      a queued/offline write — matching the original `!ack.err` guard.
+//   2. putNode honours the opaque string-KV contract: strings pass through
+//      verbatim; objects are JSON-encoded.
+//   3. deleteAllGlobal's password path must not resolve at its 5s safety-net
+//      timeout while a real deletion is still in flight (base guarded the
+//      timeout on "nothing found yet"; a naive unconditional resolve regresses).
+
+import { jest } from '@jest/globals';
+import { putNode } from '../node.js';
+import { deleteAllGlobal } from '../global.js';
+
+// Flush pending microtasks (await chains) without advancing fake timers.
+const flush = async (n = 20) => { for (let i = 0; i < n; i++) await Promise.resolve(); };
+
+// ---------------------------------------------------------------------------
+// putNode
+// ---------------------------------------------------------------------------
+
+function makePutNodeHolo(putResult) {
+  const trackCalls = [];
+  const putCalls = [];
+  const holo = {
+    appname: 'test-app',
+    isHologram: (v) => !!(v && typeof v === 'object' && typeof v.soul === 'string'),
+    parseSoulPath: (soul) => (soul ? { soul } : null),
+    _backend: {
+      put: async (holon, lens, key, payload) => {
+        putCalls.push({ holon, lens, key, payload });
+        return putResult;
+      },
+      getNodeRef: (soul) => ({
+        get: (holograms) => ({
+          get: (instanceSoul) => ({
+            put: (v) => trackCalls.push({ soul, holograms, instanceSoul, v }),
+          }),
+        }),
+      }),
+    },
+  };
+  return { holo, trackCalls, putCalls };
+}
+
+describe('putNode — backend write parity', () => {
+  const hologramValue = { soul: 'test-app/a/b/c', payload: 1 };
+
+  test('fires hologram tracking on a confirmed write (queued:false)', async () => {
+    const { holo, trackCalls } = makePutNodeHolo({ ok: true, queued: false });
+    const ok = await putNode(holo, 'h', 'l', { id: 'x', value: hologramValue });
+    expect(ok).toBe(true);
+    expect(trackCalls).toHaveLength(1);
+    expect(trackCalls[0].holograms).toBe('_holograms');
+    expect(trackCalls[0].instanceSoul).toBe('test-app/h/l/value');
+    expect(trackCalls[0].v).toBe(true);
+  });
+
+  test('does NOT fire hologram tracking on a queued write (queued:true)', async () => {
+    const { holo, trackCalls } = makePutNodeHolo({ ok: true, queued: true });
+    const ok = await putNode(holo, 'h', 'l', { id: 'x', value: hologramValue });
+    expect(ok).toBe(true);
+    expect(trackCalls).toHaveLength(0); // regression guard for the queued-write path
+  });
+
+  test('throws and does not track when the backend write fails (ok:false)', async () => {
+    const { holo, trackCalls } = makePutNodeHolo({ ok: false, queued: false });
+    await expect(putNode(holo, 'h', 'l', { id: 'x', value: hologramValue }))
+      .rejects.toThrow('Backend write failed');
+    expect(trackCalls).toHaveLength(0);
+  });
+
+  test('stores a string value verbatim (no double-encoding)', async () => {
+    const { holo, putCalls } = makePutNodeHolo({ ok: true, queued: false });
+    await putNode(holo, 'h', 'l', { id: 'x', value: 'already-a-string' });
+    expect(putCalls).toHaveLength(1);
+    expect(putCalls[0].key).toBe('value');
+    expect(putCalls[0].payload).toBe('already-a-string');
+  });
+
+  test('JSON-encodes an object value for the opaque string-KV contract', async () => {
+    const { holo, putCalls } = makePutNodeHolo({ ok: true, queued: false });
+    const obj = { foo: 'bar', n: 2 };
+    await putNode(holo, 'h', 'l', { id: 'x', value: obj });
+    expect(putCalls[0].payload).toBe(JSON.stringify(obj));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteAllGlobal — password path 5s safety-net timeout
+// ---------------------------------------------------------------------------
+
+function baseHolo(userFactory) {
+  return {
+    appname: 'test-app',
+    userName: (t) => `user-${t}`,
+    isHologram: () => false,
+    parseSoulPath: () => null,
+    getNodeRef: () => ({ get: () => ({ get: () => ({ put: () => {} }) }) }),
+    _backend: { gun: { user: userFactory } },
+  };
+}
+
+describe('deleteAllGlobal — password-path 5s safety-net timeout', () => {
+  afterEach(() => jest.useRealTimers());
+
+  test('does not resolve prematurely while a real deletion is in flight', async () => {
+    jest.useFakeTimers();
+
+    const deleteAcks = [];
+    const tableData = { item1: JSON.stringify({ x: 1 }), item2: JSON.stringify({ y: 2 }), _: {} };
+    const itemNode = (key) => ({
+      once: (res) => res(tableData[key]),
+      put: (_val, cb) => { if (cb) deleteAcks.push(cb); }, // hold the ack — slow delete
+    });
+    const dataPath = { once: (h) => h(tableData), get: (k) => itemNode(k), put: () => {} };
+    const holo = baseHolo(() => ({
+      auth: (_n, _p, cb) => cb({}),
+      get: () => ({ get: () => dataPath }),
+    }));
+
+    let settled = false;
+    const p = deleteAllGlobal(holo, 'tbl', 'pw').then((v) => { settled = true; return v; });
+
+    // Auth + once() handler run: started=true, both deletes registered + pending.
+    await flush();
+    expect(deleteAcks).toHaveLength(2);
+
+    // Fire the 5s safety-net. Because processing started, it must NOT resolve.
+    await jest.advanceTimersByTimeAsync(6000);
+    expect(settled).toBe(false); // regression guard: base's unconditional resolve would settle here
+
+    // Let the deletes ack → real completion resolves true.
+    deleteAcks.forEach((cb) => cb({}));
+    await flush();
+    await expect(p).resolves.toBe(true);
+    expect(settled).toBe(true);
+  });
+
+  test('resolves true after the timeout when nothing was found (empty/offline)', async () => {
+    jest.useFakeTimers();
+
+    // once() never delivers → handler never runs → started stays false.
+    const dataPath = { once: () => {}, get: () => ({ once: () => {}, put: () => {} }), put: () => {} };
+    const holo = baseHolo(() => ({
+      auth: (_n, _p, cb) => cb({}),
+      get: () => ({ get: () => dataPath }),
+    }));
+
+    let settled = false;
+    const p = deleteAllGlobal(holo, 'tbl', 'pw').then((v) => { settled = true; return v; });
+
+    await flush();
+    expect(settled).toBe(false); // still pending before the timeout
+    await jest.advanceTimersByTimeAsync(5000);
+    await expect(p).resolves.toBe(true); // safety-net fired because nothing started
+  });
+});

--- a/packages/holosphere/test/backend-conformance.test.js
+++ b/packages/holosphere/test/backend-conformance.test.js
@@ -2,10 +2,16 @@
  * Backend conformance test suite.
  *
  * Verifies that both GunBackend and AD4MBackend satisfy the StorageBackend
- * interface contract.  Each backend is tested in isolation — the AD4M tests
- * are skipped when no AD4M test executor is available (CI-friendly).
+ * interface contract.  GunBackend runs everywhere (in-memory, no peers). The
+ * AD4M half is an integration test that needs a live executor, so it is opt-in:
+ * it runs only when AD4M_TEST_URL is set, and is skipped otherwise so the suite
+ * stays green in CI / executor-less environments.
  *
- * Run:  npm test -- backend-conformance
+ * Run:            npm test -- backend-conformance
+ * Run + AD4M:     AD4M_TEST_URL=ws://localhost:12100/graphql \
+ *                 AD4M_TEST_TOKEN=<cap-jwt> npm test -- backend-conformance
+ *   Point AD4M_TEST_URL at a *disposable* test executor — never a shared or
+ *   production one — since the suite creates and deletes perspectives.
  */
 
 import { jest } from '@jest/globals';
@@ -24,7 +30,41 @@ try {
   // @coasys/ad4m not installed — skip AD4M tests
 }
 
+// jest's `node` test environment exposes a `WebSocket` global, but its
+// undici-backed implementation can't open a live connection from inside the
+// VM-module sandbox — the handshake fails with an opaque ErrorEvent. Swap in
+// the userland `ws` implementation for the AD4M integration run so the client
+// can actually reach the executor. Real Node (22+) and browsers work off the
+// native global unchanged; this only rewrites it for the test process, and the
+// Gun path never touches the global WebSocket.
+if (process.env.AD4M_TEST_URL) {
+  const NodeWs = (await import('ws')).default;
+  globalThis.WebSocket = NodeWs;
+}
+
 // ─── Shared conformance suite ────────────────────────────────────────────────
+
+// Poll an async read until `ok(value)` holds (or attempts run out), then return
+// the last value read. Lets one shared suite serve a synchronous backend (Gun,
+// satisfied on the first read) and an eventually-consistent one (AD4M, whose
+// executor propagates writes asynchronously) without baking a fixed sleep into
+// every assertion.
+async function readEventually(read, ok, { tries = 20, delay = 150 } = {}) {
+  let value = await read();
+  for (let i = 0; i < tries && !ok(value); i++) {
+    await new Promise(r => setTimeout(r, delay));
+    value = await read();
+  }
+  return value;
+}
+
+// Poll a predicate until it holds or attempts run out. Used for subscribe
+// assertions, where the signal is a callback firing rather than a return value.
+async function waitFor(pred, { tries = 20, delay = 150 } = {}) {
+  for (let i = 0; i < tries && !pred(); i++) {
+    await new Promise(r => setTimeout(r, delay));
+  }
+}
 
 function conformanceSuite(name, createBackend) {
   describe(`StorageBackend conformance: ${name}`, () => {
@@ -48,9 +88,15 @@ function conformanceSuite(name, createBackend) {
       const result = await backend.put('holon-a', 'quests', 'conf-1', payload);
       expect(result.ok).toBe(true);
 
-      const retrieved = await backend.get('holon-a', 'quests', 'conf-1');
+      const retrieved = await readEventually(
+        () => backend.get('holon-a', 'quests', 'conf-1'),
+        v => v !== null,
+      );
       expect(retrieved).not.toBeNull();
-      expect(JSON.parse(retrieved)).toEqual({ id: 'conf-1', title: 'Test Item' });
+      // toMatchObject, not toEqual: a backend may carry additive provenance
+      // (AD4M attaches author DID + createdAt/updatedAt). The contract is
+      // "at least the fields written", not "exactly them".
+      expect(JSON.parse(retrieved)).toMatchObject({ id: 'conf-1', title: 'Test Item' });
     });
 
     test('get on missing key returns null', async () => {
@@ -62,7 +108,12 @@ function conformanceSuite(name, createBackend) {
       await backend.put('holon-b', 'roles', 'r1', JSON.stringify({ id: 'r1', name: 'Admin' }));
       await backend.put('holon-b', 'roles', 'r2', JSON.stringify({ id: 'r2', name: 'Member' }));
 
-      const all = await backend.getAll('holon-b', 'roles');
+      const all = await readEventually(
+        () => backend.getAll('holon-b', 'roles'),
+        m => m.has('r1') && m.has('r2') &&
+             JSON.parse(m.get('r1')).name === 'Admin' &&
+             JSON.parse(m.get('r2')).name === 'Member',
+      );
       expect(all).toBeInstanceOf(Map);
       expect(all.size).toBeGreaterThanOrEqual(2);
 
@@ -81,11 +132,15 @@ function conformanceSuite(name, createBackend) {
     test('delete removes item', async () => {
       const payload = JSON.stringify({ id: 'del-1', title: 'To Delete' });
       await backend.put('holon-c', 'tasks', 'del-1', payload);
+      await readEventually(() => backend.get('holon-c', 'tasks', 'del-1'), v => v !== null);
 
       const deleted = await backend.delete('holon-c', 'tasks', 'del-1');
       expect(deleted).toBe(true);
 
-      const result = await backend.get('holon-c', 'tasks', 'del-1');
+      const result = await readEventually(
+        () => backend.get('holon-c', 'tasks', 'del-1'),
+        v => v === null,
+      );
       expect(result).toBeNull();
     });
 
@@ -93,17 +148,20 @@ function conformanceSuite(name, createBackend) {
       const payload = JSON.stringify({ id: 'g1', value: 'global data' });
       await backend.put(null, 'settings', 'g1', payload);
 
-      const result = await backend.get(null, 'settings', 'g1');
+      const result = await readEventually(
+        () => backend.get(null, 'settings', 'g1'),
+        v => v !== null,
+      );
       expect(result).not.toBeNull();
-      expect(JSON.parse(result)).toEqual({ id: 'g1', value: 'global data' });
+      expect(JSON.parse(result)).toMatchObject({ id: 'g1', value: 'global data' });
     });
 
     test('items in different holons are isolated', async () => {
       await backend.put('holon-x', 'data', 'k1', JSON.stringify({ id: 'k1', from: 'x' }));
       await backend.put('holon-y', 'data', 'k1', JSON.stringify({ id: 'k1', from: 'y' }));
 
-      const fromX = JSON.parse(await backend.get('holon-x', 'data', 'k1'));
-      const fromY = JSON.parse(await backend.get('holon-y', 'data', 'k1'));
+      const fromX = JSON.parse(await readEventually(() => backend.get('holon-x', 'data', 'k1'), v => v !== null));
+      const fromY = JSON.parse(await readEventually(() => backend.get('holon-y', 'data', 'k1'), v => v !== null));
 
       expect(fromX.from).toBe('x');
       expect(fromY.from).toBe('y');
@@ -113,8 +171,8 @@ function conformanceSuite(name, createBackend) {
       await backend.put('holon-z', 'alpha', 'k1', JSON.stringify({ id: 'k1', lens: 'alpha' }));
       await backend.put('holon-z', 'beta', 'k1', JSON.stringify({ id: 'k1', lens: 'beta' }));
 
-      const fromAlpha = JSON.parse(await backend.get('holon-z', 'alpha', 'k1'));
-      const fromBeta = JSON.parse(await backend.get('holon-z', 'beta', 'k1'));
+      const fromAlpha = JSON.parse(await readEventually(() => backend.get('holon-z', 'alpha', 'k1'), v => v !== null));
+      const fromBeta = JSON.parse(await readEventually(() => backend.get('holon-z', 'beta', 'k1'), v => v !== null));
 
       expect(fromAlpha.lens).toBe('alpha');
       expect(fromBeta.lens).toBe('beta');
@@ -126,10 +184,19 @@ function conformanceSuite(name, createBackend) {
         received.push({ key, value });
       });
 
+      // Wait for the subscription to establish its baseline before writing, so
+      // the put registers as a change against a live subscription rather than
+      // racing its async setup. AD4M's subscribe sets up asynchronously and
+      // exposes `ready()`; Gun's is synchronous and has no such field, so the
+      // optional-chain is a no-op there. (Real consumers subscribe once up front
+      // and write later — this models that ordering rather than a same-tick race.)
+      await sub.ready?.();
+
       await backend.put('holon-sub', 'events', 'e1', JSON.stringify({ id: 'e1', title: 'Event 1' }));
 
-      // Give the subscription time to fire
-      await new Promise(r => setTimeout(r, 500));
+      // Poll until the subscription fires rather than betting on a fixed sleep —
+      // AD4M's change propagation is asynchronous and slower than Gun's.
+      await waitFor(() => received.some(r => r.key === 'e1'));
 
       sub.unsubscribe();
 
@@ -140,16 +207,18 @@ function conformanceSuite(name, createBackend) {
 
     test('subscribe fires null on delete', async () => {
       await backend.put('holon-del-sub', 'items', 'd1', JSON.stringify({ id: 'd1', val: 'x' }));
-      await new Promise(r => setTimeout(r, 200));
+      await readEventually(() => backend.get('holon-del-sub', 'items', 'd1'), v => v !== null);
 
       const received = [];
       const sub = backend.subscribe('holon-del-sub', 'items', (key, value) => {
         received.push({ key, value });
       }, { includeDeletes: true });
 
-      await new Promise(r => setTimeout(r, 200));
+      // Let the subscription establish its initial snapshot before deleting, so
+      // the delete registers as a change rather than being absent from the start.
+      await waitFor(() => received.some(r => r.key === 'd1' && r.value !== null));
       await backend.delete('holon-del-sub', 'items', 'd1');
-      await new Promise(r => setTimeout(r, 500));
+      await waitFor(() => received.some(r => r.key === 'd1' && r.value === null));
 
       sub.unsubscribe();
 
@@ -165,7 +234,10 @@ function conformanceSuite(name, createBackend) {
       ];
       await Promise.all(promises);
 
-      const result = await backend.get('holon-cc', 'data', 'race');
+      const result = await readEventually(
+        () => backend.get('holon-cc', 'data', 'race'),
+        v => v !== null,
+      );
       expect(result).not.toBeNull();
       const parsed = JSON.parse(result);
       expect(parsed.id).toBe('race');
@@ -184,7 +256,10 @@ function conformanceSuite(name, createBackend) {
       await backend.put('holon-ow', 'data', 'ow1', JSON.stringify({ id: 'ow1', v: 'first' }));
       await backend.put('holon-ow', 'data', 'ow1', JSON.stringify({ id: 'ow1', v: 'second' }));
 
-      const result = JSON.parse(await backend.get('holon-ow', 'data', 'ow1'));
+      const result = JSON.parse(await readEventually(
+        () => backend.get('holon-ow', 'data', 'ow1'),
+        v => v !== null && JSON.parse(v).v === 'second',
+      ));
       expect(result.v).toBe('second');
     });
   });
@@ -203,19 +278,35 @@ conformanceSuite('GunBackend', () => {
 
 // ─── Run conformance for AD4MBackend (skipped if not available) ──────────────
 
-if (ad4mAvailable) {
-  const AD4M_TEST_URL = process.env.AD4M_TEST_URL || 'ws://localhost:12000/graphql';
-  const AD4M_TEST_TOKEN = process.env.AD4M_TEST_TOKEN;
+// Opt-in: only run against an executor explicitly named by AD4M_TEST_URL. No
+// default URL — a default risks silently connecting to (and polluting) whatever
+// executor happens to be on that port.
+const AD4M_TEST_URL = process.env.AD4M_TEST_URL;
 
+if (ad4mAvailable && AD4M_TEST_URL) {
   conformanceSuite('AD4MBackend', () => {
     const id = Math.random().toString(36).slice(2, 8);
+    // Run in opaque mode (`schemas: new Map()` → no dedicated subject classes,
+    // every lens backed by the generic model). The shared suite asserts the
+    // StorageBackend contract: an opaque key-value store partitioned by
+    // (holon, lens, key), which is exactly what GunBackend provides. AD4M's
+    // dedicated-schema mode is a *different*, richer contract — it persists
+    // only a lens's declared properties and drops undeclared fields by design —
+    // so pointing the opaque-KV suite at it would test the wrong contract.
+    // Dedicated/semantic behaviour is covered by its own tests.
     return new AD4MBackend(`conformance-test-${id}`, {
       url: AD4M_TEST_URL,
-      token: AD4M_TEST_TOKEN,
+      token: process.env.AD4M_TEST_TOKEN,
+      schemas: new Map(),
     });
   });
 } else {
   describe('AD4MBackend conformance (skipped)', () => {
-    test.skip('requires @coasys/ad4m to be installed', () => {});
+    test.skip(
+      ad4mAvailable
+        ? 'set AD4M_TEST_URL to run against a live test executor'
+        : 'requires @coasys/ad4m to be installed',
+      () => {},
+    );
   });
 }

--- a/packages/holosphere/test/backend-conformance.test.js
+++ b/packages/holosphere/test/backend-conformance.test.js
@@ -1,0 +1,221 @@
+/**
+ * Backend conformance test suite.
+ *
+ * Verifies that both GunBackend and AD4MBackend satisfy the StorageBackend
+ * interface contract.  Each backend is tested in isolation — the AD4M tests
+ * are skipped when no AD4M test executor is available (CI-friendly).
+ *
+ * Run:  npm test -- backend-conformance
+ */
+
+import { jest } from '@jest/globals';
+import { GunBackend } from '../backends/gun.js';
+
+jest.setTimeout(15000);
+
+// AD4M backend is loaded conditionally — the import itself will fail if
+// @coasys/ad4m isn't installed, which is fine for Gun-only environments.
+let AD4MBackend;
+let ad4mAvailable = false;
+try {
+  ({ AD4MBackend } = await import('../backends/ad4m.js'));
+  ad4mAvailable = true;
+} catch {
+  // @coasys/ad4m not installed — skip AD4M tests
+}
+
+// ─── Shared conformance suite ────────────────────────────────────────────────
+
+function conformanceSuite(name, createBackend) {
+  describe(`StorageBackend conformance: ${name}`, () => {
+    let backend;
+
+    beforeAll(async () => {
+      backend = createBackend();
+      await backend.ready();
+    });
+
+    afterAll(async () => {
+      await backend.close();
+    });
+
+    test('type discriminator is set', () => {
+      expect(['gun', 'ad4m']).toContain(backend.type);
+    });
+
+    test('put then get returns same payload', async () => {
+      const payload = JSON.stringify({ id: 'conf-1', title: 'Test Item' });
+      const result = await backend.put('holon-a', 'quests', 'conf-1', payload);
+      expect(result.ok).toBe(true);
+
+      const retrieved = await backend.get('holon-a', 'quests', 'conf-1');
+      expect(retrieved).not.toBeNull();
+      expect(JSON.parse(retrieved)).toEqual({ id: 'conf-1', title: 'Test Item' });
+    });
+
+    test('get on missing key returns null', async () => {
+      const result = await backend.get('holon-a', 'quests', 'nonexistent-key');
+      expect(result).toBeNull();
+    });
+
+    test('getAll returns all items in lens', async () => {
+      await backend.put('holon-b', 'roles', 'r1', JSON.stringify({ id: 'r1', name: 'Admin' }));
+      await backend.put('holon-b', 'roles', 'r2', JSON.stringify({ id: 'r2', name: 'Member' }));
+
+      const all = await backend.getAll('holon-b', 'roles');
+      expect(all).toBeInstanceOf(Map);
+      expect(all.size).toBeGreaterThanOrEqual(2);
+
+      const r1 = JSON.parse(all.get('r1'));
+      expect(r1.name).toBe('Admin');
+      const r2 = JSON.parse(all.get('r2'));
+      expect(r2.name).toBe('Member');
+    });
+
+    test('getAll on empty lens returns empty map', async () => {
+      const result = await backend.getAll('holon-empty', 'nonexistent-lens');
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
+    });
+
+    test('delete removes item', async () => {
+      const payload = JSON.stringify({ id: 'del-1', title: 'To Delete' });
+      await backend.put('holon-c', 'tasks', 'del-1', payload);
+
+      const deleted = await backend.delete('holon-c', 'tasks', 'del-1');
+      expect(deleted).toBe(true);
+
+      const result = await backend.get('holon-c', 'tasks', 'del-1');
+      expect(result).toBeNull();
+    });
+
+    test('global table (null holon) works', async () => {
+      const payload = JSON.stringify({ id: 'g1', value: 'global data' });
+      await backend.put(null, 'settings', 'g1', payload);
+
+      const result = await backend.get(null, 'settings', 'g1');
+      expect(result).not.toBeNull();
+      expect(JSON.parse(result)).toEqual({ id: 'g1', value: 'global data' });
+    });
+
+    test('items in different holons are isolated', async () => {
+      await backend.put('holon-x', 'data', 'k1', JSON.stringify({ id: 'k1', from: 'x' }));
+      await backend.put('holon-y', 'data', 'k1', JSON.stringify({ id: 'k1', from: 'y' }));
+
+      const fromX = JSON.parse(await backend.get('holon-x', 'data', 'k1'));
+      const fromY = JSON.parse(await backend.get('holon-y', 'data', 'k1'));
+
+      expect(fromX.from).toBe('x');
+      expect(fromY.from).toBe('y');
+    });
+
+    test('items in different lenses are isolated', async () => {
+      await backend.put('holon-z', 'alpha', 'k1', JSON.stringify({ id: 'k1', lens: 'alpha' }));
+      await backend.put('holon-z', 'beta', 'k1', JSON.stringify({ id: 'k1', lens: 'beta' }));
+
+      const fromAlpha = JSON.parse(await backend.get('holon-z', 'alpha', 'k1'));
+      const fromBeta = JSON.parse(await backend.get('holon-z', 'beta', 'k1'));
+
+      expect(fromAlpha.lens).toBe('alpha');
+      expect(fromBeta.lens).toBe('beta');
+    });
+
+    test('subscribe fires on put', async () => {
+      const received = [];
+      const sub = backend.subscribe('holon-sub', 'events', (key, value) => {
+        received.push({ key, value });
+      });
+
+      await backend.put('holon-sub', 'events', 'e1', JSON.stringify({ id: 'e1', title: 'Event 1' }));
+
+      // Give the subscription time to fire
+      await new Promise(r => setTimeout(r, 500));
+
+      sub.unsubscribe();
+
+      expect(received.length).toBeGreaterThanOrEqual(1);
+      const match = received.find(r => r.key === 'e1');
+      expect(match).toBeDefined();
+    });
+
+    test('subscribe fires null on delete', async () => {
+      await backend.put('holon-del-sub', 'items', 'd1', JSON.stringify({ id: 'd1', val: 'x' }));
+      await new Promise(r => setTimeout(r, 200));
+
+      const received = [];
+      const sub = backend.subscribe('holon-del-sub', 'items', (key, value) => {
+        received.push({ key, value });
+      }, { includeDeletes: true });
+
+      await new Promise(r => setTimeout(r, 200));
+      await backend.delete('holon-del-sub', 'items', 'd1');
+      await new Promise(r => setTimeout(r, 500));
+
+      sub.unsubscribe();
+
+      const deletion = received.find(r => r.key === 'd1' && r.value === null);
+      expect(deletion).toBeDefined();
+    });
+
+    test('concurrent puts to same key converge', async () => {
+      const promises = [
+        backend.put('holon-cc', 'data', 'race', JSON.stringify({ id: 'race', v: 1 })),
+        backend.put('holon-cc', 'data', 'race', JSON.stringify({ id: 'race', v: 2 })),
+        backend.put('holon-cc', 'data', 'race', JSON.stringify({ id: 'race', v: 3 })),
+      ];
+      await Promise.all(promises);
+
+      const result = await backend.get('holon-cc', 'data', 'race');
+      expect(result).not.toBeNull();
+      const parsed = JSON.parse(result);
+      expect(parsed.id).toBe('race');
+      expect([1, 2, 3]).toContain(parsed.v);
+    });
+
+    test('getNodeRef returns a traversable reference', () => {
+      const ref = backend.getNodeRef('TestApp/holon1/lens1/key1');
+      expect(ref).toBeDefined();
+      expect(typeof ref.get).toBe('function');
+      expect(typeof ref.put).toBe('function');
+      expect(typeof ref.once).toBe('function');
+    });
+
+    test('put with overwrite updates value', async () => {
+      await backend.put('holon-ow', 'data', 'ow1', JSON.stringify({ id: 'ow1', v: 'first' }));
+      await backend.put('holon-ow', 'data', 'ow1', JSON.stringify({ id: 'ow1', v: 'second' }));
+
+      const result = JSON.parse(await backend.get('holon-ow', 'data', 'ow1'));
+      expect(result.v).toBe('second');
+    });
+  });
+}
+
+// ─── Run conformance for GunBackend ──────────────────────────────────────────
+
+conformanceSuite('GunBackend', () => {
+  const id = Math.random().toString(36).slice(2, 8);
+  return new GunBackend(`conformance-test-${id}`, {
+    file: false,
+    radisk: false,
+    peers: [],
+  });
+});
+
+// ─── Run conformance for AD4MBackend (skipped if not available) ──────────────
+
+if (ad4mAvailable) {
+  const AD4M_TEST_URL = process.env.AD4M_TEST_URL || 'ws://localhost:12000/graphql';
+  const AD4M_TEST_TOKEN = process.env.AD4M_TEST_TOKEN;
+
+  conformanceSuite('AD4MBackend', () => {
+    const id = Math.random().toString(36).slice(2, 8);
+    return new AD4MBackend(`conformance-test-${id}`, {
+      url: AD4M_TEST_URL,
+      token: AD4M_TEST_TOKEN,
+    });
+  });
+} else {
+  describe('AD4MBackend conformance (skipped)', () => {
+    test.skip('requires @coasys/ad4m to be installed', () => {});
+  });
+}

--- a/packages/holosphere/test/subscription.test.js
+++ b/packages/holosphere/test/subscription.test.js
@@ -100,7 +100,7 @@ describe('Subscription Tests', () => {
     expect(holosphere.subscriptions[subscriptionId].holon).toBe(testHolon);
     expect(holosphere.subscriptions[subscriptionId].lens).toBe(testLens);
     expect(holosphere.subscriptions[subscriptionId].callback).toBe(mockCallback);
-    expect(holosphere.subscriptions[subscriptionId].mapChain).toBeDefined();
+    expect(holosphere.subscriptions[subscriptionId].backendSub).toBeDefined();
     
     // Now unsubscribe
     await subscription.unsubscribe();

--- a/packages/holosphere/utils.js
+++ b/packages/holosphere/utils.js
@@ -144,17 +144,30 @@ export function subscribe(holoInstance, holon, lens, callback, options = {}) {
         // we keep the orchestration concerns here: parse, hologram resolution,
         // object-only filtering, fire-storm detection.
         const backendSub = holoInstance._backend.subscribe(holon, lens, async (key, data) => {
-            // Fire-storm breaker (backend-agnostic).
+            // Fire-storm breaker (backend-agnostic). A write to a cyclic /
+            // over-subscribed federated node can make the backend re-fire the
+            // subscription handler in an unbounded burst (Gun map().on() or an
+            // AD4M model query), exhausting the heap before any await yields.
+            // Count fires in a 1s window; past a clear-runaway threshold, log
+            // the path + stack ONCE and bail (no parse/resolve/allocate) so the
+            // tab survives and the culprit is identifiable.
             const __fnow = Date.now();
+            // Per-PATH fire window (on the group) so we can pin the runaway lens
+            // and QUARANTINE it specifically — not just bail instance-wide and
+            // let the backend keep re-firing forever.
             const gfw = group.fires;
             gfw.push(__fnow);
             if (gfw.length > 64) { while (gfw.length && __fnow - gfw[0] > 1000) gfw.shift(); }
             if (gfw.length > QUARANTINE_FIRE_THRESHOLD) {
+                // Sustained storm on THIS lens: detach every listener on it and
+                // mark it quarantined so re-subscribes are refused for a
+                // cooldown. The tab recovers and the lens read in
+                // __repairCircular stops being starved.
                 holoInstance.__onFireWarnedAt = __fnow;
                 holoInstance.__quarantined ||= new Map();
                 holoInstance.__quarantined.set(groupKey, __fnow);
                 const __st = (new Error().stack || '').split('\n').slice(2, 8).join('\n');
-                console.error(`[subscribe] FIRE-STORM on ${holon}/${lens} (${gfw.length}/s) — QUARANTINING this lens. Stack:\n${__st}`);
+                console.error(`[subscribe] FIRE-STORM on ${holon}/${lens} (${gfw.length}/s) — QUARANTINING this lens (detaching listeners). Almost certainly a circular hologram; run __repairCircular('${holon}','${lens}') or __nuke the bad pointer, then reload. Stack:\n${__st}`);
                 for (const id of [...group.ids]) {
                     const sub = holoInstance.subscriptions[id];
                     try { sub?.backendSub?.unsubscribe(); } catch { /* ignore */ }
@@ -185,6 +198,13 @@ export function subscribe(holoInstance, holon, lens, callback, options = {}) {
                         const hologramSoul = parsed.soul;
                         const res = await holoInstance.resolveHologramDetailed(parsed, { followHolograms: true });
                         if (res.status === 'deleted') {
+                            // The source was soft-deleted (_deleted:true) — a
+                            // DEFINITIVE removal. Notify consumers the item is
+                            // gone, exactly like a local tombstone. This is the
+                            // payoff of typed resolution: a deleted federated
+                            // source now propagates as a deletion to the live UI
+                            // instead of silently lingering. Also emit the
+                            // janitor-parseable line so the dead pointer is GC'd.
                             console.warn(`Hologram at ${holon}/${lens}/${key} did not resolve (soul=${hologramSoul}); skipping.`);
                             if (holoInstance.subscriptions[subscriptionId]) {
                                 callback(null, key);
@@ -192,6 +212,14 @@ export function subscribe(holoInstance, holon, lens, callback, options = {}) {
                             return;
                         }
                         if (res.status !== 'resolved') {
+                            // Transient (unresolved/error) or structural
+                            // (circular/depth/invalid). Emit the SAME
+                            // janitor-parseable warning `get`/`getAll` emit — it
+                            // carries the LOCAL pointer (holon/lens/key) a cleaner
+                            // needs, which `resolveHologram`'s own source-soul log
+                            // does not. Unlike a deletion we do NOT emit a removal:
+                            // a transient miss must not flicker the item out of a
+                            // live view; it stays until it resolves or is GC'd.
                             console.warn(`Hologram at ${holon}/${lens}/${key} did not resolve (soul=${hologramSoul}); skipping.`);
                             return;
                         }
@@ -200,11 +228,18 @@ export function subscribe(holoInstance, holon, lens, callback, options = {}) {
                         }
                     }
 
+                    // Subscribers expect `object | null`. `parse()` can return
+                    // a string/number/boolean when a legacy or corrupted leaf
+                    // happened to be a JSON-encoded primitive (e.g.
+                    // `'"hello"'` parses to `'hello'`). Drop those so every
+                    // consumer can stop guarding with
+                    // `typeof x === 'string' ? JSON.parse(x) : x`.
                     if (parsed !== null && (typeof parsed !== 'object' || Array.isArray(parsed))) {
                         console.warn(`[holosphere.subscribe] dropping non-object payload at ${holon}/${lens}/${key}:`, typeof parsed);
                         return;
                     }
 
+                    // Check again if subscription ID still exists before calling callback
                     if (holoInstance.subscriptions[subscriptionId]) {
                         callback(parsed, key);
                     }
@@ -212,10 +247,12 @@ export function subscribe(holoInstance, holon, lens, callback, options = {}) {
                     console.error('Error processing subscribed data:', error);
                 }
             } else if (includeDeletes && key && key !== '_' && holoInstance.subscriptions[subscriptionId]) {
+                // delete / tombstone — notify consumers the item is gone
                 callback(null, key);
             }
         }, { includeDeletes });
 
+        // Store the subscription with its ID on the instance
         holoInstance.subscriptions[subscriptionId] = {
             id: subscriptionId,
             holon,
@@ -225,14 +262,22 @@ export function subscribe(holoInstance, holon, lens, callback, options = {}) {
             groupKey,
         };
 
+        // Return an object with unsubscribe method.
+        // `unsubscribe` is sync — nothing it does (`backendSub.unsubscribe()`,
+        // `delete subscriptions[id]`) blocks. Keeping it sync means the
+        // returned shape is `{ unsubscribe: () => void }` rather than
+        // `() => Promise<void>`, matching what callers expect when they
+        // store it in a `() => void` cleanup slot.
         return {
             unsubscribe: () => {
                 const sub = holoInstance.subscriptions[subscriptionId];
                 if (!sub) return;
 
                 try {
+                    // Turn off THIS subscriber's own backend listener.
                     if (sub.backendSub?.unsubscribe) sub.backendSub.unsubscribe();
 
+                    // Drop it from the per-path counter (for the leak warnings).
                     const g = holoInstance._subscriptionGroups &&
                         holoInstance._subscriptionGroups.get(groupKey);
                     if (g) {
@@ -242,6 +287,7 @@ export function subscribe(holoInstance, holon, lens, callback, options = {}) {
                         }
                     }
 
+                    // Remove from subscriptions object AFTER turning off listener
                     delete holoInstance.subscriptions[subscriptionId];
                 } catch (error) {
                     console.error(`Error during unsubscribe logic for ${subscriptionId}:`, error);

--- a/packages/holosphere/utils.js
+++ b/packages/holosphere/utils.js
@@ -139,36 +139,25 @@ export function subscribe(holoInstance, holon, lens, callback, options = {}) {
             group.warnThreshold *= 2;
         }
 
-        // Get the Gun chain up to the map()
-        const mapChain = holoInstance.gun.get(holoInstance.appname).get(holon).get(lens).map();
-
-        // Create the subscription by calling .on() on the map chain
-        const gunListener = mapChain.on(async (data, key) => {
-            // Fire-storm breaker. A write to a cyclic / over-subscribed federated
-            // node can make Gun re-fire map().on() handlers in an unbounded burst,
-            // exhausting the heap before any await yields. Count instance-wide
-            // fires in a 1s window; past a clear-runaway threshold, log the path +
-            // stack ONCE and bail (no parse/resolve/allocate) so the tab survives
-            // and the culprit is identifiable.
+        // Delegate to the backend's subscribe method.  The backend handles
+        // the raw storage subscription (Gun map().on() or AD4M model query);
+        // we keep the orchestration concerns here: parse, hologram resolution,
+        // object-only filtering, fire-storm detection.
+        const backendSub = holoInstance._backend.subscribe(holon, lens, async (key, data) => {
+            // Fire-storm breaker (backend-agnostic).
             const __fnow = Date.now();
-            // Per-PATH fire window (on the group) so we can pin the runaway lens and
-            // QUARANTINE it specifically — not just bail instance-wide and let Gun
-            // keep re-firing forever.
             const gfw = group.fires;
             gfw.push(__fnow);
             if (gfw.length > 64) { while (gfw.length && __fnow - gfw[0] > 1000) gfw.shift(); }
             if (gfw.length > QUARANTINE_FIRE_THRESHOLD) {
-                // Sustained storm on THIS lens: detach every listener on it and mark
-                // it quarantined so re-subscribes are refused for a cooldown. The tab
-                // recovers and the lens read in __repairCircular stops being starved.
-                holoInstance.__onFireWarnedAt = __fnow; // also quiets the enforce wrapper
+                holoInstance.__onFireWarnedAt = __fnow;
                 holoInstance.__quarantined ||= new Map();
                 holoInstance.__quarantined.set(groupKey, __fnow);
                 const __st = (new Error().stack || '').split('\n').slice(2, 8).join('\n');
-                console.error(`[subscribe] FIRE-STORM on ${holon}/${lens} (${gfw.length}/s) — QUARANTINING this lens (detaching listeners). Almost certainly a circular hologram; run __repairCircular('${holon}','${lens}') or __nuke the bad pointer, then reload. Stack:\n${__st}`);
+                console.error(`[subscribe] FIRE-STORM on ${holon}/${lens} (${gfw.length}/s) — QUARANTINING this lens. Stack:\n${__st}`);
                 for (const id of [...group.ids]) {
                     const sub = holoInstance.subscriptions[id];
-                    try { sub && sub.mapChain && sub.mapChain.off(); } catch { /* ignore */ }
+                    try { sub?.backendSub?.unsubscribe(); } catch { /* ignore */ }
                     delete holoInstance.subscriptions[id];
                 }
                 group.ids.clear();
@@ -182,14 +171,12 @@ export function subscribe(holoInstance, holon, lens, callback, options = {}) {
                 if (!holoInstance.__onFireWarnedAt || __fnow - holoInstance.__onFireWarnedAt > 2000) {
                     holoInstance.__onFireWarnedAt = __fnow;
                     const __st = (new Error().stack || '').split('\n').slice(2, 8).join('\n');
-                    console.error(`[subscribe] FIRE-STORM: ${__fw.length} map().on() fires/s — runaway. Latest path=${holon}/${lens} key=${key}. Stack:\n${__st}`);
+                    console.error(`[subscribe] FIRE-STORM: ${__fw.length} fires/s — runaway. Latest path=${holon}/${lens} key=${key}. Stack:\n${__st}`);
                 }
                 return;
             }
-            // Check if subscription ID still exists (might have been unsubscribed)
-            if (!holoInstance.subscriptions[subscriptionId]) {
-                return;
-            }
+
+            if (!holoInstance.subscriptions[subscriptionId]) return;
 
             if (data) {
                 try {
@@ -198,13 +185,6 @@ export function subscribe(holoInstance, holon, lens, callback, options = {}) {
                         const hologramSoul = parsed.soul;
                         const res = await holoInstance.resolveHologramDetailed(parsed, { followHolograms: true });
                         if (res.status === 'deleted') {
-                            // The source was soft-deleted (_deleted:true) — a
-                            // DEFINITIVE removal. Notify consumers the item is
-                            // gone, exactly like a local tombstone. This is the
-                            // payoff of typed resolution: a deleted federated
-                            // source now propagates as a deletion to the live UI
-                            // instead of silently lingering. Also emit the
-                            // janitor-parseable line so the dead pointer is GC'd.
                             console.warn(`Hologram at ${holon}/${lens}/${key} did not resolve (soul=${hologramSoul}); skipping.`);
                             if (holoInstance.subscriptions[subscriptionId]) {
                                 callback(null, key);
@@ -212,14 +192,6 @@ export function subscribe(holoInstance, holon, lens, callback, options = {}) {
                             return;
                         }
                         if (res.status !== 'resolved') {
-                            // Transient (unresolved/error) or structural
-                            // (circular/depth/invalid). Emit the SAME
-                            // janitor-parseable warning `get`/`getAll` emit — it
-                            // carries the LOCAL pointer (holon/lens/key) a cleaner
-                            // needs, which `resolveHologram`'s own source-soul log
-                            // does not. Unlike a deletion we do NOT emit a removal:
-                            // a transient miss must not flicker the item out of a
-                            // live view; it stays until it resolves or is GC'd.
                             console.warn(`Hologram at ${holon}/${lens}/${key} did not resolve (soul=${hologramSoul}); skipping.`);
                             return;
                         }
@@ -228,18 +200,11 @@ export function subscribe(holoInstance, holon, lens, callback, options = {}) {
                         }
                     }
 
-                    // Subscribers expect `object | null`. `parse()` can return
-                    // a string/number/boolean when a legacy or corrupted leaf
-                    // happened to be a JSON-encoded primitive (e.g.
-                    // `'"hello"'` parses to `'hello'`). Drop those so every
-                    // consumer can stop guarding with
-                    // `typeof x === 'string' ? JSON.parse(x) : x`.
                     if (parsed !== null && (typeof parsed !== 'object' || Array.isArray(parsed))) {
                         console.warn(`[holosphere.subscribe] dropping non-object payload at ${holon}/${lens}/${key}:`, typeof parsed);
                         return;
                     }
 
-                    // Check again if subscription ID still exists before calling callback
                     if (holoInstance.subscriptions[subscriptionId]) {
                         callback(parsed, key);
                     }
@@ -247,42 +212,27 @@ export function subscribe(holoInstance, holon, lens, callback, options = {}) {
                     console.error('Error processing subscribed data:', error);
                 }
             } else if (includeDeletes && key && key !== '_' && holoInstance.subscriptions[subscriptionId]) {
-                // delete / tombstone — notify consumers the item is gone
                 callback(null, key);
             }
-        });
+        }, { includeDeletes });
 
-        // Store the subscription with its ID on the instance
         holoInstance.subscriptions[subscriptionId] = {
             id: subscriptionId,
             holon,
             lens,
             callback,
-            mapChain,
-            gunListener,
+            backendSub,
             groupKey,
         };
 
-        // Return an object with unsubscribe method.
-        // `unsubscribe` is sync — nothing it does (`mapChain.off()`,
-        // `delete subscriptions[id]`) blocks. Keeping it sync means the
-        // returned shape is `{ unsubscribe: () => void }` rather than
-        // `() => Promise<void>`, matching what callers expect when they
-        // store it in a `() => void` cleanup slot.
         return {
             unsubscribe: () => {
                 const sub = holoInstance.subscriptions[subscriptionId];
-                if (!sub) {
-                    return;
-                }
+                if (!sub) return;
 
                 try {
-                    // Turn off THIS subscriber's own Gun listener.
-                    if (sub.mapChain) {
-                        sub.mapChain.off();
-                    }
+                    if (sub.backendSub?.unsubscribe) sub.backendSub.unsubscribe();
 
-                    // Drop it from the per-path counter (for the leak warnings).
                     const g = holoInstance._subscriptionGroups &&
                         holoInstance._subscriptionGroups.get(groupKey);
                     if (g) {
@@ -292,7 +242,6 @@ export function subscribe(holoInstance, holon, lens, callback, options = {}) {
                         }
                     }
 
-                    // Remove from subscriptions object AFTER turning off listener
                     delete holoInstance.subscriptions[subscriptionId];
                 } catch (error) {
                     console.error(`Error during unsubscribe logic for ${subscriptionId}:`, error);
@@ -346,111 +295,25 @@ export function generateId() { // Doesn't need holoInstance
  */
 export async function close(holoInstance) {
     try {
-        if (holoInstance.gun) {
-            // Unsubscribe from all subscriptions
-            const subscriptionIds = Object.keys(holoInstance.subscriptions);
-            for (const id of subscriptionIds) {
-                try {
-                    const subscription = holoInstance.subscriptions[id];
-                    if (subscription) {
-                        // Turn off the Gun subscription using the stored mapChain reference
-                        if (subscription.mapChain) {
-                            subscription.mapChain.off();
-                        } // Also turn off listener directly? Might be redundant.
-                        // if (subscription.gunListener) {
-                        //     subscription.gunListener.off();
-                        // }
-                    }
-                } catch (error) {
-                    console.warn(`Error cleaning up subscription ${id}:`, error);
-                }
-            }
-
-            // Clear subscriptions (the loop above already `.off()`'d the
-            // shared map chains) and drop the dedup registry so a reopened
-            // instance starts with zero listener groups.
-            holoInstance.subscriptions = {};
-            if (holoInstance._subscriptionGroups) {
-                holoInstance._subscriptionGroups.clear();
-            }
-
-            // Clear schema cache using instance method
-            holoInstance.clearSchemaCache();
-
-            // Close Gun connections
-            if (holoInstance.gun.back) {
-                try {
-                    // Clean up mesh connections
-                    const mesh = holoInstance.gun.back('opt.mesh');
-                    if (mesh) {
-                        // Clean up mesh.hear
-                        if (mesh.hear) {
-                            try {
-                                // Safely clear mesh.hear without modifying function properties
-                                const hearKeys = Object.keys(mesh.hear);
-                                for (const key of hearKeys) {
-                                    // Check if it's an array before trying to clear it
-                                    if (Array.isArray(mesh.hear[key])) {
-                                        mesh.hear[key] = [];
-                                    }
-                                }
-
-                                // Create a new empty object for mesh.hear
-                                // Only if mesh.hear is not a function
-                                if (typeof mesh.hear !== 'function') {
-                                    mesh.hear = {};
-                                }
-                            } catch (meshError) {
-                                console.warn('Error cleaning up Gun mesh hear:', meshError);
-                            }
-                        }
-
-                        // Close any open sockets in the mesh
-                        if (mesh.way) {
-                            try {
-                                Object.values(mesh.way).forEach(connection => {
-                                    if (connection && connection.wire && connection.wire.close) {
-                                        connection.wire.close();
-                                    }
-                                });
-                            } catch (sockError) {
-                                console.warn('Error closing mesh sockets:', sockError);
-                            }
-                        }
-
-                        // Clear the peers list
-                        if (mesh.opt && mesh.opt.peers) {
-                            mesh.opt.peers = {};
-                        }
-                    }
-
-                    // Attempt to clean up any TCP connections
-                    if (holoInstance.gun.back('opt.web')) {
-                        try {
-                            const server = holoInstance.gun.back('opt.web');
-                            if (server && server.close) {
-                                server.close();
-                            }
-                        } catch (webError) {
-                            console.warn('Error closing web server:', webError);
-                        }
-                    }
-                } catch (error) {
-                    console.warn('Error accessing Gun mesh:', error);
-                }
-            }
-
-            // Clear all Gun instance listeners
+        // Unsubscribe from all subscriptions
+        for (const [id, sub] of Object.entries(holoInstance.subscriptions)) {
             try {
-                holoInstance.gun.off();
+                if (sub.backendSub?.unsubscribe) sub.backendSub.unsubscribe();
             } catch (error) {
-                console.warn('Error turning off Gun listeners:', error);
+                console.warn(`Error cleaning up subscription ${id}:`, error);
             }
-
-            // Wait a moment for cleanup to complete
-            await new Promise(resolve => setTimeout(resolve, 100));
         }
 
+        holoInstance.subscriptions = {};
+        if (holoInstance._subscriptionGroups) {
+            holoInstance._subscriptionGroups.clear();
+        }
+
+        holoInstance.clearSchemaCache();
+
+        await holoInstance._backend.close();
+
+        await new Promise(resolve => setTimeout(resolve, 100));
         console.log('HoloSphere instance closed successfully');
     } catch (error) {
         console.error('Error closing HoloSphere instance:', error);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  esbuild@<0.25.0: '>=0.25.0'
+  cookie@<0.7.0: '>=0.7.0'
+  holosphere: workspace:*
+
 importers:
 
   .:
@@ -814,12 +819,6 @@ packages:
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
-  '@esbuild/aix-ppc64@0.24.2':
-    resolution: {integrity: sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
@@ -832,12 +831,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.24.2':
-    resolution: {integrity: sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
@@ -848,12 +841,6 @@ packages:
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.24.2':
-    resolution: {integrity: sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.12':
@@ -868,12 +855,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.24.2':
-    resolution: {integrity: sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
@@ -886,12 +867,6 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.24.2':
-    resolution: {integrity: sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
@@ -902,12 +877,6 @@ packages:
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.24.2':
-    resolution: {integrity: sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.12':
@@ -922,12 +891,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.24.2':
-    resolution: {integrity: sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
@@ -938,12 +901,6 @@ packages:
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.24.2':
-    resolution: {integrity: sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -958,12 +915,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.24.2':
-    resolution: {integrity: sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
@@ -974,12 +925,6 @@ packages:
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.24.2':
-    resolution: {integrity: sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.12':
@@ -994,12 +939,6 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.24.2':
-    resolution: {integrity: sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
@@ -1010,12 +949,6 @@ packages:
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.24.2':
-    resolution: {integrity: sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.12':
@@ -1030,12 +963,6 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.24.2':
-    resolution: {integrity: sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
@@ -1046,12 +973,6 @@ packages:
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.24.2':
-    resolution: {integrity: sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -1066,12 +987,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.24.2':
-    resolution: {integrity: sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
@@ -1082,12 +997,6 @@ packages:
     resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.24.2':
-    resolution: {integrity: sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.25.12':
@@ -1102,12 +1011,6 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.24.2':
-    resolution: {integrity: sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.25.12':
     resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
     engines: {node: '>=18'}
@@ -1120,12 +1023,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.24.2':
-    resolution: {integrity: sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
     engines: {node: '>=18'}
@@ -1136,12 +1033,6 @@ packages:
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.24.2':
-    resolution: {integrity: sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.25.12':
@@ -1156,12 +1047,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.24.2':
-    resolution: {integrity: sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
@@ -1172,12 +1057,6 @@ packages:
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.24.2':
-    resolution: {integrity: sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -1204,12 +1083,6 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.24.2':
-    resolution: {integrity: sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
@@ -1221,12 +1094,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
-
-  '@esbuild/win32-arm64@0.24.2':
-    resolution: {integrity: sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
@@ -1240,12 +1107,6 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.24.2':
-    resolution: {integrity: sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
@@ -1256,12 +1117,6 @@ packages:
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.24.2':
-    resolution: {integrity: sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.12':
@@ -2933,10 +2788,6 @@ packages:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
 
-  cookie@0.6.0:
-    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
-    engines: {node: '>= 0.6'}
-
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
@@ -3303,11 +3154,6 @@ packages:
 
   es6-promise@3.3.1:
     resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==}
-
-  esbuild@0.24.2:
-    resolution: {integrity: sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -6198,16 +6044,10 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.24.2':
-    optional: true
-
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
   '@esbuild/aix-ppc64@0.27.7':
-    optional: true
-
-  '@esbuild/android-arm64@0.24.2':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
@@ -6216,16 +6056,10 @@ snapshots:
   '@esbuild/android-arm64@0.27.7':
     optional: true
 
-  '@esbuild/android-arm@0.24.2':
-    optional: true
-
   '@esbuild/android-arm@0.25.12':
     optional: true
 
   '@esbuild/android-arm@0.27.7':
-    optional: true
-
-  '@esbuild/android-x64@0.24.2':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
@@ -6234,16 +6068,10 @@ snapshots:
   '@esbuild/android-x64@0.27.7':
     optional: true
 
-  '@esbuild/darwin-arm64@0.24.2':
-    optional: true
-
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/darwin-x64@0.24.2':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
@@ -6252,16 +6080,10 @@ snapshots:
   '@esbuild/darwin-x64@0.27.7':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.24.2':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.24.2':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -6270,16 +6092,10 @@ snapshots:
   '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
-  '@esbuild/linux-arm64@0.24.2':
-    optional: true
-
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
   '@esbuild/linux-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/linux-arm@0.24.2':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
@@ -6288,16 +6104,10 @@ snapshots:
   '@esbuild/linux-arm@0.27.7':
     optional: true
 
-  '@esbuild/linux-ia32@0.24.2':
-    optional: true
-
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
   '@esbuild/linux-ia32@0.27.7':
-    optional: true
-
-  '@esbuild/linux-loong64@0.24.2':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
@@ -6306,16 +6116,10 @@ snapshots:
   '@esbuild/linux-loong64@0.27.7':
     optional: true
 
-  '@esbuild/linux-mips64el@0.24.2':
-    optional: true
-
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.7':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.24.2':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -6324,16 +6128,10 @@ snapshots:
   '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
-  '@esbuild/linux-riscv64@0.24.2':
-    optional: true
-
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.7':
-    optional: true
-
-  '@esbuild/linux-s390x@0.24.2':
     optional: true
 
   '@esbuild/linux-s390x@0.25.12':
@@ -6342,16 +6140,10 @@ snapshots:
   '@esbuild/linux-s390x@0.27.7':
     optional: true
 
-  '@esbuild/linux-x64@0.24.2':
-    optional: true
-
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
   '@esbuild/linux-x64@0.27.7':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.24.2':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.12':
@@ -6360,25 +6152,16 @@ snapshots:
   '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
-  '@esbuild/netbsd-x64@0.24.2':
-    optional: true
-
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.24.2':
-    optional: true
-
   '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.24.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -6393,16 +6176,10 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
-  '@esbuild/sunos-x64@0.24.2':
-    optional: true
-
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
   '@esbuild/sunos-x64@0.27.7':
-    optional: true
-
-  '@esbuild/win32-arm64@0.24.2':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
@@ -6411,16 +6188,10 @@ snapshots:
   '@esbuild/win32-arm64@0.27.7':
     optional: true
 
-  '@esbuild/win32-ia32@0.24.2':
-    optional: true
-
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
   '@esbuild/win32-ia32@0.27.7':
-    optional: true
-
-  '@esbuild/win32-x64@0.24.2':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
@@ -7226,14 +6997,14 @@ snapshots:
     dependencies:
       '@iarna/toml': 2.2.5
       '@sveltejs/kit': 2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@5.5.0)(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      esbuild: 0.24.2
+      esbuild: 0.25.12
       set-cookie-parser: 2.7.2
 
   '@sveltejs/adapter-netlify@4.4.2(@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))':
     dependencies:
       '@iarna/toml': 2.2.5
       '@sveltejs/kit': 2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      esbuild: 0.24.2
+      esbuild: 0.25.12
       set-cookie-parser: 2.7.2
 
   '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@5.5.0)(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))':
@@ -7247,7 +7018,7 @@ snapshots:
       '@sveltejs/vite-plugin-svelte': 5.1.1(supports-color@5.5.0)(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       '@types/cookie': 0.6.0
       acorn: 8.16.0
-      cookie: 0.6.0
+      cookie: 0.7.2
       devalue: 5.8.0
       esm-env: 1.2.2
       kleur: 4.1.5
@@ -7267,7 +7038,7 @@ snapshots:
       '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       '@types/cookie': 0.6.0
       acorn: 8.16.0
-      cookie: 0.6.0
+      cookie: 0.7.2
       devalue: 5.8.0
       esm-env: 1.2.2
       kleur: 4.1.5
@@ -8376,8 +8147,6 @@ snapshots:
 
   cookie-signature@1.2.2: {}
 
-  cookie@0.6.0: {}
-
   cookie@0.7.2: {}
 
   core-js@3.49.0:
@@ -8737,34 +8506,6 @@ snapshots:
       hasown: 2.0.3
 
   es6-promise@3.3.1: {}
-
-  esbuild@0.24.2:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.24.2
-      '@esbuild/android-arm': 0.24.2
-      '@esbuild/android-arm64': 0.24.2
-      '@esbuild/android-x64': 0.24.2
-      '@esbuild/darwin-arm64': 0.24.2
-      '@esbuild/darwin-x64': 0.24.2
-      '@esbuild/freebsd-arm64': 0.24.2
-      '@esbuild/freebsd-x64': 0.24.2
-      '@esbuild/linux-arm': 0.24.2
-      '@esbuild/linux-arm64': 0.24.2
-      '@esbuild/linux-ia32': 0.24.2
-      '@esbuild/linux-loong64': 0.24.2
-      '@esbuild/linux-mips64el': 0.24.2
-      '@esbuild/linux-ppc64': 0.24.2
-      '@esbuild/linux-riscv64': 0.24.2
-      '@esbuild/linux-s390x': 0.24.2
-      '@esbuild/linux-x64': 0.24.2
-      '@esbuild/netbsd-arm64': 0.24.2
-      '@esbuild/netbsd-x64': 0.24.2
-      '@esbuild/openbsd-arm64': 0.24.2
-      '@esbuild/openbsd-x64': 0.24.2
-      '@esbuild/sunos-x64': 0.24.2
-      '@esbuild/win32-arm64': 0.24.2
-      '@esbuild/win32-ia32': 0.24.2
-      '@esbuild/win32-x64': 0.24.2
 
   esbuild@0.25.12:
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,11 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  esbuild@<0.25.0: '>=0.25.0'
-  cookie@<0.7.0: '>=0.7.0'
-  holosphere: workspace:*
-
 importers:
 
   .:
@@ -40,16 +35,16 @@ importers:
     devDependencies:
       '@sveltejs/adapter-netlify':
         specifier: ^4.4.2
-        version: 4.4.2(@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))
+        version: 4.4.2(@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@5.5.0)(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))
       '@sveltejs/adapter-static':
         specifier: ^3.0.6
-        version: 3.0.10(@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))
+        version: 3.0.10(@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@5.5.0)(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))
       '@sveltejs/kit':
         specifier: ^2.59.1
-        version: 2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+        version: 2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@5.5.0)(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.1
-        version: 5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+        version: 5.1.1(supports-color@5.5.0)(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       '@tsconfig/svelte':
         specifier: ^5.0.4
         version: 5.0.8
@@ -194,28 +189,28 @@ importers:
         version: 1.5.6
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.32.0
-        version: 8.59.2(@typescript-eslint/parser@8.59.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+        version: 8.59.2(@typescript-eslint/parser@8.59.2(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: ^8.32.0
-        version: 8.59.2(eslint@8.57.1)(typescript@5.9.3)
+        version: 8.59.2(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
       autoprefixer:
         specifier: ^10.4.20
         version: 10.5.0(postcss@8.5.14)
       eslint:
         specifier: ^8.57.0
-        version: 8.57.1
+        version: 8.57.1(supports-color@5.5.0)
       eslint-config-prettier:
         specifier: ^9.0.0
-        version: 9.1.2(eslint@8.57.1)
+        version: 9.1.2(eslint@8.57.1(supports-color@5.5.0))
       eslint-plugin-svelte:
         specifier: ^3.5.1
-        version: 3.17.1(eslint@8.57.1)(svelte@5.55.5(@typescript-eslint/types@8.60.0))
+        version: 3.17.1(eslint@8.57.1(supports-color@5.5.0))(svelte@5.55.5(@typescript-eslint/types@8.60.0))
       eslint-plugin-tailwindcss:
         specifier: ^3.18.0
         version: 3.18.3(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
       eslint-plugin-unused-imports:
         specifier: ^4.0.0
-        version: 4.4.1(@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
+        version: 4.4.1(@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@8.57.1(supports-color@5.5.0))
       jsdoc:
         specifier: ^4.0.5
         version: 4.0.5
@@ -286,7 +281,7 @@ importers:
         version: 22.19.17
       eslint:
         specifier: ^9.35.0
-        version: 9.39.4(jiti@2.7.0)
+        version: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       h3-js:
         specifier: ^4.4.0
         version: 4.4.0
@@ -295,7 +290,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.20.0
-        version: 8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.60.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
       vitest:
         specifier: ^4.0.18
         version: 4.1.5(@types/node@22.19.17)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
@@ -350,10 +345,13 @@ importers:
         version: 8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
+        version: 3.2.4(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(supports-color@5.5.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
 
   packages/holosphere:
     dependencies:
+      '@coasys/ad4m':
+        specifier: '>=0.13.0-0'
+        version: 0.13.0-test-8
       '@noble/curves':
         specifier: ^1.8.0
         version: 1.9.7
@@ -394,7 +392,7 @@ importers:
         version: link:../core
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
-        version: 1.29.0(zod@3.25.76)
+        version: 1.29.0(supports-color@5.5.0)(zod@3.25.76)
       dotenv:
         specifier: ^17.2.3
         version: 17.4.2
@@ -428,7 +426,7 @@ importers:
         version: 1.29.0(zod@3.25.76)
       axios:
         specifier: ^1.7.8
-        version: 1.16.0(debug@4.4.3)
+        version: 1.16.0(debug@4.4.3(supports-color@5.5.0))
       compression:
         specifier: ^1.8.1
         version: 1.8.1
@@ -476,7 +474,7 @@ importers:
         version: link:../holosphere
       http-proxy:
         specifier: ^1.18.1
-        version: 1.18.1(debug@4.4.3)
+        version: 1.18.1(debug@4.4.3(supports-color@5.5.0))
       i18next:
         specifier: ^22.5.1
         version: 22.5.1
@@ -509,7 +507,7 @@ importers:
         version: 4.104.0(ws@8.20.0)(zod@3.25.76)
       puppeteer:
         specifier: ^24.42.0
-        version: 24.43.0(typescript@5.9.3)
+        version: 24.43.0(supports-color@5.5.0)(typescript@5.9.3)
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
@@ -518,7 +516,7 @@ importers:
         version: 0.34.5
       telegraf:
         specifier: ^4.16.3
-        version: 4.16.3
+        version: 4.16.3(supports-color@5.5.0)
       winston:
         specifier: ^3.17.0
         version: 3.19.0
@@ -555,7 +553,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
+        version: 3.2.4(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(supports-color@5.5.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
 
   packages/text-ui:
     dependencies:
@@ -775,6 +773,9 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
+  '@coasys/ad4m@0.13.0-test-8':
+    resolution: {integrity: sha512-ux0nJcFCd+otqjMJMAGlXPbtCCqcafYWL3fC+W83ry9sIT6iCTZNDtjdzb3F/tDoSl4qJi9f8GjuHsUEGkp4xA==}
+
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
     engines: {node: '>=0.1.90'}
@@ -813,6 +814,12 @@ packages:
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
+  '@esbuild/aix-ppc64@0.24.2':
+    resolution: {integrity: sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
@@ -825,6 +832,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.24.2':
+    resolution: {integrity: sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
@@ -835,6 +848,12 @@ packages:
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.24.2':
+    resolution: {integrity: sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.12':
@@ -849,6 +868,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.24.2':
+    resolution: {integrity: sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
@@ -861,6 +886,12 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.24.2':
+    resolution: {integrity: sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
@@ -871,6 +902,12 @@ packages:
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.24.2':
+    resolution: {integrity: sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.12':
@@ -885,6 +922,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.24.2':
+    resolution: {integrity: sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
@@ -895,6 +938,12 @@ packages:
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.24.2':
+    resolution: {integrity: sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -909,6 +958,12 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.24.2':
+    resolution: {integrity: sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
@@ -919,6 +974,12 @@ packages:
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.24.2':
+    resolution: {integrity: sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.12':
@@ -933,6 +994,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.24.2':
+    resolution: {integrity: sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
@@ -943,6 +1010,12 @@ packages:
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.24.2':
+    resolution: {integrity: sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.12':
@@ -957,6 +1030,12 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.24.2':
+    resolution: {integrity: sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
@@ -967,6 +1046,12 @@ packages:
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.24.2':
+    resolution: {integrity: sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -981,6 +1066,12 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.24.2':
+    resolution: {integrity: sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
@@ -991,6 +1082,12 @@ packages:
     resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.24.2':
+    resolution: {integrity: sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.25.12':
@@ -1005,6 +1102,12 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.24.2':
+    resolution: {integrity: sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.25.12':
     resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
     engines: {node: '>=18'}
@@ -1017,6 +1120,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.24.2':
+    resolution: {integrity: sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
     engines: {node: '>=18'}
@@ -1027,6 +1136,12 @@ packages:
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.24.2':
+    resolution: {integrity: sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.25.12':
@@ -1041,6 +1156,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.24.2':
+    resolution: {integrity: sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
@@ -1051,6 +1172,12 @@ packages:
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.24.2':
+    resolution: {integrity: sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -1077,6 +1204,12 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.24.2':
+    resolution: {integrity: sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
@@ -1088,6 +1221,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.24.2':
+    resolution: {integrity: sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
@@ -1101,6 +1240,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.24.2':
+    resolution: {integrity: sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
@@ -1111,6 +1256,12 @@ packages:
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.24.2':
+    resolution: {integrity: sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.12':
@@ -1183,6 +1334,14 @@ packages:
 
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
+
+  '@holochain/client@0.16.0':
+    resolution: {integrity: sha512-GJEl6F3OSlDX71H+rtyUXpEuor7O9MhvNIi+Tq6obrysu71JsbXfR1rtmSBiNb9fttHOZLW60EzY/Lj3I9dv8g==}
+    engines: {node: '>=16.0.0 || >=18.0.0'}
+
+  '@holochain/serialization@0.1.0-beta-rc.3':
+    resolution: {integrity: sha512-DJx4V2KXHVLciyOGjOYKTM/JLBpBEZ3RsPIRCgf7qmwhQdxXvhi2p+oFFRD51yUT5uC1/MzIVeJCl/R60PwFbw==}
+    deprecated: Holochain no longer requires canonical serialization of zome call payloads
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -1511,6 +1670,10 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@msgpack/msgpack@2.8.0':
+    resolution: {integrity: sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==}
+    engines: {node: '>= 10'}
+
   '@noble/ciphers@2.1.1':
     resolution: {integrity: sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==}
     engines: {node: '>= 20.19.0'}
@@ -1525,6 +1688,9 @@ packages:
   '@noble/curves@2.0.1':
     resolution: {integrity: sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==}
     engines: {node: '>= 20.19.0'}
+
+  '@noble/ed25519@2.3.0':
+    resolution: {integrity: sha512-M7dvXL2B92/M7dw9+gzuydL8qn/jiqNHaoR3Q+cb1q1GHV7uwE17WCyFMG+Y+TZb5izcaXk5TdJRrDUxHXL78A==}
 
   '@noble/hashes@1.3.2':
     resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
@@ -1905,6 +2071,10 @@ packages:
     peerDependencies:
       svelte: ^5.0.0
       vite: ^6.0.0
+
+  '@tauri-apps/api@1.6.0':
+    resolution: {integrity: sha512-rqI++FWClU5I2UBp4HXFvl+sBWkdigBkxnpJDQUWttNyG7IZP4FwQGhTNL5EOw0vI8i6eSAJ5frLqO7n7jbJdg==}
+    engines: {node: '>= 14.6.0', npm: '>= 6.6.0', yarn: '>= 1.19.1'}
 
   '@telegraf/types@7.1.0':
     resolution: {integrity: sha512-kGevOIbpMcIlCDeorKGpwZmdH7kHbqlk/Yj6dEpJMKEQw5lk0KVQY0OLXaCswy8GqlIVLd5625OB+rAntP9xVw==}
@@ -2763,6 +2933,10 @@ packages:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
 
+  cookie@0.6.0:
+    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
+    engines: {node: '>= 0.6'}
+
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
@@ -3073,6 +3247,10 @@ packages:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
     engines: {node: '>=12'}
 
+  emittery@1.2.1:
+    resolution: {integrity: sha512-sFz64DCRjirhwHLxofFqxYQm6DCp6o0Ix7jwKQvuCHPn4GMRZNuBZyLPu9Ccmk/QSCAMZt6FOUqA8JZCQvA9fw==}
+    engines: {node: '>=14.16'}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -3125,6 +3303,11 @@ packages:
 
   es6-promise@3.3.1:
     resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==}
+
+  esbuild@0.24.2:
+    resolution: {integrity: sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -3774,6 +3957,11 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isomorphic-ws@5.0.0:
+    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    peerDependencies:
+      ws: '*'
+
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -3943,6 +4131,9 @@ packages:
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
+  js-base64@3.8.0:
+    resolution: {integrity: sha512-65kvbemyZhj+ExQt1PEFyBEjL5vAHysu1lJdW1AwhhChkO8ZBPizYk/m9GVrpbS2Je1hF+UYZ+6KywqtZV8mHw==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -4036,6 +4227,12 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  libsodium-wrappers@0.7.16:
+    resolution: {integrity: sha512-Gtr/WBx4dKjvRL1pvfwZqu7gO6AfrQ0u9vFL+kXihtHf6NfkROR8pjYWn98MFDI3jN19Ii1ZUfPR9afGiPyfHg==}
+
+  libsodium@0.7.16:
+    resolution: {integrity: sha512-3HrzSPuzm6Yt9aTYCDxYEG8x8/6C0+ag655Y7rhhWZM9PT4NpdnbqlzXhGZlDnkgR6MeSTnOt/VIyHLs9aSf+Q==}
+
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
@@ -4067,6 +4264,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -5927,6 +6127,15 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
+  '@coasys/ad4m@0.13.0-test-8':
+    dependencies:
+      '@holochain/client': 0.16.0
+      base64-js: 1.5.1
+      pako: 2.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@colors/colors@1.6.0': {}
 
   '@dabh/diagnostics@2.0.8':
@@ -5989,10 +6198,16 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.24.2':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
   '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.24.2':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
@@ -6001,10 +6216,16 @@ snapshots:
   '@esbuild/android-arm64@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.24.2':
+    optional: true
+
   '@esbuild/android-arm@0.25.12':
     optional: true
 
   '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.24.2':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
@@ -6013,10 +6234,16 @@ snapshots:
   '@esbuild/android-x64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.24.2':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.24.2':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
@@ -6025,10 +6252,16 @@ snapshots:
   '@esbuild/darwin-x64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.24.2':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.24.2':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -6037,10 +6270,16 @@ snapshots:
   '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.24.2':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
   '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.24.2':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
@@ -6049,10 +6288,16 @@ snapshots:
   '@esbuild/linux-arm@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.24.2':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
   '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.24.2':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
@@ -6061,10 +6306,16 @@ snapshots:
   '@esbuild/linux-loong64@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.24.2':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.24.2':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -6073,10 +6324,16 @@ snapshots:
   '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.24.2':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.24.2':
     optional: true
 
   '@esbuild/linux-s390x@0.25.12':
@@ -6085,10 +6342,16 @@ snapshots:
   '@esbuild/linux-s390x@0.27.7':
     optional: true
 
+  '@esbuild/linux-x64@0.24.2':
+    optional: true
+
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
   '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.24.2':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.12':
@@ -6097,16 +6360,25 @@ snapshots:
   '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.24.2':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-arm64@0.24.2':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.24.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -6121,10 +6393,16 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.24.2':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
   '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.24.2':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
@@ -6133,10 +6411,16 @@ snapshots:
   '@esbuild/win32-arm64@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.24.2':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
   '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.24.2':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
@@ -6145,9 +6429,14 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1(supports-color@5.5.0))':
     dependencies:
-      eslint: 8.57.1
+      eslint: 8.57.1(supports-color@5.5.0)
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))':
+    dependencies:
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0))':
@@ -6157,7 +6446,7 @@ snapshots:
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.21.2':
+  '@eslint/config-array@0.21.2(supports-color@5.5.0)':
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3(supports-color@5.5.0)
@@ -6173,7 +6462,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@2.1.4':
+  '@eslint/eslintrc@2.1.4(supports-color@5.5.0)':
     dependencies:
       ajv: 6.15.0
       debug: 4.4.3(supports-color@5.5.0)
@@ -6187,7 +6476,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/eslintrc@3.3.5':
+  '@eslint/eslintrc@3.3.5(supports-color@5.5.0)':
     dependencies:
       ajv: 6.15.0
       debug: 4.4.3(supports-color@5.5.0)
@@ -6228,6 +6517,24 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
+  '@holochain/client@0.16.0':
+    dependencies:
+      '@holochain/serialization': 0.1.0-beta-rc.3
+      '@msgpack/msgpack': 2.8.0
+      '@noble/ed25519': 2.3.0
+      '@tauri-apps/api': 1.6.0
+      emittery: 1.2.1
+      isomorphic-ws: 5.0.0(ws@8.20.0)
+      js-base64: 3.8.0
+      libsodium-wrappers: 0.7.16
+      lodash-es: 4.18.1
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@holochain/serialization@0.1.0-beta-rc.3': {}
+
   '@hono/node-server@1.19.14(hono@4.12.18)':
     dependencies:
       hono: 4.12.18
@@ -6244,7 +6551,7 @@ snapshots:
 
   '@humanfs/types@0.15.0': {}
 
-  '@humanwhocodes/config-array@0.13.0':
+  '@humanwhocodes/config-array@0.13.0(supports-color@5.5.0)':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
       debug: 4.4.3(supports-color@5.5.0)
@@ -6587,6 +6894,28 @@ snapshots:
       '@types/geojson': 7946.0.16
       pbf: 4.0.1
 
+  '@modelcontextprotocol/sdk@1.29.0(supports-color@5.5.0)(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.18)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1(supports-color@5.5.0)
+      express-rate-limit: 8.5.1(express@5.2.1(supports-color@5.5.0))
+      hono: 4.12.18
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.18)
@@ -6597,7 +6926,7 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.0.8
-      express: 5.2.1
+      express: 5.2.1(supports-color@5.5.0)
       express-rate-limit: 8.5.1(express@5.2.1)
       hono: 4.12.18
       jose: 6.2.3
@@ -6608,6 +6937,8 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
+
+  '@msgpack/msgpack@2.8.0': {}
 
   '@noble/ciphers@2.1.1': {}
 
@@ -6622,6 +6953,8 @@ snapshots:
   '@noble/curves@2.0.1':
     dependencies:
       '@noble/hashes': 2.0.1
+
+  '@noble/ed25519@2.3.0': {}
 
   '@noble/hashes@1.3.2': {}
 
@@ -6889,23 +7222,43 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
+  '@sveltejs/adapter-netlify@4.4.2(@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@5.5.0)(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))':
+    dependencies:
+      '@iarna/toml': 2.2.5
+      '@sveltejs/kit': 2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@5.5.0)(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      esbuild: 0.24.2
+      set-cookie-parser: 2.7.2
+
   '@sveltejs/adapter-netlify@4.4.2(@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))':
     dependencies:
       '@iarna/toml': 2.2.5
       '@sveltejs/kit': 2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      esbuild: 0.27.7
+      esbuild: 0.24.2
       set-cookie-parser: 2.7.2
 
-  '@sveltejs/adapter-netlify@4.4.2(@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))':
+  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@5.5.0)(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))':
     dependencies:
-      '@iarna/toml': 2.2.5
-      '@sveltejs/kit': 2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      esbuild: 0.27.7
-      set-cookie-parser: 2.7.2
+      '@sveltejs/kit': 2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@5.5.0)(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
 
-  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))':
+  '@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@5.5.0)(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
-      '@sveltejs/kit': 2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@standard-schema/spec': 1.1.0
+      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
+      '@sveltejs/vite-plugin-svelte': 5.1.1(supports-color@5.5.0)(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@types/cookie': 0.6.0
+      acorn: 8.16.0
+      cookie: 0.6.0
+      devalue: 5.8.0
+      esm-env: 1.2.2
+      kleur: 4.1.5
+      magic-string: 0.30.21
+      mrmime: 2.0.1
+      set-cookie-parser: 3.1.0
+      sirv: 3.0.2
+      svelte: 5.55.5(@typescript-eslint/types@8.60.0)
+      vite: 6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
+    optionalDependencies:
+      typescript: 5.9.3
 
   '@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
@@ -6914,7 +7267,7 @@ snapshots:
       '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       '@types/cookie': 0.6.0
       acorn: 8.16.0
-      cookie: 0.7.2
+      cookie: 0.6.0
       devalue: 5.8.0
       esm-env: 1.2.2
       kleur: 4.1.5
@@ -6927,25 +7280,14 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@5.5.0)(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(supports-color@5.5.0)(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      '@types/cookie': 0.6.0
-      acorn: 8.16.0
-      cookie: 0.7.2
-      devalue: 5.8.0
-      esm-env: 1.2.2
-      kleur: 4.1.5
-      magic-string: 0.30.21
-      mrmime: 2.0.1
-      set-cookie-parser: 3.1.0
-      sirv: 3.0.2
+      '@sveltejs/vite-plugin-svelte': 5.1.1(supports-color@5.5.0)(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      debug: 4.4.3(supports-color@5.5.0)
       svelte: 5.55.5(@typescript-eslint/types@8.60.0)
       vite: 6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
-    optionalDependencies:
-      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
@@ -6956,12 +7298,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@sveltejs/vite-plugin-svelte@5.1.1(supports-color@5.5.0)(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(supports-color@5.5.0)(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(supports-color@5.5.0)(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       debug: 4.4.3(supports-color@5.5.0)
+      deepmerge: 4.3.1
+      kleur: 4.1.5
+      magic-string: 0.30.21
       svelte: 5.55.5(@typescript-eslint/types@8.60.0)
       vite: 6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
+      vitefu: 1.1.3(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
     transitivePeerDependencies:
       - supports-color
 
@@ -6978,18 +7324,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
-    dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)))(svelte@5.55.5(@typescript-eslint/types@8.60.0))(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-      debug: 4.4.3(supports-color@5.5.0)
-      deepmerge: 4.3.1
-      kleur: 4.1.5
-      magic-string: 0.30.21
-      svelte: 5.55.5(@typescript-eslint/types@8.60.0)
-      vite: 6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
-      vitefu: 1.1.3(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
-    transitivePeerDependencies:
-      - supports-color
+  '@tauri-apps/api@1.6.0': {}
 
   '@telegraf/types@7.1.0': {}
 
@@ -7242,15 +7577,31 @@ snapshots:
       '@types/node': 22.19.17
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.2(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.2(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.59.2
-      '@typescript-eslint/type-utils': 8.59.2(eslint@8.57.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.2(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.59.2(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.2(eslint@8.57.1(supports-color@5.5.0))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.59.2
-      eslint: 8.57.1
+      eslint: 8.57.1(supports-color@5.5.0)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.60.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.60.0
+      '@typescript-eslint/type-utils': 8.60.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.60.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.60.0
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -7274,14 +7625,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.2(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.59.2(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.59.2
       '@typescript-eslint/types': 8.59.2
       '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.59.2
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 8.57.1
+      eslint: 8.57.1(supports-color@5.5.0)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.60.0
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/typescript-estree': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.60.0
+      debug: 4.4.3(supports-color@5.5.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -7334,13 +7697,25 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.59.2(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.59.2(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.59.2
       '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.2(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.2(eslint@8.57.1(supports-color@5.5.0))(typescript@5.9.3)
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 8.57.1
+      eslint: 8.57.1(supports-color@5.5.0)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/type-utils@8.60.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/typescript-estree': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.60.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
+      debug: 4.4.3(supports-color@5.5.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -7392,13 +7767,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.59.2(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.59.2(eslint@8.57.1(supports-color@5.5.0))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1(supports-color@5.5.0))
       '@typescript-eslint/scope-manager': 8.59.2
       '@typescript-eslint/types': 8.59.2
       '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
-      eslint: 8.57.1
+      eslint: 8.57.1(supports-color@5.5.0)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.60.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
+      '@typescript-eslint/scope-manager': 8.60.0
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/typescript-estree': 8.60.0(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -7622,9 +8008,9 @@ snapshots:
       postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  axios@1.16.0(debug@4.4.3):
+  axios@1.16.0(debug@4.4.3(supports-color@5.5.0)):
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3)
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@5.5.0))
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -7754,7 +8140,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  body-parser@2.2.2:
+  body-parser@2.2.2(supports-color@5.5.0):
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
@@ -7989,6 +8375,8 @@ snapshots:
   cookie-signature@1.0.7: {}
 
   cookie-signature@1.2.2: {}
+
+  cookie@0.6.0: {}
 
   cookie@0.7.2: {}
 
@@ -8304,6 +8692,8 @@ snapshots:
 
   emittery@0.13.1: {}
 
+  emittery@1.2.1: {}
+
   emoji-regex@8.0.0: {}
 
   enabled@2.0.0: {}
@@ -8347,6 +8737,34 @@ snapshots:
       hasown: 2.0.3
 
   es6-promise@3.3.1: {}
+
+  esbuild@0.24.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.24.2
+      '@esbuild/android-arm': 0.24.2
+      '@esbuild/android-arm64': 0.24.2
+      '@esbuild/android-x64': 0.24.2
+      '@esbuild/darwin-arm64': 0.24.2
+      '@esbuild/darwin-x64': 0.24.2
+      '@esbuild/freebsd-arm64': 0.24.2
+      '@esbuild/freebsd-x64': 0.24.2
+      '@esbuild/linux-arm': 0.24.2
+      '@esbuild/linux-arm64': 0.24.2
+      '@esbuild/linux-ia32': 0.24.2
+      '@esbuild/linux-loong64': 0.24.2
+      '@esbuild/linux-mips64el': 0.24.2
+      '@esbuild/linux-ppc64': 0.24.2
+      '@esbuild/linux-riscv64': 0.24.2
+      '@esbuild/linux-s390x': 0.24.2
+      '@esbuild/linux-x64': 0.24.2
+      '@esbuild/netbsd-arm64': 0.24.2
+      '@esbuild/netbsd-x64': 0.24.2
+      '@esbuild/openbsd-arm64': 0.24.2
+      '@esbuild/openbsd-x64': 0.24.2
+      '@esbuild/sunos-x64': 0.24.2
+      '@esbuild/win32-arm64': 0.24.2
+      '@esbuild/win32-ia32': 0.24.2
+      '@esbuild/win32-x64': 0.24.2
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -8426,9 +8844,9 @@ snapshots:
     dependencies:
       eslint: 9.39.4(jiti@2.7.0)
 
-  eslint-config-prettier@9.1.2(eslint@8.57.1):
+  eslint-config-prettier@9.1.2(eslint@8.57.1(supports-color@5.5.0)):
     dependencies:
-      eslint: 8.57.1
+      eslint: 8.57.1(supports-color@5.5.0)
 
   eslint-plugin-prettier@5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3):
     dependencies:
@@ -8439,11 +8857,11 @@ snapshots:
     optionalDependencies:
       eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.7.0))
 
-  eslint-plugin-svelte@3.17.1(eslint@8.57.1)(svelte@5.55.5(@typescript-eslint/types@8.60.0)):
+  eslint-plugin-svelte@3.17.1(eslint@8.57.1(supports-color@5.5.0))(svelte@5.55.5(@typescript-eslint/types@8.60.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1(supports-color@5.5.0))
       '@jridgewell/sourcemap-codec': 1.5.5
-      eslint: 8.57.1
+      eslint: 8.57.1(supports-color@5.5.0)
       esutils: 2.0.3
       globals: 16.5.0
       known-css-properties: 0.37.0
@@ -8465,11 +8883,11 @@ snapshots:
       tailwind-api-utils: 1.0.3(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.4))
       tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.4)
 
-  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1):
+  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@8.57.1(supports-color@5.5.0)):
     dependencies:
-      eslint: 8.57.1
+      eslint: 8.57.1(supports-color@5.5.0)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.59.2(@typescript-eslint/parser@8.59.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.59.2(@typescript-eslint/parser@8.59.2(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
 
   eslint-scope@7.2.2:
     dependencies:
@@ -8487,13 +8905,13 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@8.57.1:
+  eslint@8.57.1(supports-color@5.5.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1(supports-color@5.5.0))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/eslintrc': 2.1.4
+      '@eslint/eslintrc': 2.1.4(supports-color@5.5.0)
       '@eslint/js': 8.57.1
-      '@humanwhocodes/config-array': 0.13.0
+      '@humanwhocodes/config-array': 0.13.0(supports-color@5.5.0)
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       '@ungap/structured-clone': 1.3.1
@@ -8534,10 +8952,51 @@ snapshots:
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.2
+      '@eslint/config-array': 0.21.2(supports-color@5.5.0)
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.5
+      '@eslint/eslintrc': 3.3.5(supports-color@5.5.0)
+      '@eslint/js': 9.39.4
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3(supports-color@5.5.0)
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2(supports-color@5.5.0)
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5(supports-color@5.5.0)
       '@eslint/js': 9.39.4
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.8
@@ -8671,9 +9130,14 @@ snapshots:
       express: 4.22.1
       ip-address: 10.2.0
 
+  express-rate-limit@8.5.1(express@5.2.1(supports-color@5.5.0)):
+    dependencies:
+      express: 5.2.1(supports-color@5.5.0)
+      ip-address: 10.2.0
+
   express-rate-limit@8.5.1(express@5.2.1):
     dependencies:
-      express: 5.2.1
+      express: 5.2.1(supports-color@5.5.0)
       ip-address: 10.2.0
 
   express-validator@7.3.2:
@@ -8717,10 +9181,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@5.2.1:
+  express@5.2.1(supports-color@5.5.0):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2
+      body-parser: 2.2.2(supports-color@5.5.0)
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -8730,7 +9194,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@5.5.0)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -8741,8 +9205,8 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.1
       range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.1
+      router: 2.2.0(supports-color@5.5.0)
+      send: 1.2.1(supports-color@5.5.0)
       serve-static: 2.2.1
       statuses: 2.0.2
       type-is: 2.0.1
@@ -8832,7 +9296,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
@@ -8872,7 +9336,7 @@ snapshots:
     dependencies:
       tabbable: 5.3.3
 
-  follow-redirects@1.16.0(debug@4.4.3):
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@5.5.0)):
     optionalDependencies:
       debug: 4.4.3(supports-color@5.5.0)
 
@@ -9040,10 +9504,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy@1.18.1(debug@4.4.3):
+  http-proxy@1.18.1(debug@4.4.3(supports-color@5.5.0)):
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.16.0(debug@4.4.3)
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@5.5.0))
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -9155,6 +9619,10 @@ snapshots:
   isarray@1.0.0: {}
 
   isexe@2.0.0: {}
+
+  isomorphic-ws@5.0.0(ws@8.20.0):
+    dependencies:
+      ws: 8.20.0
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -9515,6 +9983,8 @@ snapshots:
 
   jose@6.2.3: {}
 
+  js-base64@3.8.0: {}
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -9613,6 +10083,12 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  libsodium-wrappers@0.7.16:
+    dependencies:
+      libsodium: 0.7.16
+
+  libsodium@0.7.16: {}
+
   lie@3.3.0:
     dependencies:
       immediate: 3.0.6
@@ -9642,6 +10118,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash-es@4.18.1: {}
 
   lodash.merge@4.6.2: {}
 
@@ -10183,7 +10661,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  puppeteer-core@24.43.0:
+  puppeteer-core@24.43.0(supports-color@5.5.0):
     dependencies:
       '@puppeteer/browsers': 2.13.1
       chromium-bidi: 14.0.0(devtools-protocol@0.0.1608973)
@@ -10200,13 +10678,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  puppeteer@24.43.0(typescript@5.9.3):
+  puppeteer@24.43.0(supports-color@5.5.0)(typescript@5.9.3):
     dependencies:
       '@puppeteer/browsers': 2.13.1
       chromium-bidi: 14.0.0(devtools-protocol@0.0.1608973)
       cosmiconfig: 9.0.1(typescript@5.9.3)
       devtools-protocol: 0.0.1608973
-      puppeteer-core: 24.43.0
+      puppeteer-core: 24.43.0(supports-color@5.5.0)
       typed-query-selector: 2.12.2
     transitivePeerDependencies:
       - bare-abort-controller
@@ -10382,7 +10860,7 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.3
       fsevents: 2.3.3
 
-  router@2.2.0:
+  router@2.2.0(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
@@ -10453,7 +10931,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  send@1.2.1:
+  send@1.2.1(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
@@ -10483,7 +10961,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10874,7 +11352,7 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  telegraf@4.16.3:
+  telegraf@4.16.3(supports-color@5.5.0):
     dependencies:
       '@telegraf/types': 7.1.0
       abort-controller: 3.0.0
@@ -11012,6 +11490,17 @@ snapshots:
       typescript: 5.9.3
       yaml: 2.8.4
 
+  typescript-eslint@8.60.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.60.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.60.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.60.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   typescript-eslint@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.60.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
@@ -11071,7 +11560,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@3.2.4(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4):
+  vite-node@3.2.4(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(supports-color@5.5.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3(supports-color@5.5.0)
@@ -11134,7 +11623,7 @@ snapshots:
     optionalDependencies:
       vite: 6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
 
-  vitest@3.2.4(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4):
+  vitest@3.2.4(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(supports-color@5.5.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -11157,7 +11646,7 @@ snapshots:
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 6.4.2(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
-      vite-node: 3.2.4(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
+      vite-node: 3.2.4(@types/node@22.19.17)(jiti@2.7.0)(sass@1.99.0)(supports-color@5.5.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,10 @@ packages:
   - "packages/*"
   # holosphere is vendored at packages/holosphere and consumed as a workspace
   # package (consumers depend on it via `workspace:*`).
+allowBuilds:
+  '@parcel/watcher': true
+  core-js: true
+  esbuild: true
+  puppeteer: true
+  sharp: true
+  svelte-preprocess: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,3 +10,9 @@ allowBuilds:
   puppeteer: true
   sharp: true
   svelte-preprocess: true
+# Security pins + workspace linkage. pnpm >=10.x reads overrides from here;
+# the legacy `pnpm.overrides` field in package.json is ignored by pnpm 11.
+overrides:
+  esbuild@<0.25.0: '>=0.25.0'
+  cookie@<0.7.0: '>=0.7.0'
+  holosphere: workspace:*


### PR DESCRIPTION
## Summary

Introduces a pluggable `StorageBackend` interface in the `holosphere` package, decoupling persistence from the HoloSphere API. All existing GUN operations are extracted into a behaviour-preserving `GunBackend` (the default), and a new **browser-ready `AD4MBackend`** is added, selectable via config / `VITE_HOLOSPHERE_BACKEND`. **No changes to the `@holons/core` public API** — GUN remains the default and behaves identically.

## What changed

### Backend abstraction
- **`backends/interface.d.ts`** — the `StorageBackend` contract: `put / get / getAll / delete / subscribe / getNodeRef / ready / close` plus a `type` discriminator (`'gun' | 'ad4m'`).
- **`backends/gun.js`** — GUN logic extracted from the inline HoloSphere ops (paths, read/write timeouts, `.map().on()` subscriptions, traversable node refs). Behaviour-preserving.
- **`content.js` / `global.js` / `node.js` / `utils.js`** — route all persistence through `_backend.*`.
- **`holosphere.js` / `core/src/holosphere/factory.ts`** — backend selection via config (default `gun`); AD4M is loaded **lazily** via dynamic `import()` so the browser bundle never eagerly pulls Node-only deps.
- **`build.js` / `package.json`** — `@coasys/ad4m` marked external across the esbuild configs; declared an **optional** peer.

### AD4M adapter
- **`backends/ad4m.js`** — holon → perspective, lens → subject class, item → subject instance, key → base-expression URI; write-through subscriptions.
- **Two modes.** Given lens JSON Schemas, each lens gets a *dedicated* typed subject class that persists only its declared properties. Given an empty schema map, every lens uses one `GenericLensModel` that round-trips the whole payload opaquely as JSON. Apps run **dedicated**; the conformance suite runs **opaque** (the same opaque-KV contract GUN satisfies).
- **`subjects/index.js`** — subject-class loader; **browser-safe** (Node builtins `fs`/`path`/`url` imported lazily, only on the disk-reading branch).
- **Gotcha fixed — never declare an `id` property on a subject model.** AD4M reserves `id` as the alias for the base-expression URI. A data `id` makes `findAll` hydrate each instance from the `id` *link value* (the logical key) instead of the full URI, so lens-prefix scoping in `getAll` silently filters every instance out. The generic model stores only `data` and recovers the logical id from the base URI's last segment.
- **Subscribe race fixed.** AD4M's `subscribe()` establishes its baseline asynchronously (perspective fetch + query subscribe), so a same-tick `put` could race it. The subscription handle now exposes an optional `ready()` promise consumers await before writing. Gun's synchronous handle has no such field, so the optional-chain is a no-op there.

### Browser path & app wiring
- **`core/src/holosphere/ad4mSchemas.ts`** (new) — bundles the lens JSON Schemas in-memory via Vite's `import.meta.glob` (the browser has no filesystem to read `schemaDir` from).
- **`apps/kiosk` + `apps/web`** — `VITE_HOLOSPHERE_BACKEND` switch (`gun` default / `ad4m`), plus a dev-only `window.__holosphere` handle for in-browser exercising.
- **`scripts/dev-executor.mjs`** (new) — boots an isolated, single-user, **disposable** ad4m-executor for local dev + conformance (its own data dir / ports / admin credential; all config via env).

## Scope-review responses

A scope review flagged four items outside the core AD4M work. All four are now addressed on this branch (commits `784f55f`, `f4fef3f`, `b1f2ba5`):

1. **Security regression — pnpm overrides (fixed, `784f55f`).** The refactor had moved the `pnpm.overrides` / `onlyBuiltDependencies` pins into the root `package.json` `pnpm` field, which **pnpm 11 ignores** — silently dropping the `esbuild >=0.25` / `cookie >=0.7` security pins. Migrated them to `pnpm-workspace.yaml` (the only place pnpm 11 reads them), regenerated the lockfile (esbuild `<0.25` = 0, real `cookie <0.7` = 0), and added the `node:`-prefixed builtins to the holosphere esbuild externals so the `prepare` hook installs cleanly.
2. **GUN behavioural parity (fixed + tested, `f4fef3f`).** Three divergences from pre-refactor GUN behaviour restored to **exact** parity and locked with deterministic regression tests (`test/backend-behavior.test.js`, no live mesh): (a) `putNode` records a hologram only after a **confirmed** write (`!result.queued`) — never on a queued/offline write; (b) `deleteAllGlobal`'s 5s safety-net timeout no longer resolves while a real deletion is in flight (a `started` guard mirrors the base); (c) the object→`JSON.stringify` encoding in `putNode` is retained **deliberately** — it is forced by the opaque string-KV contract every backend must satisfy — and is now covered by a test.
3. **Reviewability tax (fixed, `b1f2ba5`).** Restored the explanatory *why* comments that survived the code but were dropped when logic moved between files — `utils.js` `subscribe()` (fire-storm breaker + per-lens quarantine, soft-delete-vs-transient resolution, object-only payload filtering, sync-unsubscribe teardown ordering) and `backends/gun.js` `put()` (queued-write rationale, relocated to the new call site). Comment-only, no behaviour change.
4. **`discord-ui` backend default (kept — required, not scope creep).** Removing the `|| 'nostr'` default is **necessary**: `core/src/holosphere/factory.ts` tightened the factory type to `backend?: 'gun' | 'ad4m'`, so the typed `.ts` wrapper must conform or `tsc` fails (verified). `'nostr'` was always dead — it fell through to Gun — so this is a no-op at runtime.

## Tests & verification

- **`test/backend-conformance.test.js`** — a shared conformance suite. The GUN half runs everywhere; the AD4M half runs only when `AD4M_TEST_URL` points at a **disposable** executor (the suite creates and deletes perspectives). **28/28 green** against a live executor.
- **`test/backend-behavior.test.js`** (new) — deterministic behavioural-parity regression tests for the write/delete semantics above. **7/7 green**, no live mesh required.
- **Both apps verified in-browser on the AD4M backend** (dedicated mode, live executor) — CRUD + live subscriptions round-trip end to end.
- Gate from clean: `pnpm -r typecheck` ✅, `@holons/core` vitest 286/286 ✅. (`pnpm lint` has pre-existing `apps/web` prettier violations unrelated to this PR; the holosphere integration suite includes live-Gun/SEA tests that flake headless — the deterministic tests above do not.)
- All commits carry DCO sign-off (`git commit -s`).

## Notes

- **Base branch:** `test/holosphere-signing` (this branch is **6 commits** ahead — 3 for the backend work, 3 for the scope-review responses above). `main` is far behind and is not the correct base.
- AD4M is an **optional** backend — GUN-only deployments need nothing new at runtime; the lazy import + esbuild externals keep the Node-only `@coasys/ad4m` out of the browser bundle.

## Test plan

- [x] GUN backend (default): CRUD, live subscriptions, holograms — behaviour unchanged
- [x] AD4M backend in-browser (dedicated mode): CRUD + subscriptions via `VITE_HOLOSPHERE_BACKEND=ad4m`
- [x] Conformance suite (opaque mode): 28/28 with `AD4M_TEST_URL` pointed at a disposable executor
- [x] Behavioural-parity regression tests (GUN write/delete semantics): 7/7
- [ ] Reviewer: sanity-check the GUN op extraction in `content.js` / `global.js` for behaviour parity
